### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/client/TezClientUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/client/TezClientUtils.java
@@ -118,6 +118,9 @@ public class TezClientUtils {
   private static Logger LOG = LoggerFactory.getLogger(TezClientUtils.class);
   private static final int UTF8_CHUNK_SIZE = 16 * 1024;
 
+  
+  private TezClientUtils() {}
+
   private static FileStatus[] getLRFileStatus(String fileName, Configuration conf) throws
       IOException {
     URI uri;

--- a/tez-api/src/main/java/org/apache/tez/common/ATSConstants.java
+++ b/tez-api/src/main/java/org/apache/tez/common/ATSConstants.java
@@ -124,4 +124,5 @@ public class ATSConstants {
   public static final String CALLER_TYPE = "callerType";
   public static final String DESCRIPTION = "description";
 
+  private ATSConstants() {}
 }

--- a/tez-api/src/main/java/org/apache/tez/common/RPCUtil.java
+++ b/tez-api/src/main/java/org/apache/tez/common/RPCUtil.java
@@ -31,6 +31,8 @@ import com.google.protobuf.ServiceException;
 
 public class RPCUtil {
 
+  private RPCUtil() {}
+
   /**
    * Returns an instance of {@link TezException}
    */

--- a/tez-api/src/main/java/org/apache/tez/common/ReflectionUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/common/ReflectionUtils.java
@@ -36,6 +36,8 @@ public class ReflectionUtils {
 
   private static final Map<String, Class<?>> CLAZZ_CACHE = new ConcurrentHashMap<String, Class<?>>();
 
+  private ReflectionUtils() {}
+
   @Private
   public static Class<?> getClazz(String className) throws TezReflectionException {
     Class<?> clazz = CLAZZ_CACHE.get(className);

--- a/tez-api/src/main/java/org/apache/tez/common/TezCommonUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/common/TezCommonUtils.java
@@ -63,6 +63,8 @@ public class TezCommonUtils {
 
   public static final String TEZ_SYSTEM_SUB_DIR = ".tez";
 
+  private TezCommonUtils() {}
+
   /**
    * <p>
    * This function returns the staging directory defined in the config with

--- a/tez-api/src/main/java/org/apache/tez/common/TezUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/common/TezUtils.java
@@ -52,6 +52,8 @@ public class TezUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(TezUtils.class);
 
+  private TezUtils() {}
+
   /**
    * Allows changing the log level for task / AM logging. </p>
    *

--- a/tez-api/src/main/java/org/apache/tez/common/TezYARNUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/common/TezYARNUtils.java
@@ -38,6 +38,8 @@ public class TezYARNUtils {
   
   private static Pattern ENV_VARIABLE_PATTERN = Pattern.compile(Shell.getEnvironmentVariableRegex());
 
+  private TezYARNUtils() {}
+
   public static String getFrameworkClasspath(Configuration conf, boolean usingArchive) {
     StringBuilder classpathBuilder = new StringBuilder();
 

--- a/tez-api/src/main/java/org/apache/tez/dag/api/TezConstants.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/TezConstants.java
@@ -105,6 +105,8 @@ public class TezConstants {
   private static final String TEZ_AM_SERVICE_PLUGIN_NAME_YARN_CONTAINERS = "TezYarn";
   private static final String TEZ_AM_SERVICE_PLUGIN_NAME_IN_AM = "TezUber";
 
+  private TezConstants() {}
+
   public static String getTezYarnServicePluginName() {
     return TEZ_AM_SERVICE_PLUGIN_NAME_YARN_CONTAINERS;
   }

--- a/tez-common/src/main/java/org/apache/tez/common/EnvironmentUpdateUtils.java
+++ b/tez-common/src/main/java/org/apache/tez/common/EnvironmentUpdateUtils.java
@@ -31,6 +31,8 @@ import java.util.Map;
 @InterfaceAudience.Private
 public class EnvironmentUpdateUtils {
 
+  private EnvironmentUpdateUtils() {}
+
   /**
    * Allows dynamic update to the environment variables. After calling put,
    * System.getenv(key) will then return value.

--- a/tez-common/src/main/java/org/apache/tez/common/TezUtilsInternal.java
+++ b/tez-common/src/main/java/org/apache/tez/common/TezUtilsInternal.java
@@ -61,6 +61,8 @@ public class TezUtilsInternal {
 
   private static final Logger LOG = LoggerFactory.getLogger(TezUtilsInternal.class);
 
+  private TezUtilsInternal() {}
+
   public static ConfigurationProto readUserSpecifiedTezConfiguration(String baseDir) throws
       IOException {
     FileInputStream confPBBinaryStream = null;

--- a/tez-common/src/main/java/org/apache/tez/dag/utils/RelocalizationUtils.java
+++ b/tez-common/src/main/java/org/apache/tez/dag/utils/RelocalizationUtils.java
@@ -40,6 +40,8 @@ import com.google.common.collect.Lists;
 @InterfaceAudience.Private
 public class RelocalizationUtils {
   
+  private RelocalizationUtils() {}
+
   public static List<URL> processAdditionalResources(Map<String, URI> additionalResources,
       Configuration conf, String destDir) throws IOException, TezException {
     if (additionalResources == null || additionalResources.isEmpty()) {

--- a/tez-dag/src/main/java/org/apache/tez/Utils.java
+++ b/tez-dag/src/main/java/org/apache/tez/Utils.java
@@ -34,6 +34,8 @@ public class Utils {
 
   private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
 
+  private Utils() {}
+
   public static String getContainerLauncherIdentifierString(int launcherIndex, AppContext appContext) {
     String name;
     try {

--- a/tez-dag/src/main/java/org/apache/tez/dag/history/utils/DAGUtils.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/history/utils/DAGUtils.java
@@ -94,7 +94,7 @@ public class DAGUtils {
   public static final String VERTEX_GROUP_EDGE_MERGED_INPUTS_KEY = "edgeMergedInputs";
   public static final String VERTEX_GROUP_DESTINATION_VERTEX_NAME_KEY = "destinationVertexName";
 
-
+  private DAGUtils() {}
 
   public static JSONObject generateSimpleJSONPlan(DAGPlan dagPlan) throws JSONException {
     JSONObject dagJson;

--- a/tez-dag/src/main/java/org/apache/tez/dag/history/utils/TezEventUtils.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/history/utils/TezEventUtils.java
@@ -34,6 +34,8 @@ import org.apache.tez.runtime.api.impl.TezEvent;
 
 public class TezEventUtils {
 
+  private TezEventUtils() {}
+
   public static TezEventProto toProto(TezEvent event) throws IOException {
     TezEventProto.Builder evtBuilder =
         TezEventProto.newBuilder();

--- a/tez-dag/src/main/java/org/apache/tez/dag/utils/ProtoUtils.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/utils/ProtoUtils.java
@@ -26,6 +26,8 @@ import com.google.protobuf.ByteString;
 
 public class ProtoUtils {
 
+  private ProtoUtils() {}
+
   public static RecoveryProtos.SummaryEventProto toSummaryEventProto(
       TezDAGID dagID, long timestamp, HistoryEventType historyEventType, byte[] payload) {
     RecoveryProtos.SummaryEventProto.Builder builder =

--- a/tez-dag/src/main/java/org/apache/tez/dag/utils/TezBuilderUtils.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/utils/TezBuilderUtils.java
@@ -29,6 +29,8 @@ import org.apache.tez.dag.records.TezVertexID;
 
 public class TezBuilderUtils {
 
+  private TezBuilderUtils() {}
+
   public static TezVertexID newVertexID(TezDAGID dagId, int vertexId) {
     return TezVertexID.getInstance(dagId, vertexId);
   }

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/lib/MRInputUtils.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/lib/MRInputUtils.java
@@ -47,6 +47,8 @@ public class MRInputUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(MRInputUtils.class);
 
+  private MRInputUtils() {}
+
   public static TaskSplitMetaInfo[] readSplits(Configuration conf) throws IOException {
     TaskSplitMetaInfo[] allTaskSplitMetaInfo;
     allTaskSplitMetaInfo = SplitMetaInfoReaderTez

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/utils/Utils.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/utils/Utils.java
@@ -45,6 +45,8 @@ public class Utils {
 
   private static final String LOG4J_CONFIGURATION = "log4j.configuration";
 
+  private Utils() {}
+
   /**
    * Parse tez counters from json
    *

--- a/tez-runtime-internals/src/main/java/org/apache/tez/common/TezConverterUtils.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/common/TezConverterUtils.java
@@ -27,6 +27,8 @@ import org.apache.hadoop.yarn.api.records.URL;
 
 public class TezConverterUtils {
 
+  private TezConverterUtils() {}
+
   /**
    * return a {@link URI} from a given url
    * 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ConfigUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/ConfigUtils.java
@@ -40,6 +40,8 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 @InterfaceAudience.Private
 public class ConfigUtils {
 
+  private ConfigUtils() {}
+
   public static Class<? extends CompressionCodec> getIntermediateOutputCompressorClass(
       Configuration conf, Class<DefaultCodec> defaultValue) {
     Class<? extends CompressionCodec> codecClass = defaultValue;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/Constants.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/Constants.java
@@ -63,4 +63,5 @@ public class Constants {
   public static final String TEZ_RUNTIME_TASK_OUTPUT_MANAGER = 
       "tez.runtime.task.local.output.manager";
 
+  private Constants() {}
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/TezRuntimeUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/TezRuntimeUtils.java
@@ -41,6 +41,8 @@ public class TezRuntimeUtils {
   private static final Logger LOG = LoggerFactory
       .getLogger(TezRuntimeUtils.class);
   
+  private TezRuntimeUtils() {}
+  
   public static String getTaskIdentifier(String vertexName, int taskIndex) {
     return String.format("%s_%06d", vertexName, taskIndex);
   }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/security/SecureShuffleUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/security/SecureShuffleUtils.java
@@ -40,7 +40,9 @@ import org.apache.tez.common.security.JobTokenSecretManager;
 public class SecureShuffleUtils {
   public static final String HTTP_HEADER_URL_HASH = "UrlHash";
   public static final String HTTP_HEADER_REPLY_URL_HASH = "ReplyHash";
-  
+
+  private SecureShuffleUtils() {}
+
   /**
    * Base64 encoded hash of msg
    * @param msg

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
@@ -84,6 +84,8 @@ public class ShuffleUtils {
         }
       };
 
+  private ShuffleUtils() {}
+
   public static SecretKey getJobTokenSecretFromTokenBytes(ByteBuffer meta)
       throws IOException {
     DataInputByteBuffer in = new DataInputByteBuffer();

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/Utils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/conf/Utils.java
@@ -24,6 +24,8 @@ import org.apache.tez.dag.api.EdgeProperty;
 @Private
 class Utils {
 
+  private Utils() {}
+
   /**
    * Modify the EdgeProperty to set the history text if available
    * @param edgeConfig Edge config

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/utils/BufferUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/utils/BufferUtils.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.io.DataOutputBuffer;
 
 @Private
 public class BufferUtils {
+  private BufferUtils() {}
+
   public static int compare(DataInputBuffer buf1, DataInputBuffer buf2) {
     byte[] b1 = buf1.getData();
     byte[] b2 = buf2.getData();

--- a/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/utils/Utils.java
+++ b/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/utils/Utils.java
@@ -34,6 +34,8 @@ public class Utils {
 
   private static Pattern sanitizeLabelPattern = Pattern.compile("[:\\-\\W]+");
 
+  private Utils() {}
+
   public static String getShortClassName(String className) {
     int pos = className.lastIndexOf(".");
     if (pos != -1 && pos < className.length() - 1) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes technical debt of 810 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava