### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/client/CallerContext.java
+++ b/tez-api/src/main/java/org/apache/tez/client/CallerContext.java
@@ -62,6 +62,20 @@ public class CallerContext {
   private CallerContext() {
   }
 
+  private CallerContext(String context, String callerId, String callerType,
+      @Nullable String blob) {
+    if (callerId != null || callerType != null) {
+      setCallerIdAndType(callerId, callerType);
+    }
+    setContext(context);
+    setBlob(blob);
+  }
+
+  private CallerContext(String context, @Nullable String blob) {
+    setContext(context);
+    setBlob(blob);
+  }
+
   /**
    * Instantiate the Caller Context
    * @param context Context in which Tez is being invoked. For example, HIVE or PIG.
@@ -93,21 +107,6 @@ public class CallerContext {
     return new CallerContext(context, blob);
   }
 
-
-  private CallerContext(String context, String callerId, String callerType,
-      @Nullable String blob) {
-    if (callerId != null || callerType != null) {
-      setCallerIdAndType(callerId, callerType);
-    }
-    setContext(context);
-    setBlob(blob);
-  }
-
-  private CallerContext(String context, @Nullable String blob) {
-    setContext(context);
-    setBlob(blob);
-  }
-
   public String getCallerType() {
     return callerType;
   }
@@ -118,6 +117,16 @@ public class CallerContext {
 
   public String getBlob() {
     return blob;
+  }
+
+  /**
+   * @param blob Free-form text or a json-representation of relevant meta-data.
+   *             This can be used to describe the work being done. For example, for Hive,
+   *             this could be the Hive query text.
+   */
+  public CallerContext setBlob(@Nullable String blob) {
+    this.blob = blob;
+    return this;
   }
 
   public String getContext() {
@@ -147,16 +156,6 @@ public class CallerContext {
         "Caller Id and Caller Type cannot be null or empty");
     this.callerType = callerType;
     this.callerId = callerId;
-    return this;
-  }
-
-  /**
-   * @param blob Free-form text or a json-representation of relevant meta-data.
-   *             This can be used to describe the work being done. For example, for Hive,
-   *             this could be the Hive query text.
-   */
-  public CallerContext setBlob(@Nullable String blob) {
-    this.blob = blob;
     return this;
   }
 

--- a/tez-api/src/main/java/org/apache/tez/common/ReflectionUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/common/ReflectionUtils.java
@@ -35,6 +35,9 @@ import org.apache.tez.dag.api.TezUncheckedException;
 public class ReflectionUtils {
 
   private static final Map<String, Class<?>> CLAZZ_CACHE = new ConcurrentHashMap<String, Class<?>>();
+  // Parameters for addResourcesToSystemClassLoader
+  private static final Class<?>[] parameters = new Class[]{URL.class};
+  private static Method sysClassLoaderMethod = null;
 
   @Private
   public static Class<?> getClazz(String className) throws TezReflectionException {
@@ -115,10 +118,6 @@ public class ReflectionUtils {
         .currentThread().getContextClassLoader());
     Thread.currentThread().setContextClassLoader(classLoader);
   }
-
-  // Parameters for addResourcesToSystemClassLoader
-  private static final Class<?>[] parameters = new Class[]{URL.class};
-  private static Method sysClassLoaderMethod = null;
 
   @Private
   public static synchronized void addResourcesToSystemClassLoader(List<URL> urls) {

--- a/tez-api/src/main/java/org/apache/tez/common/counters/Limits.java
+++ b/tez-api/src/main/java/org/apache/tez/common/counters/Limits.java
@@ -36,6 +36,8 @@ public class Limits {
   private static int GROUPS_MAX;
   private static int COUNTERS_MAX;
   private static boolean initialized = false;
+  private int totalCounters;
+  private LimitExceededException firstViolation;
 
   private static synchronized void ensureInitialized() {
     if (initialized) {
@@ -62,9 +64,6 @@ public class Limits {
         + ", MAX_COUNTERS=" + COUNTERS_MAX);
   }
 
-  private int totalCounters;
-  private LimitExceededException firstViolation;
-
   public static String filterName(String name, int maxLen) {
     return name.length() > maxLen ? name.substring(0, maxLen - 1) : name;
   }
@@ -77,6 +76,19 @@ public class Limits {
   public static String filterGroupName(String name) {
     ensureInitialized();
     return filterName(name, GROUP_NAME_MAX);
+  }
+
+  public synchronized static void setConfiguration(Configuration conf) {
+    if (Limits.conf == null && conf != null) {
+      Limits.conf = conf;
+    }
+  }
+
+  @VisibleForTesting
+  @InterfaceAudience.Private
+  public synchronized static void reset() {
+    conf = null;
+    initialized = false;
   }
 
   public synchronized void checkCounters(int size) {
@@ -109,19 +121,6 @@ public class Limits {
 
   public synchronized LimitExceededException violation() {
     return firstViolation;
-  }
-
-  public synchronized static void setConfiguration(Configuration conf) {
-    if (Limits.conf == null && conf != null) {
-      Limits.conf = conf;
-    }
-  }
-
-  @VisibleForTesting
-  @InterfaceAudience.Private
-  public synchronized static void reset() {
-    conf = null;
-    initialized = false;
   }
 
 }

--- a/tez-api/src/main/java/org/apache/tez/common/security/JobTokenSecretManager.java
+++ b/tez-api/src/main/java/org/apache/tez/common/security/JobTokenSecretManager.java
@@ -43,6 +43,26 @@ public class JobTokenSecretManager extends SecretManager<JobTokenIdentifier> {
   private final Mac mac;
 
   /**
+   * Default constructor
+   */
+  public JobTokenSecretManager() {
+    this(null);
+  }
+
+  public JobTokenSecretManager(SecretKey key) {
+    this.masterKey = (key == null) ? generateSecret() : key;
+    this.currentJobTokens = new TreeMap<String, SecretKey>();
+    try {
+      mac = Mac.getInstance(DEFAULT_HMAC_ALGORITHM);
+      mac.init(masterKey);
+    } catch (NoSuchAlgorithmException nsa) {
+      throw new IllegalArgumentException("Can't find " + DEFAULT_HMAC_ALGORITHM + " algorithm.", nsa);
+    } catch (InvalidKeyException ike) {
+      throw new IllegalArgumentException("Invalid key to HMAC computation", ike);
+    }
+  }
+
+  /**
    * Convert the byte[] to a secret key
    * @param key the byte[] to create the secret key from
    * @return the secret key
@@ -71,27 +91,6 @@ public class JobTokenSecretManager extends SecretManager<JobTokenIdentifier> {
       return mac.doFinal(msg);
     }
   }
-
-  /**
-   * Default constructor
-   */
-  public JobTokenSecretManager() {
-    this(null);
-  }
-
-  public JobTokenSecretManager(SecretKey key) {
-    this.masterKey = (key == null) ? generateSecret() : key;
-    this.currentJobTokens = new TreeMap<String, SecretKey>();
-    try {
-      mac = Mac.getInstance(DEFAULT_HMAC_ALGORITHM);
-      mac.init(masterKey);
-    } catch (NoSuchAlgorithmException nsa) {
-      throw new IllegalArgumentException("Can't find " + DEFAULT_HMAC_ALGORITHM + " algorithm.", nsa);
-    } catch (InvalidKeyException ike) {
-      throw new IllegalArgumentException("Invalid key to HMAC computation", ike);
-    }
-  }
-
 
   /**
    * Create a new password/secret for the given job token identifier.

--- a/tez-api/src/main/java/org/apache/tez/common/security/TokenCache.java
+++ b/tez-api/src/main/java/org/apache/tez/common/security/TokenCache.java
@@ -47,7 +47,7 @@ import org.apache.hadoop.security.token.TokenIdentifier;
 public class TokenCache {
   
   private static final Logger LOG = LoggerFactory.getLogger(TokenCache.class);
-
+  private static final Text SESSION_TOKEN = new Text("SessionToken");
   
   /**
    * auxiliary method to get user's secret keys..
@@ -59,9 +59,9 @@ public class TokenCache {
       return null;
     return credentials.getSecretKey(alias);
   }
-  
+
   /**
-   * Convenience method to obtain delegation tokens from namenodes 
+   * Convenience method to obtain delegation tokens from namenodes
    * corresponding to the paths passed.
    * @param credentials
    * @param ps array of paths
@@ -95,7 +95,7 @@ public class TokenCache {
    * @param conf
    * @throws IOException
    */
-  static void obtainTokensForFileSystemsInternal(FileSystem fs, 
+  static void obtainTokensForFileSystemsInternal(FileSystem fs,
       Credentials credentials, Configuration conf) throws IOException {
     // TODO Change this to use YARN utilities once YARN-1664 is fixed.
     String delegTokenRenewer = Master.getMasterPrincipal(conf);
@@ -112,8 +112,6 @@ public class TokenCache {
       }
     }
   }
-
-  private static final Text SESSION_TOKEN = new Text("SessionToken");
 
   /**
    * store session specific token

--- a/tez-common/src/main/java/org/apache/tez/common/TezUtilsInternal.java
+++ b/tez-common/src/main/java/org/apache/tez/common/TezUtilsInternal.java
@@ -60,8 +60,40 @@ import org.apache.tez.dag.records.TaskAttemptTerminationCause;
 @Private
 public class TezUtilsInternal {
 
+  @Private
+  public static final int MAX_VERTEX_NAME_LENGTH = 40;
   private static final Logger LOG = LoggerFactory.getLogger(TezUtilsInternal.class);
+  private static final Pattern pattern = Pattern.compile("\\W");
 
+<<<<<<< Updated upstream
+=======
+  private TezUtilsInternal() {}
+//
+//  public static void addUserSpecifiedTezConfiguration(String baseDir, Configuration conf) throws
+//      IOException {
+//    FileInputStream confPBBinaryStream = null;
+//    ConfigurationProto.Builder confProtoBuilder = ConfigurationProto.newBuilder();
+//    try {
+//      confPBBinaryStream =
+//          new FileInputStream(new File(baseDir, TezConstants.TEZ_PB_BINARY_CONF_NAME));
+//      confProtoBuilder.mergeFrom(confPBBinaryStream);
+//    } finally {
+//      if (confPBBinaryStream != null) {
+//        confPBBinaryStream.close();
+//      }
+//    }
+//
+//    ConfigurationProto confProto = confProtoBuilder.build();
+//
+//    List<PlanKeyValuePair> kvPairList = confProto.getConfKeyValuesList();
+//    if (kvPairList != null && !kvPairList.isEmpty()) {
+//      for (PlanKeyValuePair kvPair : kvPairList) {
+//        conf.set(kvPair.getKey(), kvPair.getValue());
+//      }
+//    }
+//  }
+
+>>>>>>> Stashed changes
   public static ConfigurationProto readUserSpecifiedTezConfiguration(String baseDir) throws
       IOException {
     FileInputStream confPBBinaryStream = null;
@@ -88,31 +120,6 @@ public class TezUtilsInternal {
       }
     }
   }
-//
-//  public static void addUserSpecifiedTezConfiguration(String baseDir, Configuration conf) throws
-//      IOException {
-//    FileInputStream confPBBinaryStream = null;
-//    ConfigurationProto.Builder confProtoBuilder = ConfigurationProto.newBuilder();
-//    try {
-//      confPBBinaryStream =
-//          new FileInputStream(new File(baseDir, TezConstants.TEZ_PB_BINARY_CONF_NAME));
-//      confProtoBuilder.mergeFrom(confPBBinaryStream);
-//    } finally {
-//      if (confPBBinaryStream != null) {
-//        confPBBinaryStream.close();
-//      }
-//    }
-//
-//    ConfigurationProto confProto = confProtoBuilder.build();
-//
-//    List<PlanKeyValuePair> kvPairList = confProto.getConfKeyValuesList();
-//    if (kvPairList != null && !kvPairList.isEmpty()) {
-//      for (PlanKeyValuePair kvPair : kvPairList) {
-//        conf.set(kvPair.getKey(), kvPair.getValue());
-//      }
-//    }
-//  }
-
 
   public static byte[] compressBytes(byte[] inBytes) throws IOException {
     StopWatch sw = new StopWatch().start();
@@ -167,10 +174,6 @@ public class TezUtilsInternal {
     byte[] output = bos.toByteArray();
     return output;
   }
-
-  private static final Pattern pattern = Pattern.compile("\\W");
-  @Private
-  public static final int MAX_VERTEX_NAME_LENGTH = 40;
 
   @Private
   public static String cleanVertexName(String vertexName) {

--- a/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/utils/SVGUtils.java
+++ b/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/utils/SVGUtils.java
@@ -35,14 +35,7 @@ import java.util.concurrent.TimeUnit;
 
 public class SVGUtils {
 
-  private static int MAX_DAG_RUNTIME = 0;
   private static final int SCREEN_WIDTH = 1800;
-
-  public SVGUtils() {    
-  }
-
-  private int Y_MAX;
-  private int X_MAX;
   private static final DecimalFormat secondFormat = new DecimalFormat("#.##");
   private static final int X_BASE = 100;
   private static final int Y_BASE = 100;
@@ -57,7 +50,14 @@ public class SVGUtils {
   private static final String CRITICAL_COLOR = "IndianRed";
   private static final float RECT_OPACITY = 1.0f;
   private static final String TITLE_BR = "&#13;";
+  private static int MAX_DAG_RUNTIME = 0;
+  List<String> svgLines = new LinkedList<>();
+  private int Y_MAX;
+  private int X_MAX;
 
+  public SVGUtils() {
+  }
+  
   public static String getTimeStr(final long millis) {
     long minutes = TimeUnit.MILLISECONDS.toMinutes(millis)
             - TimeUnit.HOURS.toMinutes(TimeUnit.MILLISECONDS.toHours(millis));
@@ -68,11 +68,9 @@ public class SVGUtils {
     long seconds = millis - TimeUnit.MINUTES.toMillis(
         TimeUnit.MILLISECONDS.toMinutes(millis));
     b.append(secondFormat.format(seconds/1000.0) + "s");
-    
-    return b.toString(); 
+
+    return b.toString();
   }
-  
-  List<String> svgLines = new LinkedList<>();
   
   private final int addOffsetX(int x) {
     int xOff = x + X_BASE;


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 165 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava