### PR TITLE
squid:S2131 - Primitives should not be boxed just for "String" conversion

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/Fetcher.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/Fetcher.java
@@ -247,7 +247,7 @@ public class Fetcher extends CallableWithNdc<FetchResult> {
       try {
         // this breaks badly on partitioned input - please use responsibly
         Preconditions.checkArgument(partition == 0, "Partition == 0");
-        final String tmpSuffix = "" + System.currentTimeMillis() + ".tmp";
+        final String tmpSuffix = System.currentTimeMillis() + ".tmp";
         final String finalOutput = getMapOutputFile(srcAttemptId.getPathComponent());
         final Path outputPath = localDirAllocator.getLocalPathForWrite(finalOutput, compressedLength, conf);
         final TezSpillRecord spillRec = new TezSpillRecord(1);

--- a/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/MultipleCommitsExample.java
+++ b/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/MultipleCommitsExample.java
@@ -206,7 +206,7 @@ public class MultipleCommitsExample extends TezExampleBase {
       String uv12OutputPathPrefix, int uv12OutputNum,
       String v3OutputPathPrefix, int v3OutputNum, boolean commitOnVertexSuccess) throws IOException {
     DAG dag = DAG.create("multipleCommitsDAG");
-    dag.setConf(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS, !commitOnVertexSuccess + "");
+    dag.setConf(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS, Boolean.toString(!commitOnVertexSuccess));
     Vertex v1 = Vertex.create("v1", ProcessorDescriptor.create(MultipleOutputProcessor.class.getName())
         .setUserPayload(
             new MultipleOutputProcessor.MultipleOutputProcessorConfig(

--- a/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/LocalityAnalyzer.java
+++ b/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/LocalityAnalyzer.java
@@ -93,10 +93,10 @@ public class LocalityAnalyzer extends TezAnalyzerBase implements Analyzer {
 
         List<String> record = Lists.newLinkedList();
         record.add(vertexName);
-        record.add(totalVertexTasks + "");
-        record.add(dataLocalRatio + "");
-        record.add(rackLocalRatio + "");
-        record.add(othersRatio + "");
+        record.add(Long.toString(totalVertexTasks));
+        record.add(Float.toString(dataLocalRatio));
+        record.add(Float.toString(rackLocalRatio));
+        record.add(Float.toString(othersRatio));
 
         TaskAttemptDetails dataLocalResult = computeAverages(vertexInfo,
             DAGCounter.DATA_LOCAL_TASKS);
@@ -105,18 +105,18 @@ public class LocalityAnalyzer extends TezAnalyzerBase implements Analyzer {
         TaskAttemptDetails otherTaskResult = computeAverages(vertexInfo,
             DAGCounter.OTHER_LOCAL_TASKS);
 
-        record.add(dataLocalResult.avgRuntime + "");
-        record.add(rackLocalResult.avgRuntime + "");
-        record.add(otherTaskResult.avgRuntime + "");
+        record.add(Float.toString(dataLocalResult.avgRuntime));
+        record.add(Float.toString(rackLocalResult.avgRuntime));
+        record.add(Float.toString(otherTaskResult.avgRuntime));
 
         //Get the number of inputs to this vertex
         record.add(vertexInfo.getInputEdges().size()
             + vertexInfo.getAdditionalInputInfoList().size() + "");
 
         //Get the avg HDFS bytes read in this vertex for different type of locality
-        record.add(dataLocalResult.avgHDFSBytesRead + "");
-        record.add(rackLocalResult.avgHDFSBytesRead + "");
-        record.add(otherTaskResult.avgHDFSBytesRead + "");
+        record.add(Float.toString(dataLocalResult.avgHDFSBytesRead));
+        record.add(Float.toString(rackLocalResult.avgHDFSBytesRead));
+        record.add(Float.toString(otherTaskResult.avgHDFSBytesRead));
 
         String recommendation = "";
         if (dataLocalRatio < config.getFloat(DATA_LOCAL_RATIO, DATA_LOCAL_RATIO_DEFAULT)) {

--- a/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/ShuffleTimeAnalyzer.java
+++ b/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/ShuffleTimeAnalyzer.java
@@ -131,9 +131,9 @@ public class ShuffleTimeAnalyzer extends TezAnalyzerBase implements Analyzer {
             }
             result.add(comments);
 
-            result.add(reduceInputGroupsVal + "");
-            result.add(reduceInputRecordsVal + "");
-            result.add("" + (1.0f * reduceInputGroupsVal / reduceInputRecordsVal));
+            result.add(Long.toString(reduceInputGroupsVal));
+            result.add(Long.toString(reduceInputRecordsVal));
+            result.add(Float.toString(1.0f * reduceInputGroupsVal / reduceInputRecordsVal));
             result.add(getCounterValue(TaskCounter.SHUFFLE_BYTES, counterGroupName, attemptInfo));
 
             result.add(Long.toString(attemptInfo.getTimeTaken()));

--- a/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/SkewAnalyzer.java
+++ b/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/SkewAnalyzer.java
@@ -157,10 +157,10 @@ public class SkewAnalyzer extends TezAnalyzerBase implements Analyzer {
           result.add(attemptInfo.getTaskAttemptId());
           result.add(counterGroup);
           result.add(attemptInfo.getNodeId());
-          result.add(inputGroupsCount + "");
-          result.add(inputRecordsCount + "");
-          result.add(ratio + "");
-          result.add(shuffleBytesPerSource + "");
+          result.add(Long.toString(inputGroupsCount));
+          result.add(Long.toString(inputRecordsCount));
+          result.add(Float.toString(ratio));
+          result.add(Long.toString(shuffleBytesPerSource));
           result.add(attemptInfo.getTimeTaken() + "");
           result.add("Please check partitioning. Otherwise consider increasing memLimit");
 
@@ -220,10 +220,10 @@ public class SkewAnalyzer extends TezAnalyzerBase implements Analyzer {
             result.add(attemptInfo.getTaskAttemptId());
             result.add(counterGroup);
             result.add(attemptInfo.getNodeId());
-            result.add(inputGroupsCount + "");
-            result.add(inputRecordsCount + "");
-            result.add(ratio + "");
-            result.add(shuffleBytesPerSource + "");
+            result.add(Long.toString(inputGroupsCount));
+            result.add(Long.toString(inputRecordsCount));
+            result.add(Float.toString(ratio));
+            result.add(Long.toString(shuffleBytesPerSource));
             result.add(attemptInfo.getTimeTaken() + "");
             result.add("Some task attempts are getting > 60% of reduce input records. "
                 + "Consider adjusting parallelism & check partition logic");
@@ -277,10 +277,10 @@ public class SkewAnalyzer extends TezAnalyzerBase implements Analyzer {
           result.add(attemptInfo.getTaskAttemptId());
           result.add(counterGroup);
           result.add(attemptInfo.getNodeId());
-          result.add(inputGroupsCount + "");
-          result.add(inputRecordsCount + "");
-          result.add(ratio + "");
-          result.add(shuffleBytesPerSource + "");
+          result.add(Long.toString(inputGroupsCount));
+          result.add(Long.toString(inputRecordsCount));
+          result.add(Float.toString(ratio));
+          result.add(Long.toString(shuffleBytesPerSource));
           result.add(attemptInfo.getTimeTaken() + "");
           result.add("Consider increasing parallelism.");
 

--- a/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/SlowNodeAnalyzer.java
+++ b/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/SlowNodeAnalyzer.java
@@ -74,21 +74,21 @@ public class SlowNodeAnalyzer extends TezAnalyzerBase implements Analyzer {
       Collection<TaskAttemptInfo> taskAttemptInfos = nodeDetails.get(nodeName);
 
       record.add(nodeName);
-      record.add(taskAttemptInfos.size() + "");
-      record.add(getNumberOfTasks(taskAttemptInfos, TaskAttemptState.KILLED) + "");
-      record.add(getNumberOfTasks(taskAttemptInfos, TaskAttemptState.FAILED) + "");
+      record.add(Integer.toString(taskAttemptInfos.size()));
+      record.add(Integer.toString(getNumberOfTasks(taskAttemptInfos, TaskAttemptState.KILLED)));
+      record.add(Integer.toString(getNumberOfTasks(taskAttemptInfos, TaskAttemptState.FAILED)));
 
       Iterable<TaskAttemptInfo> succeedTasks = getFilteredTaskAttempts(taskAttemptInfos,
           TaskAttemptState.SUCCEEDED);
-      record.add(getAvgTaskExecutionTime(succeedTasks) + "");
+      record.add(Float.toString(getAvgTaskExecutionTime(succeedTasks)));
 
       Iterable<TaskAttemptInfo> killedTasks = getFilteredTaskAttempts(taskAttemptInfos,
           TaskAttemptState.KILLED);
-      record.add(getAvgTaskExecutionTime(killedTasks) + "");
+      record.add(Float.toString(getAvgTaskExecutionTime(killedTasks)));
 
       Iterable<TaskAttemptInfo> failedTasks = getFilteredTaskAttempts(taskAttemptInfos,
           TaskAttemptState.FAILED);
-      record.add(getAvgTaskExecutionTime(failedTasks) + "");
+      record.add(Float.toString(getAvgTaskExecutionTime(failedTasks)));
 
       record.add(getAvgCounter(taskAttemptInfos, FileSystemCounter.class
           .getName(), FileSystemCounter.HDFS_BYTES_READ.name()) + "");

--- a/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/SlowestVertexAnalyzer.java
+++ b/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/SlowestVertexAnalyzer.java
@@ -139,10 +139,10 @@ public class SlowestVertexAnalyzer extends TezAnalyzerBase implements Analyzer {
       List<String> record = Lists.newLinkedList();
       record.add(vertexName);
       record.add(vertexInfo.getTaskAttempts().size() + "");
-      record.add(totalTime + "");
-      record.add(Math.max(0, shuffleMax) + "");
+      record.add(Long.toString(totalTime));
+      record.add(Long.toString(Math.max(0, shuffleMax)));
       record.add(shuffleMaxSource);
-      record.add(Math.max(0, slowestLastEventTime) + "");
+      record.add(Long.toString(Math.max(0, slowestLastEventTime)));
       record.add(maxSourceName);
       //Finding out real_work done at vertex level might be meaningless (as it is quite posisble
       // that it went to starvation).

--- a/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/SpillAnalyzerImpl.java
+++ b/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/SpillAnalyzerImpl.java
@@ -100,11 +100,11 @@ public class SpillAnalyzerImpl extends TezAnalyzerBase implements Analyzer {
             recorList.add(attemptInfo.getTaskAttemptId());
             recorList.add(attemptInfo.getNodeId());
             recorList.add(source);
-            recorList.add(spillCount + "");
+            recorList.add(Long.toString(spillCount));
             recorList.add(attemptInfo.getTimeTaken() + "");
-            recorList.add(outBytes + "");
-            recorList.add(outputRecords + "");
-            recorList.add(spilledRecords + "");
+            recorList.add(Long.toString(outBytes));
+            recorList.add(Long.toString(outputRecords));
+            recorList.add(Long.toString(spilledRecords));
             recorList.add("Consider increasing " + TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB
                 + ". Try increasing container size.");
 

--- a/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/TaskConcurrencyAnalyzer.java
+++ b/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/TaskConcurrencyAnalyzer.java
@@ -133,7 +133,7 @@ public class TaskConcurrencyAnalyzer extends TezAnalyzerBase implements Analyzer
   }
 
   private void addToResult(String vertexName, long currentTime, int concurrentTasks) {
-    String[] record = { currentTime + "", vertexName, concurrentTasks + "" };
+    String[] record = { Long.toString(currentTime), vertexName, Integer.toString(concurrentTasks) };
     csvResult.addRecord(record);
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2131 - Primitives should not be boxed just for "String" conversion.
This pull request removes technical debt of 210 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
George Kankava