### PR TITLE
[TEZ-3369][WIP] Fixing Tez's DAGClients to work with Cascading 

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/common/ATSConstants.java
+++ b/tez-api/src/main/java/org/apache/tez/common/ATSConstants.java
@@ -110,6 +110,7 @@ public class ATSConstants {
   public static final String RESOURCE_URI_BASE = "/ws/v1/timeline";
   public static final String TEZ_DAG_ID = "TEZ_DAG_ID";
   public static final String TEZ_VERTEX_ID = "TEZ_VERTEX_ID";
+  public static final String TEZ_TASK_ID = "TEZ_TASK_ID";
 
   /* In Yarn but not present in 2.2 */
   public static final String TIMELINE_SERVICE_WEBAPP_HTTP_ADDRESS_CONF_NAME =

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClient.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClient.java
@@ -20,6 +20,7 @@ package org.apache.tez.dag.api.client;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Nullable;
@@ -73,6 +74,37 @@ public abstract class DAGClient implements Closeable {
   public abstract DAGStatus getDAGStatus(@Nullable Set<StatusGetOpts> statusOptions,
       long timeout)
       throws IOException, TezException;
+
+  /**
+   * Get basic DAG information details such as name / id / vertex ID -> name mapping
+   * @return DAG information
+   * @throws IOException
+   * @throws TezException
+   */
+  public abstract DAGInformation getDAGInformation() throws IOException, TezException;
+
+  /**
+   * Retrieve some details for a given task such as state / task counters etc.
+   * @param vertexID ID of the vertex to which the task belongs
+   * @param taskID ID of the task whose details need to be retrieved
+   * @return Task information
+   * @throws IOException
+   * @throws TezException
+   */
+  public abstract TaskInformation getTaskInformation(String vertexID, String taskID) throws IOException, TezException;
+
+  /**
+   * Retrieve a list of task information objects. This API can be called multiple times to paginate
+   * over task information for a set of tasks at a time.
+   * @param vertexID ID of the vertex to which the tasks belong
+   * @param startTaskID if null, we retrieve Task information details from the first task (ordered by TaskID).
+   * If not null, we retrieve task information for tasks starting with this task.
+   * @param limit Number of task information objects to retrieve
+   * @return List of Task information objects.
+   * @throws IOException
+   * @throws TezException
+   */
+  public abstract List<TaskInformation> getTaskInformation(String vertexID, @Nullable String startTaskID, int limit) throws IOException, TezException;
 
   /**
    * Get the status of a Vertex of a DAG

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientInternal.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientInternal.java
@@ -20,12 +20,12 @@ package org.apache.tez.dag.api.client;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Nullable;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
-import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException;
 import org.apache.tez.dag.api.TezException;
@@ -113,4 +113,41 @@ public abstract class DAGClientInternal implements Closeable {
    */
   public abstract DAGStatus waitForCompletionWithStatusUpdates(@Nullable Set<StatusGetOpts> statusGetOpts)
       throws IOException, TezException, InterruptedException;
+
+  /**
+   * Get basic DAG information details such as name / id / vertex ID -> name mapping
+   * @return DAG information
+   * @throws IOException
+   * @throws TezException
+   * @throws ApplicationNotFoundException
+   */
+  public abstract DAGInformation getDAGInformation()
+    throws IOException, TezException, ApplicationNotFoundException;
+
+  /**
+   * Retrieve some details for a given task such as state / task counters etc.
+   * @param vertexID ID of the vertex to which the task belongs
+   * @param taskID ID of the task whose details need to be retrieved
+   * @return Task information
+   * @throws IOException
+   * @throws TezException
+   * @throws ApplicationNotFoundException
+   */
+  public abstract TaskInformation getTaskInformation(String vertexID, String taskID)
+    throws IOException, TezException, ApplicationNotFoundException;
+
+  /**
+   * Retrieve a list of task information objects. This API can be called multiple times to paginate
+   * over task information for a set of tasks at a time.
+   * @param vertexID ID of the vertex to which the tasks belong
+   * @param startTaskID if null, we retrieve Task information details from the first task (ordered by TaskID).
+   * If not null, we retrieve task information for tasks starting with this task.
+   * @param limit Number of task information objects to retrieve
+   * @return List of Task information objects.
+   * @throws IOException
+   * @throws TezException
+   * @throws ApplicationNotFoundException
+   */
+  public abstract List<TaskInformation> getTaskInformation(String vertexID, String startTaskID, int limit)
+    throws IOException, TezException, ApplicationNotFoundException;
 }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGInformation.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGInformation.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.dag.api.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.classification.InterfaceAudience.Public;
+import org.apache.tez.dag.api.DAG;
+import org.apache.tez.dag.api.records.DAGProtos;
+
+/**
+ * Some information about the {@link DAG}
+ */
+@Public
+public class DAGInformation {
+
+  DAGProtos.DAGInformationProtoOrBuilder proxy = null;
+  private List<VertexInformation> vertexInformationList = null;
+  private AtomicBoolean vertexListInitialized = new AtomicBoolean(false);
+
+  @Private
+  public DAGInformation(DAGProtos.DAGInformationProtoOrBuilder proxy) {
+    this.proxy = proxy;
+  }
+
+  public String getName() {
+    return proxy.getName();
+  }
+
+  public String getDAGID() {
+    return proxy.getDagId();
+  }
+
+  public List<VertexInformation> getVertexInformation() {
+    if (vertexListInitialized.get()) {
+      return vertexInformationList;
+    }
+
+    vertexInformationList = new ArrayList<>(proxy.getVerticesCount());
+    for(DAGProtos.VertexInformationProto vertexProto : proxy.getVerticesList()) {
+      vertexInformationList.add(new VertexInformation(vertexProto));
+    }
+
+    vertexListInitialized.set(true);
+    return vertexInformationList;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    if (o instanceof DAGInformation) {
+      DAGInformation other = (DAGInformation) o;
+
+      List<VertexInformation> vertexList = getVertexInformation();
+      List<VertexInformation> otherVertexList = other.getVertexInformation();
+      return getName().equals(other.getName())
+        && getDAGID().equals(other.getDAGID())
+        &&
+        ((vertexList == null && otherVertexList == null)
+          || vertexList.equals(otherVertexList));
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 46021;
+    int result = prime + getName().hashCode();
+
+    String id = getDAGID();
+    List<VertexInformation> vertexInformationList = getVertexInformation();
+
+    result = prime * result +
+      ((id == null)? 0 : id.hashCode());
+    result = prime * result +
+      ((vertexInformationList == null)? 0 : vertexInformationList.hashCode());
+
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    String vertexListStr = StringUtils.join(getVertexInformation(), ",");
+    return ("name=" + getName()
+      + ", dagId=" + getDAGID()
+      + ", VertexInformationList=" + vertexListStr);
+  }
+}

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/TaskInformation.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/TaskInformation.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.dag.api.client;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.classification.InterfaceAudience.Public;
+import org.apache.tez.common.counters.TezCounters;
+import org.apache.tez.dag.api.DagTypeConverters;
+import org.apache.tez.dag.api.TezUncheckedException;
+import org.apache.tez.dag.api.records.DAGProtos;
+
+/**
+ * Some information about Tez tasks.
+ */
+@Public
+public class TaskInformation {
+
+  DAGProtos.TaskInformationProtoOrBuilder proxy = null;
+
+  private TezCounters taskCounters = null;
+  private AtomicBoolean countersInitialized = new AtomicBoolean(false);
+
+  @Private
+  public TaskInformation(DAGProtos.TaskInformationProtoOrBuilder proxy) {
+    this.proxy = proxy;
+  }
+
+  public TaskState getState() {
+    return getState(proxy.getState());
+  }
+
+  private TaskState getState(DAGProtos.TaskStateProto stateProto) {
+    switch (stateProto) {
+      case TASK_NEW:
+        return TaskState.NEW;
+      case TASK_SCHEDULED:
+        return TaskState.SCHEDULED;
+      case TASK_RUNNING:
+        return TaskState.RUNNING;
+      case TASK_SUCCEEDED:
+        return TaskState.SUCCEEDED;
+      case TASK_FAILED:
+        return TaskState.FAILED;
+      case TASK_KILLED:
+        return TaskState.KILLED;
+      default:
+        throw new TezUncheckedException(
+          "Unsupported value for TaskState: " + stateProto);
+    }
+  }
+
+  public String getID() {
+    return proxy.getId();
+  }
+
+  public Long getScheduledTime() {
+    return proxy.getScheduledTime();
+  }
+
+  public Long getStartTime() {
+    return proxy.getStartTime();
+  }
+
+  public Long getEndTime() {
+    return proxy.getEndTime();
+  }
+
+  public String getSuccessfulAttemptID() {
+    return proxy.getSuccessfulAttemptId();
+  }
+
+  public TezCounters getTaskCounters() {
+    if (countersInitialized.get()) {
+      return taskCounters;
+    }
+    if (proxy.hasTaskCounters()) {
+      taskCounters = DagTypeConverters.convertTezCountersFromProto(
+        proxy.getTaskCounters());
+    }
+    countersInitialized.set(true);
+    return taskCounters;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) return true;
+    if (obj == null || getClass() != obj.getClass()) return false;
+
+    if (obj instanceof TaskInformation) {
+      TaskInformation other = (TaskInformation) obj;
+      return getState().equals(other.getState())
+        && getID().equals(other.getID())
+        && getScheduledTime().equals(other.getScheduledTime())
+        && getStartTime().equals(other.getStartTime())
+        && getEndTime().equals(other.getEndTime())
+        && getSuccessfulAttemptID().equals(other.getSuccessfulAttemptID())
+        &&
+        ((getTaskCounters() == null && other.getTaskCounters() == null)
+          || getTaskCounters().equals(other.getTaskCounters()));
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 46021;
+    int result = prime + getState().hashCode();
+
+    String id = getID();
+    Long scheduledTime = getScheduledTime();
+    Long startTime = getStartTime();
+    Long endTime = getEndTime();
+    String successfulAttemptId = getSuccessfulAttemptID();
+    TezCounters counters = getTaskCounters();
+
+    result = prime * result +
+      ((id == null)? 0 : id.hashCode());
+    result = prime * result +
+      ((scheduledTime == null)? 0 : scheduledTime.hashCode());
+    result = prime * result +
+      ((startTime == null)? 0 : startTime.hashCode());
+    result = prime * result +
+      ((endTime == null)? 0 : endTime.hashCode());
+    result = prime * result +
+      ((successfulAttemptId == null)? 0 : successfulAttemptId.hashCode());
+    result = prime * result +
+      ((counters == null)? 0 : counters.hashCode());
+
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return ("state=" + getState()
+      + ", id=" + getID()
+      + ", scheduledTime=" + getScheduledTime()
+      + ", startTime=" + getStartTime()
+      + ", endTime=" + getEndTime()
+      + ", successfulAttemptId=" + getSuccessfulAttemptID()
+      + ", counters="
+      + (getTaskCounters() == null ? "null" : getTaskCounters().toString()));
+  }
+}

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/TaskInformation.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/TaskInformation.java
@@ -71,6 +71,10 @@ public class TaskInformation {
     return proxy.getId();
   }
 
+  public String getDiagnostics() {
+    return proxy.getDiagnostics();
+  }
+
   public Long getScheduledTime() {
     return proxy.getScheduledTime();
   }
@@ -108,10 +112,12 @@ public class TaskInformation {
       TaskInformation other = (TaskInformation) obj;
       return getState().equals(other.getState())
         && getID().equals(other.getID())
+        && getDiagnostics().equals(other.getDiagnostics())
         && getScheduledTime().equals(other.getScheduledTime())
         && getStartTime().equals(other.getStartTime())
         && getEndTime().equals(other.getEndTime())
-        && getSuccessfulAttemptID().equals(other.getSuccessfulAttemptID())
+        && (( getSuccessfulAttemptID() == null && other.getSuccessfulAttemptID() == null)
+          || getSuccessfulAttemptID().equals(other.getSuccessfulAttemptID()))
         &&
         ((getTaskCounters() == null && other.getTaskCounters() == null)
           || getTaskCounters().equals(other.getTaskCounters()));
@@ -125,6 +131,7 @@ public class TaskInformation {
     int result = prime + getState().hashCode();
 
     String id = getID();
+    String diagnostics = getDiagnostics();
     Long scheduledTime = getScheduledTime();
     Long startTime = getStartTime();
     Long endTime = getEndTime();
@@ -133,6 +140,8 @@ public class TaskInformation {
 
     result = prime * result +
       ((id == null)? 0 : id.hashCode());
+    result = prime * result +
+      ((diagnostics == null)? 0 : diagnostics.hashCode());
     result = prime * result +
       ((scheduledTime == null)? 0 : scheduledTime.hashCode());
     result = prime * result +
@@ -151,10 +160,11 @@ public class TaskInformation {
   public String toString() {
     return ("state=" + getState()
       + ", id=" + getID()
+      + ", diagnostics=" + getDiagnostics()
       + ", scheduledTime=" + getScheduledTime()
       + ", startTime=" + getStartTime()
       + ", endTime=" + getEndTime()
-      + ", successfulAttemptId=" + getSuccessfulAttemptID()
+      + ", successfulAttemptId=" + ( getSuccessfulAttemptID() == null ? "null" : getSuccessfulAttemptID())
       + ", counters="
       + (getTaskCounters() == null ? "null" : getTaskCounters().toString()));
   }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/TaskState.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/TaskState.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.dag.api.client;
+
+import org.apache.hadoop.classification.InterfaceAudience;
+
+@InterfaceAudience.Private
+public enum TaskState {
+  NEW, SCHEDULED, RUNNING, SUCCEEDED, FAILED, KILLED
+}

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/VertexInformation.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/VertexInformation.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.dag.api.client;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.classification.InterfaceAudience.Public;
+import org.apache.tez.dag.api.records.DAGProtos;
+
+/**
+ * Subset of information about a Tez vertex.
+ */
+@Public
+public class VertexInformation {
+
+  private List<TaskInformation> taskInformationList = null;
+  DAGProtos.VertexInformationProtoOrBuilder proxy = null;
+  private AtomicBoolean taskListInitialized = new AtomicBoolean(false);
+
+  @Private
+  public VertexInformation(DAGProtos.VertexInformationProtoOrBuilder proxy) {
+    this.proxy = proxy;
+  }
+
+  public String getName() {
+    return proxy.getName();
+  }
+
+  public String getId() {
+    return proxy.getId();
+  }
+
+  public List<TaskInformation> getTaskInformationList() {
+    if (taskListInitialized.get()) {
+      return taskInformationList;
+    }
+
+    taskInformationList = new ArrayList<>(proxy.getTasksCount());
+    for(DAGProtos.TaskInformationProto taskProto : proxy.getTasksList()) {
+      taskInformationList.add(new TaskInformation(taskProto));
+    }
+
+    taskListInitialized.set(true);
+    return taskInformationList;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    if (o instanceof VertexInformation) {
+      VertexInformation other = (VertexInformation) o;
+      List<TaskInformation> taskList = getTaskInformationList();
+      List<TaskInformation> otherTaskList = other.getTaskInformationList();
+
+      return getName().equals(other.getName())
+        && getId().equals(other.getId())
+        &&
+        ((taskList == null && otherTaskList == null)
+          || taskList.equals(otherTaskList));
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 46021;
+    int result = prime + getName().hashCode();
+
+    String id = getId();
+    List<TaskInformation> taskInformationList = getTaskInformationList();
+
+    result = prime * result +
+      ((id == null)? 0 : id.hashCode());
+    result = prime * result +
+      ((taskInformationList == null)? 0 : taskInformationList.hashCode());
+
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    String taskListStr = StringUtils.join(getTaskInformationList(), ",");
+    return ("name=" + getName()
+      + ", id=" + getId()
+      + ", TaskInformationList=" + taskListStr);
+  }
+}

--- a/tez-api/src/main/proto/DAGApiRecords.proto
+++ b/tez-api/src/main/proto/DAGApiRecords.proto
@@ -287,8 +287,40 @@ message TezCountersProto {
   repeated TezCounterGroupProto counter_groups = 1;
 }
 
+message DAGInformationProto {
+  required string name = 1;
+  required string dagId = 2;
+  repeated VertexInformationProto vertices = 3;
+}
+
+message VertexInformationProto {
+  required string name = 1;
+  required string id = 2;
+  repeated TaskInformationProto tasks = 3;
+}
+
+message TaskInformationProto {
+  required string id = 1;
+  required TaskStateProto state = 2;
+  required int64 scheduledTime = 3;
+  required int64 startTime = 4;
+  required int64 endTime = 5;
+  required string successfulAttemptId = 6;
+  required string diagnostics = 7;
+  optional TezCountersProto taskCounters = 8;
+}
+
 enum StatusGetOptsProto {
   GET_COUNTERS = 0;
+}
+
+enum TaskStateProto {
+  TASK_NEW = 0;
+  TASK_SCHEDULED = 1;
+  TASK_RUNNING = 2;
+  TASK_SUCCEEDED = 3;
+  TASK_FAILED = 4;
+  TASK_KILLED = 5;
 }
 
 message VertexLocationHintProto {

--- a/tez-api/src/main/proto/DAGApiRecords.proto
+++ b/tez-api/src/main/proto/DAGApiRecords.proto
@@ -305,8 +305,8 @@ message TaskInformationProto {
   required int64 scheduledTime = 3;
   required int64 startTime = 4;
   required int64 endTime = 5;
-  required string successfulAttemptId = 6;
-  required string diagnostics = 7;
+  required string diagnostics = 6;
+  optional string successfulAttemptId = 7;
   optional TezCountersProto taskCounters = 8;
 }
 

--- a/tez-api/src/main/proto/DAGClientAMProtocol.proto
+++ b/tez-api/src/main/proto/DAGClientAMProtocol.proto
@@ -97,7 +97,7 @@ message GetTaskInformationResponseProto {
 message GetTaskInformationListRequestProto {
   required string dagId = 1;
   required string vertexId = 2;
-  required string startTaskId = 3;
+  optional string startTaskId = 3;
   optional int32 limit = 4;
 }
 

--- a/tez-api/src/main/proto/DAGClientAMProtocol.proto
+++ b/tez-api/src/main/proto/DAGClientAMProtocol.proto
@@ -76,6 +76,35 @@ message ShutdownSessionRequestProto {
 message ShutdownSessionResponseProto {
 }
 
+message GetDAGInformationRequestProto {
+  required string dagId = 1;
+}
+
+message GetDAGInformationResponseProto {
+  optional DAGInformationProto dagInformation = 1;
+}
+
+message GetTaskInformationRequestProto {
+  required string dagId = 1;
+  required string vertexId = 2;
+  required string taskId = 3;
+}
+
+message GetTaskInformationResponseProto {
+  optional TaskInformationProto taskInformation = 1;
+}
+
+message GetTaskInformationListRequestProto {
+  required string dagId = 1;
+  required string vertexId = 2;
+  required string startTaskId = 3;
+  optional int32 limit = 4;
+}
+
+message GetTaskInformationListResponseProto {
+  repeated TaskInformationProto taskInformation = 1;
+}
+
 enum TezAppMasterStatusProto {
   INITIALIZING = 0;
   READY = 1;
@@ -93,7 +122,12 @@ message GetAMStatusResponseProto {
 service DAGClientAMProtocol {
   rpc getAllDAGs (GetAllDAGsRequestProto) returns (GetAllDAGsResponseProto);
   rpc getDAGStatus (GetDAGStatusRequestProto) returns (GetDAGStatusResponseProto);
+  rpc getDAGInformation (GetDAGInformationRequestProto) returns (GetDAGInformationResponseProto);
+
   rpc getVertexStatus (GetVertexStatusRequestProto) returns (GetVertexStatusResponseProto);
+  rpc getTaskInformation (GetTaskInformationRequestProto) returns (GetTaskInformationResponseProto);
+  rpc getTaskInformationList (GetTaskInformationListRequestProto) returns (GetTaskInformationListResponseProto);
+
   rpc tryKillDAG (TryKillDAGRequestProto) returns (TryKillDAGResponseProto);
   rpc submitDAG (SubmitDAGRequestProto) returns (SubmitDAGResponseProto);
   rpc shutdownSession (ShutdownSessionRequestProto) returns (ShutdownSessionResponseProto);

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/TestATSHttpClient.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/TestATSHttpClient.java
@@ -26,13 +26,24 @@ import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.collect.Lists;
+
 import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException;
 import org.apache.tez.common.counters.TezCounters;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.TezException;
+import org.apache.tez.dag.api.records.DAGProtos.DAGInformationProto;
+import org.apache.tez.dag.api.records.DAGProtos.VertexInformationProto;
+import org.apache.tez.dag.api.records.DAGProtos.TaskStateProto;
+import org.apache.tez.dag.api.records.DAGProtos.TezCounterProto;
+import org.apache.tez.dag.api.records.DAGProtos.TezCountersProto;
+import org.apache.tez.dag.api.records.DAGProtos.TezCounterGroupProto;
+import org.apache.tez.dag.api.records.DAGProtos.TaskInformationProto;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.junit.Assert;
@@ -88,7 +99,7 @@ public class TestATSHttpClient {
     final String expectedVertexUrl = "http://yarn.ats.webapp/ws/v1/timeline/TEZ_VERTEX_ID" +
         "?primaryFilter=TEZ_DAG_ID:EXAMPLE_DAG_ID&fields=primaryfilters,otherinfo";
 
-    Set<StatusGetOpts> statusOptions = new HashSet<StatusGetOpts>(1);
+    Set<StatusGetOpts> statusOptions = new HashSet<>(1);
     statusOptions.add(StatusGetOpts.GET_COUNTERS);
 
 
@@ -147,7 +158,7 @@ public class TestATSHttpClient {
         "?primaryFilter=TEZ_DAG_ID:EXAMPLE_DAG_ID&secondaryFilter=vertexName:vertex1name&" +
         "fields=primaryfilters,otherinfo";
 
-    Set<StatusGetOpts> statusOptions = new HashSet<StatusGetOpts>(1);
+    Set<StatusGetOpts> statusOptions = new HashSet<>(1);
     statusOptions.add(StatusGetOpts.GET_COUNTERS);
 
     final String jsonData = "{entities:[ {otherinfo:{numFailedTasks:1,numSucceededTasks:2," +
@@ -175,5 +186,322 @@ public class TestATSHttpClient {
     Assert.assertEquals("Counters Size", 2, vertexCounters.countCounters());
     Assert.assertEquals("Counter Value", 1,
         vertexCounters.getGroup("CG1").findCounter("C1").getValue());
+  }
+
+  @Test(timeout = 5000)
+  public void testGetDAGInformation() throws JSONException, TezException, IOException, ApplicationNotFoundException {
+    DAGClientTimelineImpl
+      httpClient = new DAGClientTimelineImpl(mock(ApplicationId.class), "dag_1468518877269_2795_1",
+      new TezConfiguration(), null, 0);
+    DAGClientTimelineImpl spyClient = spy(httpClient);
+    spyClient.baseUri = "http://yarn.ats.webapp/ws/v1/timeline";
+    final String expectedDagInfoUrl = "http://yarn.ats.webapp/ws/v1/timeline/" +
+      "TEZ_DAG_ID/dag_1468518877269_2795_1?fields=primaryfilters,otherinfo";
+
+    final String jsonData = "{  \n" +
+      "   entitytype:'TEZ_DAG_ID',\n" +
+      "   entity:'dag_1468518877269_2795_1',\n" +
+      "   starttime:1470167608648,\n" +
+      "   primaryfilters : {  \n" +
+      "      dagName:[ 'Test DAG'],\n" +
+      "      status:['SUCCEEDED'],\n" +
+      "      applicationId:['application_1468518877269_2795'],\n" +
+      "   },\n" +
+      "   otherinfo:{  \n" +
+      "      numFailedTasks:0,\n" +
+      "      vertexNameIdMapping:{'v1':'vertex_1468518877269_2795_1_01','v2':'vertex_1468518877269_2795_1_00'},\n" +
+      "      status:'SUCCEEDED',\n" +
+      "      dagPlan: { dagName:'Test DAG' },\n" +
+      "      applicationId:'application_1468518877269_2795',\n" +
+      "      endTime:1470167673199,\n" +
+      "      counters:{ counterGroups:[ { counterGroupName:'group1',counters:[ { counterName:'c1',counterValue:46 } ]}]\n" +
+      "      }\n" +
+      "   }\n" +
+      "}";
+
+    doReturn(new JSONObject(jsonData)).when(spyClient).getJsonRootEntity(expectedDagInfoUrl);
+    DAGInformation dagInformation = spyClient.getDAGInformation();
+
+    VertexInformationProto vertex1 =
+      VertexInformationProto.newBuilder()
+        .setId("vertex_1468518877269_2795_1_01")
+        .setName("v1").build();
+    VertexInformationProto vertex2 =
+      VertexInformationProto.newBuilder()
+        .setId("vertex_1468518877269_2795_1_00")
+        .setName("v2").build();
+    List<VertexInformationProto> vertexInformationProtos = Lists.newArrayList(vertex1, vertex2);
+
+    DAGInformationProto dagInformationProto = DAGInformationProto.newBuilder()
+      .setDagId("dag_1468518877269_2795_1")
+      .setName("Test DAG")
+      .addAllVertices(vertexInformationProtos)
+      .build();
+    DAGInformation expectedDagInformation = new DAGInformation(dagInformationProto);
+    Assert.assertEquals(expectedDagInformation, dagInformation);
+  }
+
+  @Test(timeout = 5000)
+  public void testGetTaskInformation() throws JSONException, TezException, IOException, ApplicationNotFoundException {
+    DAGClientTimelineImpl
+      httpClient = new DAGClientTimelineImpl(mock(ApplicationId.class), "dag_1468518877269_2795_1",
+      new TezConfiguration(), null, 0);
+
+    DAGClientTimelineImpl spyClient = spy(httpClient);
+    spyClient.baseUri = "http://yarn.ats.webapp/ws/v1/timeline";
+    final String expectedTaskInfoUrl = "http://yarn.ats.webapp/ws/v1/timeline/" +
+      "TEZ_TASK_ID/task_1468518877269_3815_1_01_000001?fields=primaryfilters,otherinfo";
+
+    // todo: move json to resource files
+    final String jsonData = "{  \n" +
+      "   'entitytype':'TEZ_TASK_ID',\n" +
+      "   'entity':'task_1468518877269_3815_1_01_000001',\n" +
+      "   'starttime':1470778337429,\n" +
+      "   'domain':'Tez_ATS_application_1468518877269_3815',\n" +
+      "   'primaryfilters':{  \n" +
+      "      'status':[  \n" +
+      "         'SUCCEEDED'\n" +
+      "      ],\n" +
+      "      'applicationId':[  \n" +
+      "         'application_1468518877269_3815'\n" +
+      "      ],\n" +
+      "      'TEZ_VERTEX_ID':[  \n" +
+      "         'vertex_1468518877269_3815_1_01'\n" +
+      "      ],\n" +
+      "      'TEZ_DAG_ID':[  \n" +
+      "         'dag_1468518877269_2795_1'\n" +
+      "      ]\n" +
+      "   },\n" +
+      "   'otherinfo':{  \n" +
+      "      'startTime':1470778337429,\n" +
+      "      'status':'SUCCEEDED',\n" +
+      "      'timeTaken':7111,\n" +
+      "      'successfulAttemptId':'attempt_1468518877269_3815_1_01_000001_0',\n" +
+      "      'scheduledTime':1470778337429,\n" +
+      "      'numFailedTaskAttempts':0,\n" +
+      "      'endTime':1470778368202,\n" +
+      "      'diagnostics':'sample diagnostics',\n" +
+      "      'counters':{ 'counterGroups':[ { 'counterGroupName':'group1', 'counters':[ { 'counterName':'c1', 'counterValue':1 } ] }]}\n" +
+      "   }\n" +
+      "}";
+
+    doReturn(new JSONObject(jsonData)).when(spyClient).getJsonRootEntity(expectedTaskInfoUrl);
+    TaskInformation taskInformation = spyClient.getTaskInformation("vertex_1468518877269_3815_1_01", "task_1468518877269_3815_1_01_000001");
+
+
+    TezCountersProto taskCountersProto= TezCountersProto.newBuilder()
+      .addCounterGroups(TezCounterGroupProto.newBuilder()
+        .setDisplayName("group1")
+        .setName("group1")
+        .addCounters(TezCounterProto.newBuilder()
+          .setDisplayName("c1")
+          .setName("c1")
+          .setValue(1)))
+      .build();
+
+    TaskInformationProto taskInformationProto = TaskInformationProto.newBuilder()
+      .setId("task_1468518877269_3815_1_01_000001")
+      .setDiagnostics("sample diagnostics")
+      .setStartTime(1470778337429L)
+      .setState(TaskStateProto.TASK_SUCCEEDED)
+      .setScheduledTime(1470778337429L)
+      .setEndTime(1470778368202L)
+      .setSuccessfulAttemptId("attempt_1468518877269_3815_1_01_000001_0")
+      .setTaskCounters(taskCountersProto)
+      .build();
+
+    Assert.assertEquals(new TaskInformation(taskInformationProto), taskInformation);
+  }
+
+  @Test(timeout = 5000)
+  public void testGetTaskInformationList() throws JSONException, TezException, IOException, ApplicationNotFoundException {
+    DAGClientTimelineImpl
+      httpClient = new DAGClientTimelineImpl(mock(ApplicationId.class), "dag_1468518877269_2795_1",
+      new TezConfiguration(), null, 0);
+
+    DAGClientTimelineImpl spyClient = spy(httpClient);
+    spyClient.baseUri = "http://yarn.ats.webapp/ws/v1/timeline";
+
+    final String expectedTaskInfoUrl = "http://yarn.ats.webapp/ws/v1/timeline/" +
+      "TEZ_TASK_ID?primaryFilter=TEZ_VERTEX_ID:vertex_1468518877269_3815_1_01&fields=primaryfilters,otherinfo&limit=2";
+
+    // todo: move json to resource files
+    final String jsonData = "{  \n" +
+      "   'entities':[  \n" +
+      "      {  \n" +
+      "         'entitytype':'TEZ_TASK_ID',\n" +
+      "         'entity':'task_1468518877269_3815_1_01_000001',\n" +
+      "         'starttime':1470778337429,\n" +
+      "         'domain':'Tez_ATS_application_1468518877269_3815',\n" +
+      "         'primaryfilters':{  \n" +
+      "            'status':[  \n" +
+      "               'SUCCEEDED'\n" +
+      "            ],\n" +
+      "            'applicationId':[  \n" +
+      "               'application_1468518877269_3815'\n" +
+      "            ],\n" +
+      "            'TEZ_VERTEX_ID':[  \n" +
+      "               'vertex_1468518877269_3815_1_01'\n" +
+      "            ],\n" +
+      "            'TEZ_DAG_ID':[  \n" +
+      "               'dag_1468518877269_3815_1'\n" +
+      "            ]\n" +
+      "         },\n" +
+      "         'otherinfo':{  \n" +
+      "            'startTime':1470778337429,\n" +
+      "            'status':'SUCCEEDED',\n" +
+      "            'timeTaken':7111,\n" +
+      "            'successfulAttemptId':'attempt_1468518877269_3815_1_01_000001_0',\n" +
+      "            'scheduledTime':1470778337429,\n" +
+      "            'numFailedTaskAttempts':0,\n" +
+      "            'endTime':1470778368101,\n" +
+      "            'diagnostics':'sample diagnostics',\n" +
+      "            'counters':{ 'counterGroups':[ { 'counterGroupName':'group1','counters':[ { 'counterName':'c1','counterValue':1 } ] } ] }\n" +
+      "         }\n" +
+      "      },\n" +
+      "      {  \n" +
+      "         'entitytype':'TEZ_TASK_ID',\n" +
+      "         'entity':'task_1468518877269_3815_1_01_000002',\n" +
+      "         'starttime':1470778337429,\n" +
+      "         'domain':'Tez_ATS_application_1468518877269_3815',\n" +
+      "         'primaryfilters':{  \n" +
+      "            'status':[  \n" +
+      "               'SUCCEEDED'\n" +
+      "            ],\n" +
+      "            'applicationId':[  \n" +
+      "               'application_1468518877269_3815'\n" +
+      "            ],\n" +
+      "            'TEZ_VERTEX_ID':[  \n" +
+      "               'vertex_1468518877269_3815_1_01'\n" +
+      "            ],\n" +
+      "            'TEZ_DAG_ID':[  \n" +
+      "               'dag_1468518877269_3815_1'\n" +
+      "            ]\n" +
+      "         },\n" +
+      "         'otherinfo':{  \n" +
+      "            'startTime':1470778337429,\n" +
+      "            'status':'SUCCEEDED',\n" +
+      "            'timeTaken':7412,\n" +
+      "            'successfulAttemptId':'attempt_1468518877269_3815_1_01_000002_0',\n" +
+      "            'scheduledTime':1470778337429,\n" +
+      "            'numFailedTaskAttempts':0,\n" +
+      "            'endTime':1470778368101,\n" +
+      "            'diagnostics':'sample diagnostics',\n" +
+      "            'counters':{ 'counterGroups':[ { 'counterGroupName':'group1','counters':[ { 'counterName':'c1','counterValue':1 } ] } ] }\n" +
+      "         }\n" +
+      "      }\n" +
+      "   ]\n" +
+      "}";
+
+    doReturn(new JSONObject(jsonData)).when(spyClient).getJsonRootEntity(expectedTaskInfoUrl);
+    List<TaskInformation> taskInformationList = spyClient.getTaskInformation("vertex_1468518877269_3815_1_01", null, 2);
+
+    TezCountersProto taskCountersProto = TezCountersProto.newBuilder()
+      .addCounterGroups(TezCounterGroupProto.newBuilder()
+        .setDisplayName("group1")
+        .setName("group1")
+        .addCounters(TezCounterProto.newBuilder()
+          .setDisplayName("c1")
+          .setName("c1")
+          .setValue(1)))
+      .build();
+
+    TaskInformationProto taskInformationProto1 = TaskInformationProto.newBuilder()
+      .setId("task_1468518877269_3815_1_01_000001")
+      .setDiagnostics("sample diagnostics")
+      .setStartTime(1470778337429L)
+      .setState(TaskStateProto.TASK_SUCCEEDED)
+      .setScheduledTime(1470778337429L)
+      .setEndTime(1470778368101L)
+      .setSuccessfulAttemptId("attempt_1468518877269_3815_1_01_000001_0")
+      .setTaskCounters(taskCountersProto)
+      .build();
+
+    TaskInformationProto taskInformationProto2 =
+      TaskInformationProto.newBuilder(taskInformationProto1)
+        .setId("task_1468518877269_3815_1_01_000002")
+        .setSuccessfulAttemptId("attempt_1468518877269_3815_1_01_000002_0")
+        .build();
+
+    List<TaskInformation> expectedTaskInformations = Lists.newArrayList(new TaskInformation(taskInformationProto1), new TaskInformation(taskInformationProto2));
+    Assert.assertEquals(expectedTaskInformations, taskInformationList);
+  }
+
+  @Test(timeout = 5000)
+  public void testGetTaskInformationWithStartList() throws JSONException, TezException, IOException, ApplicationNotFoundException {
+    DAGClientTimelineImpl
+      httpClient = new DAGClientTimelineImpl(mock(ApplicationId.class), "dag_1468518877269_2795_1",
+      new TezConfiguration(), null, 0);
+
+    DAGClientTimelineImpl spyClient = spy(httpClient);
+    spyClient.baseUri = "http://yarn.ats.webapp/ws/v1/timeline";
+
+    // test out with startTaskId = task2 (task_1468518877269_3815_1_01_000002)
+    final String expectedTaskInfoWithStartUrl = "http://yarn.ats.webapp/ws/v1/timeline/" +
+      "TEZ_TASK_ID?primaryFilter=TEZ_VERTEX_ID:vertex_1468518877269_3815_1_01&fields=primaryfilters,otherinfo&limit=2&fromId=task_1468518877269_3815_1_01_000002";
+
+    // todo: move json to resource files
+    final String jsonData = "{  \n" +
+      "   'entities':[  \n" +
+      "      {  \n" +
+      "         'entitytype':'TEZ_TASK_ID',\n" +
+      "         'entity':'task_1468518877269_3815_1_01_000002',\n" +
+      "         'starttime':1470778337429,\n" +
+      "         'domain':'Tez_ATS_application_1468518877269_3815',\n" +
+      "         'primaryfilters':{  \n" +
+      "            'status':[  \n" +
+      "               'SUCCEEDED'\n" +
+      "            ],\n" +
+      "            'applicationId':[  \n" +
+      "               'application_1468518877269_3815'\n" +
+      "            ],\n" +
+      "            'TEZ_VERTEX_ID':[  \n" +
+      "               'vertex_1468518877269_3815_1_01'\n" +
+      "            ],\n" +
+      "            'TEZ_DAG_ID':[  \n" +
+      "               'dag_1468518877269_3815_1'\n" +
+      "            ]\n" +
+      "         },\n" +
+      "         'otherinfo':{  \n" +
+      "            'startTime':1470778337429,\n" +
+      "            'status':'SUCCEEDED',\n" +
+      "            'timeTaken':7412,\n" +
+      "            'successfulAttemptId':'attempt_1468518877269_3815_1_01_000002_0',\n" +
+      "            'scheduledTime':1470778337429,\n" +
+      "            'numFailedTaskAttempts':0,\n" +
+      "            'endTime':1470778368101,\n" +
+      "            'diagnostics':'sample diagnostics',\n" +
+      "            'counters':{ 'counterGroups':[ { 'counterGroupName':'group1','counters':[ { 'counterName':'c1','counterValue':1 } ] } ] }\n" +
+      "         }\n" +
+      "      }\n" +
+      "   ]\n" +
+      "}";
+
+    doReturn(new JSONObject(jsonData)).when(spyClient).getJsonRootEntity(expectedTaskInfoWithStartUrl);
+    List<TaskInformation> taskInformationList = spyClient.getTaskInformation("vertex_1468518877269_3815_1_01", "task_1468518877269_3815_1_01_000002", 2);
+
+    TezCountersProto taskCountersProto = TezCountersProto.newBuilder()
+      .addCounterGroups(TezCounterGroupProto.newBuilder()
+        .setDisplayName("group1")
+        .setName("group1")
+        .addCounters(TezCounterProto.newBuilder()
+          .setDisplayName("c1")
+          .setName("c1")
+          .setValue(1)))
+      .build();
+
+    TaskInformationProto taskInformationProto1 = TaskInformationProto.newBuilder()
+      .setId("task_1468518877269_3815_1_01_000002")
+      .setDiagnostics("sample diagnostics")
+      .setStartTime(1470778337429L)
+      .setState(TaskStateProto.TASK_SUCCEEDED)
+      .setScheduledTime(1470778337429L)
+      .setEndTime(1470778368101L)
+      .setSuccessfulAttemptId("attempt_1468518877269_3815_1_01_000002_0")
+      .setTaskCounters(taskCountersProto)
+      .build();
+
+    List<TaskInformation> expectedTaskInformations = Lists.newArrayList(new TaskInformation(taskInformationProto1));
+    Assert.assertEquals(expectedTaskInformations, taskInformationList);
   }
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/api/client/DAGClientHandler.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/api/client/DAGClientHandler.java
@@ -19,11 +19,20 @@
 package org.apache.tez.dag.api.client;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.tez.dag.api.oldrecords.TaskReport;
+import org.apache.tez.dag.app.dag.Task;
+import org.apache.tez.dag.app.dag.TaskAttempt;
+import org.apache.tez.dag.app.dag.Vertex;
+import org.apache.tez.dag.app.dag.impl.TaskImpl;
+import org.apache.tez.dag.records.TezTaskID;
+import org.apache.tez.dag.records.TezVertexID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.ipc.Server;
@@ -68,6 +77,125 @@ public class DAGClientHandler {
   public DAGStatus getDAGStatus(String dagIdStr,
       Set<StatusGetOpts> statusOptions, long timeout) throws TezException {
     return getDAG(dagIdStr).getDAGStatus(statusOptions, timeout);
+  }
+
+  public DAGInformation getDAGInformation(String dagIdStr) throws TezException {
+    DAG dag = getDAG(dagIdStr);
+
+    DAGInformationBuilder dagInformationBuilder = new DAGInformationBuilder();
+    dagInformationBuilder.setDagId(dagIdStr);
+    dagInformationBuilder.setName(dag.getName());
+
+    Map<TezVertexID, Vertex> vertexMap = dag.getVertices();
+    List<VertexInformation> vertexInfoList = new ArrayList<>(vertexMap.size());
+    for (Map.Entry<TezVertexID, Vertex> entry : vertexMap.entrySet()) {
+      VertexInformationBuilder vertexBuilder = new VertexInformationBuilder();
+      vertexBuilder.setName(entry.getValue().getName());
+      vertexBuilder.setId(entry.getValue().getVertexId().toString());
+      vertexInfoList.add(vertexBuilder);
+    }
+
+    dagInformationBuilder.setVertexInformationList(vertexInfoList);
+    return dagInformationBuilder;
+  }
+
+  public TaskInformation getTaskInformation(String dagId, String vertexId, String taskId) throws TezException {
+    DAG dag = getDAG(dagId);
+    Vertex vertex = dag.getVertex(getVertexId(vertexId));
+    if (vertex == null) {
+      throw new TezException("Vertex not found: " + vertexId);
+    }
+
+    Task task = vertex.getTask(getTaskId(taskId));
+    if (task == null) {
+      throw new TezException("Task not found: " + taskId);
+    }
+
+    return getTaskInfoFromTask(task);
+  }
+
+  public List<TaskInformation> getTaskInformationList(String dagId, String vertexId, String startTaskId, int limit) throws TezException {
+    DAG dag = getDAG(dagId);
+    Vertex vertex = dag.getVertex(getVertexId(vertexId));
+    if (vertex == null) {
+      throw new TezException("Vertex not found: " + vertexId);
+    }
+
+    Iterable<Task> taskList;
+    if (startTaskId != null) {
+      Task startTask = vertex.getTask(getTaskId(startTaskId));
+      if (startTask == null) {
+        throw new TezException("Start task not found: " + startTaskId);
+      }
+      taskList = vertex.getTaskSubset(startTask, limit);
+    } else {
+      // need to start from the beginning
+      taskList = vertex.getTaskSubset(limit);
+    }
+
+    List<TaskInformation> taskInformationList = new ArrayList<>(limit);
+    for( Task task : taskList) {
+      taskInformationList.add(getTaskInfoFromTask(task));
+    }
+
+    return taskInformationList;
+  }
+
+  private TaskInformation getTaskInfoFromTask(Task task) throws TezException {
+    TaskInformationBuilder builder = new TaskInformationBuilder();
+    TaskReport report = task.getReport();
+
+    builder.setId(task.getTaskId().toString());
+    builder.setDiagnostics(StringUtils.join(task.getDiagnostics(), TaskImpl.LINE_SEPARATOR));
+    builder.setStartTime(report.getStartTime());
+    builder.setScheduledTime(task.getScheduledTime());
+    builder.setEndTime(task.getFinishTime());
+    builder.setState(convertState(task.getState()));
+    TaskAttempt successfulAttempt = task.getSuccessfulAttempt();
+    if (successfulAttempt != null) {
+      builder.setSuccessfulAttemptId(successfulAttempt.getID().toString());
+    }
+    if (task.getCounters() != null) {
+      builder.setTaskCounters(task.getCounters());
+    }
+
+    return builder;
+  }
+
+  // we should switch the TaskState objects in Task to be consistent
+  private TaskState convertState(org.apache.tez.dag.api.oldrecords.TaskState state) throws TezException {
+    switch (state) {
+      case NEW:
+        return TaskState.NEW;
+      case SCHEDULED:
+        return TaskState.SCHEDULED;
+      case RUNNING:
+        return TaskState.RUNNING;
+      case SUCCEEDED:
+        return TaskState.SUCCEEDED;
+      case FAILED:
+        return TaskState.FAILED;
+      case KILLED:
+        return TaskState.KILLED;
+      default:
+        throw new TezException("Invalid enum value for TaskState: " + state);
+    }
+  }
+
+  private TezVertexID getVertexId(String vertexId) throws TezException {
+    try {
+      return TezVertexID.fromString(vertexId);
+    } catch (IllegalArgumentException e) {
+      throw new TezException("Bad vertexId: " + vertexId);
+    }
+  }
+
+  private TezTaskID getTaskId(String taskId) throws TezException {
+    try {
+      return TezTaskID.fromString(taskId);
+    } catch (IllegalArgumentException e) {
+      throw new TezException("Bad taskId: " + taskId);
+    }
   }
 
   public VertexStatus getVertexStatus(String dagIdStr, String vertexName,

--- a/tez-dag/src/main/java/org/apache/tez/dag/api/client/DAGInformationBuilder.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/api/client/DAGInformationBuilder.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.dag.api.client;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.tez.dag.api.records.DAGProtos.VertexInformationProto;
+import org.apache.tez.dag.api.records.DAGProtos.DAGInformationProto;
+
+public class DAGInformationBuilder extends DAGInformation {
+
+  public DAGInformationBuilder() {
+    super(DAGInformationProto.newBuilder());
+  }
+
+  // name id vertex list
+  public void setName(String name) {
+    getBuilder().setName(name);
+  }
+
+  public void setDagId(String id) {
+    getBuilder().setDagId(id);
+  }
+
+  public void setVertexInformationList(List<VertexInformation> vertexInformationList) {
+    List<VertexInformationProto> vertexProtos = new ArrayList<>(vertexInformationList.size());
+    for(VertexInformation vertexInformation : vertexInformationList) {
+      VertexInformationBuilder vertexBuilder = new VertexInformationBuilder();
+      vertexBuilder.setId(vertexInformation.getId());
+      vertexBuilder.setName(vertexInformation.getName());
+      vertexBuilder.setTaskInformationList(vertexInformation.getTaskInformationList());
+
+      vertexProtos.add(vertexBuilder.getProto());
+    }
+    getBuilder().addAllVertices(vertexProtos);
+  }
+
+  public DAGInformationProto getProto() {
+    return getBuilder().build();
+  }
+
+  private DAGInformationProto.Builder getBuilder() {
+    return (DAGInformationProto.Builder) this.proxy;
+  }
+
+}

--- a/tez-dag/src/main/java/org/apache/tez/dag/api/client/DAGInformationBuilder.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/api/client/DAGInformationBuilder.java
@@ -30,7 +30,6 @@ public class DAGInformationBuilder extends DAGInformation {
     super(DAGInformationProto.newBuilder());
   }
 
-  // name id vertex list
   public void setName(String name) {
     getBuilder().setName(name);
   }

--- a/tez-dag/src/main/java/org/apache/tez/dag/api/client/TaskInformationBuilder.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/api/client/TaskInformationBuilder.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.dag.api.client;
+
+import org.apache.tez.common.counters.TezCounters;
+import org.apache.tez.dag.api.DagTypeConverters;
+import org.apache.tez.dag.api.TezUncheckedException;
+import org.apache.tez.dag.api.records.DAGProtos.TaskStateProto;
+import org.apache.tez.dag.api.records.DAGProtos.TaskInformationProto;
+
+public class TaskInformationBuilder extends TaskInformation {
+
+  public TaskInformationBuilder() {
+    super(TaskInformationProto.newBuilder());
+  }
+
+  public void setState(TaskState taskState) {
+    getBuilder().setState(getProtoState(taskState));
+  }
+
+  public void setId(String id) {
+    getBuilder().setId(id);
+  }
+
+  public void setScheduledTime(Long scheduledTime) {
+    getBuilder().setScheduledTime(scheduledTime);
+  }
+
+  public void setStartTime(Long startTime) {
+    getBuilder().setStartTime(startTime);
+  }
+
+  public void setEndTime(Long endTime) {
+    getBuilder().setEndTime(endTime);
+  }
+
+  public void setSuccessfulAttemptId(String successfulAttemptId) {
+    getBuilder().setSuccessfulAttemptId(successfulAttemptId);
+  }
+
+  public void setTaskCounters(TezCounters counters) {
+    getBuilder().setTaskCounters(
+      DagTypeConverters.convertTezCountersToProto(counters));
+  }
+
+  public TaskInformationProto getProto() {
+    return getBuilder().build();
+  }
+
+  private TaskStateProto getProtoState(TaskState taskState) {
+    switch (taskState) {
+      case NEW:
+        return TaskStateProto.TASK_NEW;
+      case SCHEDULED:
+        return TaskStateProto.TASK_SCHEDULED;
+      case RUNNING:
+        return TaskStateProto.TASK_RUNNING;
+      case SUCCEEDED:
+        return TaskStateProto.TASK_SUCCEEDED;
+      case FAILED:
+        return TaskStateProto.TASK_FAILED;
+      case KILLED:
+        return TaskStateProto.TASK_KILLED;
+      default:
+        throw new TezUncheckedException("Unsupported value for TaskState: " + taskState);
+    }
+  }
+
+  private TaskInformationProto.Builder getBuilder() {
+    return (TaskInformationProto.Builder) this.proxy;
+  }
+}

--- a/tez-dag/src/main/java/org/apache/tez/dag/api/client/TaskInformationBuilder.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/api/client/TaskInformationBuilder.java
@@ -38,6 +38,10 @@ public class TaskInformationBuilder extends TaskInformation {
     getBuilder().setId(id);
   }
 
+  public void setDiagnostics(String diagnostics) {
+    getBuilder().setDiagnostics(diagnostics);
+  }
+
   public void setScheduledTime(Long scheduledTime) {
     getBuilder().setScheduledTime(scheduledTime);
   }

--- a/tez-dag/src/main/java/org/apache/tez/dag/api/client/VertexInformationBuilder.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/api/client/VertexInformationBuilder.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.dag.api.client;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.tez.dag.api.records.DAGProtos.TaskInformationProto;
+import org.apache.tez.dag.api.records.DAGProtos.VertexInformationProto;
+
+public class VertexInformationBuilder extends VertexInformation {
+
+  public VertexInformationBuilder() {
+    super(VertexInformationProto.newBuilder());
+  }
+
+  public void setName(String name) {
+    getBuilder().setName(name);
+  }
+
+  public void setId(String id) {
+    getBuilder().setId(id);
+  }
+
+  public void setTaskInformationList(List<TaskInformation> taskInformationList) {
+    List<TaskInformationProto> taskProtos = new ArrayList<>(taskInformationList.size());
+    for(TaskInformation task : taskInformationList) {
+      TaskInformationBuilder taskBuilder = new TaskInformationBuilder();
+      taskBuilder.setState(task.getState());
+      taskBuilder.setId(task.getID());
+      taskBuilder.setScheduledTime(task.getScheduledTime());
+      taskBuilder.setStartTime(task.getStartTime());
+      taskBuilder.setEndTime(task.getEndTime());
+      taskBuilder.setSuccessfulAttemptId(task.getSuccessfulAttemptID());
+      taskBuilder.setTaskCounters(task.getTaskCounters());
+
+      taskProtos.add(taskBuilder.getProto());
+    }
+    getBuilder().addAllTasks(taskProtos);
+  }
+
+  public VertexInformationProto getProto() {
+    return getBuilder().build();
+  }
+
+  private VertexInformationProto.Builder getBuilder() {
+    return (VertexInformationProto.Builder) this.proxy;
+  }
+}

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/Task.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/Task.java
@@ -73,4 +73,5 @@ public interface Task {
   long getFirstAttemptStartTime();
 
   long getFinishTime();
+  long getScheduledTime();
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/Vertex.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/Vertex.java
@@ -18,6 +18,7 @@
 
 package org.apache.tez.dag.app.dag;
 
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +67,14 @@ import org.apache.tez.runtime.api.impl.OutputSpec;
  */
 public interface Vertex extends Comparable<Vertex> {
 
+  // used to compare Tasks using their TaskIds
+  class TaskIdComparator implements Comparator<Task> {
+    @Override
+    public int compare(Task lhs, Task rhs) {
+      return lhs.getTaskId().compareTo(rhs.getTaskId());
+    }
+  }
+
   TezVertexID getVertexId();
   public VertexPlan getVertexPlan();
 
@@ -88,6 +97,9 @@ public interface Vertex extends Comparable<Vertex> {
 
   int getMaxTaskConcurrency();
   Map<TezTaskID, Task> getTasks();
+  Iterable<Task> getTaskSubset(int limit);
+  Iterable<Task> getTaskSubset(Task startTask, int limit);
+
   Task getTask(TezTaskID taskID);
   Task getTask(int taskIndex);
   List<String> getDiagnostics();

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/TaskImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/TaskImpl.java
@@ -112,8 +112,7 @@ public class TaskImpl implements Task, EventHandler<TaskEvent> {
 
   private static final Logger LOG = LoggerFactory.getLogger(TaskImpl.class);
 
-  private static final String LINE_SEPARATOR = System
-    .getProperty("line.separator");
+  public static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
   protected final Configuration conf;
   protected final TaskCommunicatorManagerInterface taskCommunicatorManagerInterface;
@@ -557,6 +556,16 @@ public class TaskImpl implements Task, EventHandler<TaskEvent> {
     readLock.lock();
     try {
       return finishTime;
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  @Override
+  public long getScheduledTime() {
+    readLock.lock();
+    try {
+      return scheduledTime;
     } finally {
       readLock.unlock();
     }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/VertexImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/VertexImpl.java
@@ -34,7 +34,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NavigableSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -189,6 +191,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multiset;
@@ -230,6 +233,9 @@ public class VertexImpl implements org.apache.tez.dag.app.dag.Vertex, EventHandl
   private boolean lazyTasksCopyNeeded = false;
   // must be a linked map for ordering
   volatile LinkedHashMap<TezTaskID, Task> tasks = new LinkedHashMap<TezTaskID, Task>();
+  // this is used to implement pagination support - iterating tasks from a given task
+  volatile NavigableSet<Task> navigableTaskSet = new TreeSet<Task>(new TaskIdComparator());
+
   private Object fullCountersLock = new Object();
   private TezCounters fullCounters = null;
   private TezCounters cachedCounters = null;
@@ -1446,6 +1452,17 @@ public class VertexImpl implements org.apache.tez.dag.app.dag.Vertex, EventHandl
   }
 
   @Override
+  public Iterable<Task> getTaskSubset(int limit) {
+    return Iterables.limit(navigableTaskSet, limit);
+  }
+
+  @Override
+  public Iterable<Task> getTaskSubset(Task startTask, int limit) {
+    NavigableSet<Task> tailSet = navigableTaskSet.tailSet(startTask, false);
+    return Iterables.limit(tailSet, limit);
+  }
+
+  @Override
   public VertexState getState() {
     readLock.lock();
     try {
@@ -1939,6 +1956,7 @@ public class VertexImpl implements org.apache.tez.dag.app.dag.Vertex, EventHandl
         lazyTasksCopyNeeded = false;
       }
     }
+    navigableTaskSet.add(task);
     tasks.put(task.getTaskId(), task);
     // TODO Metrics
     //metrics.waitingTask(task);
@@ -2458,6 +2476,7 @@ public class VertexImpl implements org.apache.tez.dag.app.dag.Vertex, EventHandl
         continue;
       }
       LOG.info("Removing task: " + entry.getKey());
+      navigableTaskSet.remove(entry.getValue());
       iter.remove();
       this.numTasks--;
     }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/VertexImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/VertexImpl.java
@@ -1458,7 +1458,7 @@ public class VertexImpl implements org.apache.tez.dag.app.dag.Vertex, EventHandl
 
   @Override
   public Iterable<Task> getTaskSubset(Task startTask, int limit) {
-    NavigableSet<Task> tailSet = navigableTaskSet.tailSet(startTask, false);
+    NavigableSet<Task> tailSet = navigableTaskSet.tailSet(startTask, true);
     return Iterables.limit(tailSet, limit);
   }
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClientAMProtocolBlockingPBServerImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClientAMProtocolBlockingPBServerImpl.java
@@ -22,8 +22,11 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
+
+import com.google.common.collect.Lists;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertArrayEquals;
@@ -46,6 +49,18 @@ import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.UserPayload;
 import org.apache.tez.dag.api.Vertex;
 import org.apache.tez.dag.api.client.DAGClientHandler;
+import org.apache.tez.dag.api.client.DAGInformationBuilder;
+import org.apache.tez.dag.api.client.TaskInformation;
+import org.apache.tez.dag.api.client.TaskInformationBuilder;
+import org.apache.tez.dag.api.client.TaskState;
+import org.apache.tez.dag.api.client.VertexInformation;
+import org.apache.tez.dag.api.client.VertexInformationBuilder;
+import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetDAGInformationRequestProto;
+import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetDAGInformationResponseProto;
+import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetTaskInformationRequestProto;
+import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetTaskInformationResponseProto;
+import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetTaskInformationListRequestProto;
+import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetTaskInformationListResponseProto;
 import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.SubmitDAGRequestProto;
 import org.apache.tez.dag.api.records.DAGProtos.DAGPlan;
 import org.junit.Before;
@@ -131,5 +146,150 @@ public class TestDAGClientAMProtocolBlockingPBServerImpl {
     assertEquals(lrURL.getHost(), host);
     assertEquals(lrURL.getPort(), port);
     assertEquals(lrURL.getFile(), path);
+  }
+
+  @Test(timeout = 5000)
+  public void testGetDAGInformation() throws Exception {
+    TezConfiguration conf = new TezConfiguration();
+
+    String dagId = "dag_9999_0001_1";
+
+    GetDAGInformationRequestProto.Builder requestBuilder =
+      GetDAGInformationRequestProto.newBuilder().setDagId(dagId);
+
+    VertexInformationBuilder vertexInformationBuilder = createTestVertex("vertex_100_0001_1_02", "test vertex");
+    DAGInformationBuilder testDAGInfo = createTestDAG(dagId, "my test dag", vertexInformationBuilder);
+    GetDAGInformationResponseProto response =
+      GetDAGInformationResponseProto.newBuilder()
+        .setDagInformation(testDAGInfo.getProto())
+        .build();
+
+    DAGClientHandler dagClientHandler = mock(DAGClientHandler.class);
+    ACLManager aclManager = mock(ACLManager.class);
+    DAGClientAMProtocolBlockingPBServerImpl serverImpl = spy(new DAGClientAMProtocolBlockingPBServerImpl(
+      dagClientHandler, FileSystem.get(conf)));
+    when(dagClientHandler.getACLManager(dagId)).thenReturn(aclManager);
+    when(dagClientHandler.getDAGInformation(dagId)).thenReturn(testDAGInfo);
+    when(aclManager.checkDAGViewAccess((UserGroupInformation) any())).thenReturn(true);
+
+    GetDAGInformationResponseProto actualResponse = serverImpl.getDAGInformation(null, requestBuilder.build());
+
+    assertEquals(response, actualResponse);
+  }
+
+  @Test(timeout = 5000)
+  public void testGetTaskInformation() throws Exception {
+    TezConfiguration conf = new TezConfiguration();
+
+    String dagId = "dag_9999_0001_1";
+    String vertexId = "vertex_100_0001_1_02";
+    String taskId = "task_100_0001_1_02_000000";
+
+    GetTaskInformationRequestProto.Builder requestBuilder =
+      GetTaskInformationRequestProto.newBuilder()
+      .setDagId(dagId)
+      .setVertexId(vertexId)
+      .setTaskId(taskId);
+
+    TaskInformationBuilder task = createTestTask(taskId, "test diagnostics", TaskState.RUNNING, 123, 456);
+
+    GetTaskInformationResponseProto response =
+      GetTaskInformationResponseProto.newBuilder()
+        .setTaskInformation(task.getProto())
+        .build();
+
+    DAGClientHandler dagClientHandler = mock(DAGClientHandler.class);
+    ACLManager aclManager = mock(ACLManager.class);
+    DAGClientAMProtocolBlockingPBServerImpl serverImpl = spy(new DAGClientAMProtocolBlockingPBServerImpl(
+      dagClientHandler, FileSystem.get(conf)));
+    when(dagClientHandler.getACLManager(dagId)).thenReturn(aclManager);
+    when(dagClientHandler.getTaskInformation(dagId, vertexId, taskId)).thenReturn(task);
+    when(aclManager.checkDAGViewAccess((UserGroupInformation) any())).thenReturn(true);
+
+    GetTaskInformationResponseProto actualResponse = serverImpl.getTaskInformation(null, requestBuilder.build());
+
+    assertEquals(response, actualResponse);
+  }
+
+  @Test(timeout = 5000)
+  public void testGetTaskInformationList() throws Exception {
+    TezConfiguration conf = new TezConfiguration();
+
+    String dagId = "dag_9999_0001_1";
+    String vertexId = "vertex_100_0001_1_02";
+    String taskId1 = "task_100_0001_1_01_000000";
+    String taskId2 = "task_100_0001_1_02_000000";
+    int limit = 1;
+
+    GetTaskInformationListRequestProto.Builder requestBuilder =
+      GetTaskInformationListRequestProto.newBuilder()
+        .setDagId(dagId)
+        .setVertexId(vertexId)
+        .setLimit(limit);
+
+    TaskInformationBuilder task1 = createTestTask(taskId1, "test diagnostics", TaskState.RUNNING, 123, 456);
+    TaskInformationBuilder task2 = createTestTask(taskId2, "test diagnostics", TaskState.RUNNING, 123, 456);
+
+    GetTaskInformationListResponseProto response =
+      GetTaskInformationListResponseProto.newBuilder()
+        .addTaskInformation(task1.getProto())
+        .build();
+
+    DAGClientHandler dagClientHandler = mock(DAGClientHandler.class);
+    ACLManager aclManager = mock(ACLManager.class);
+    DAGClientAMProtocolBlockingPBServerImpl serverImpl = spy(new DAGClientAMProtocolBlockingPBServerImpl(
+      dagClientHandler, FileSystem.get(conf)));
+    when(dagClientHandler.getACLManager(dagId)).thenReturn(aclManager);
+    when(dagClientHandler.getTaskInformationList(dagId, vertexId, null, limit)).thenReturn(Lists.<TaskInformation>newArrayList(task1));
+    when(aclManager.checkDAGViewAccess((UserGroupInformation) any())).thenReturn(true);
+
+    // first try call with no startTaskId
+    GetTaskInformationListResponseProto actualResponse = serverImpl.getTaskInformationList(null, requestBuilder.build());
+    assertEquals(response, actualResponse);
+
+    // now follow up with a Task id call
+    requestBuilder.clear();
+    String startTaskId = actualResponse.getTaskInformation(0).getId();
+    requestBuilder.setDagId(dagId).setVertexId(vertexId).setStartTaskId(startTaskId).setLimit(limit);
+    response = GetTaskInformationListResponseProto.newBuilder()
+        .addTaskInformation(task2.getProto())
+        .build();
+    when(dagClientHandler.getTaskInformationList(dagId, vertexId, startTaskId, limit)).thenReturn(Lists.<TaskInformation>newArrayList(task2));
+
+    actualResponse = serverImpl.getTaskInformationList(null, requestBuilder.build());
+    assertEquals(response, actualResponse);
+  }
+
+  private DAGInformationBuilder createTestDAG(String dagId, String dagName, VertexInformation ... vertices) {
+    DAGInformationBuilder dagInformationBuilder = new DAGInformationBuilder();
+    List<VertexInformation> vertexInformationList = Lists.newArrayList(vertices);
+    dagInformationBuilder.setDagId(dagId);
+    dagInformationBuilder.setName(dagName);
+    dagInformationBuilder.setVertexInformationList(vertexInformationList);
+
+    return dagInformationBuilder;
+  }
+
+  private VertexInformationBuilder createTestVertex(String vertexId, String vertexName, TaskInformation ... tasks) {
+    VertexInformationBuilder vertexInformationBuilder = new VertexInformationBuilder();
+    vertexInformationBuilder.setId(vertexId);
+    vertexInformationBuilder.setName(vertexName);
+
+    if (tasks != null && tasks.length > 0) {
+      vertexInformationBuilder.setTaskInformationList(Lists.newArrayList(tasks));
+    }
+    return vertexInformationBuilder;
+  }
+
+  private TaskInformationBuilder createTestTask(String taskId, String diagnostics, TaskState state, long startTime, long endTime) {
+    TaskInformationBuilder taskInformationBuilder = new TaskInformationBuilder();
+    taskInformationBuilder.setId(taskId);
+    taskInformationBuilder.setDiagnostics(diagnostics);
+    taskInformationBuilder.setState(state);
+    taskInformationBuilder.setStartTime(startTime);
+    taskInformationBuilder.setScheduledTime(startTime);
+    taskInformationBuilder.setEndTime(endTime);
+
+    return taskInformationBuilder;
   }
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexImpl.java
@@ -6583,14 +6583,14 @@ public class TestVertexImpl {
 
     // check requesting for more tasks than left, we should return only number left
     taskIterable = vB.getTaskSubset(task1, 10);
-    Assert.assertEquals("Incorrect number of tasks returned", 1, Iterables.size(taskIterable));
-    Task task2 = taskIterable.iterator().next();
+    Assert.assertEquals("Incorrect number of tasks returned", 2, Iterables.size(taskIterable));
+    Task task2 = Iterables.get(taskIterable, 1);
 
     Assert.assertNotEquals(task1.getTaskId(), task2.getTaskId());
 
-    //check that we don't get anything if we ask again from task2
+    //check that we get only 1 if we ask again from task2
     taskIterable = vB.getTaskSubset(task2, 1);
-    Assert.assertEquals("Incorrect number of tasks returned", 0, Iterables.size(taskIterable));
+    Assert.assertEquals("Incorrect number of tasks returned", 1, Iterables.size(taskIterable));
 
     // try requesting for tasks again from the start
     taskIterable = vB.getTaskSubset(10);

--- a/tez-mapreduce/src/main/java/org/apache/tez/dag/api/client/MRDAGClient.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/dag/api/client/MRDAGClient.java
@@ -23,6 +23,7 @@ package org.apache.tez.dag.api.client;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.hadoop.classification.InterfaceAudience;
@@ -90,5 +91,20 @@ public class MRDAGClient extends DAGClient {
   public DAGStatus getDAGStatus(@Nullable Set<StatusGetOpts> statusOptions,
       long timeout) throws IOException, TezException {
     return getDAGStatus(statusOptions);
+  }
+
+  @Override
+  public DAGInformation getDAGInformation() throws IOException, TezException {
+    return realClient.getDAGInformation();
+  }
+
+  @Override
+  public TaskInformation getTaskInformation(String vertexID, String taskID) throws IOException, TezException {
+    return realClient.getTaskInformation(vertexID, taskID);
+  }
+
+  @Override
+  public List<TaskInformation> getTaskInformation(String vertexID, @Nullable String startTaskID, int limit) throws IOException, TezException {
+    return realClient.getTaskInformation(vertexID, startTaskID, limit);
   }
 }


### PR DESCRIPTION
Adding a few APIs to Tez to help Cascading break its dependency on an internal implementation and still get some of the data it needs. 
Added APIs:
```
DAGInformation getDAGInformation()
TaskInformation getTaskInformation(String vertexID, String taskID)
List<TaskInformation> getTaskInformation(String vertexID, @Nullable String startTaskID, int limit)
```

Putting this PR out as a WIP to get some feedback on the APIs and the data they return. 
I'm still working through cleaning up the code, fixing some todos and testing more. 