### PR TITLE
[TEZ-3453] Correct the downloaded ATS dag data location for analyzer

### DIFF
--- a/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/TezAnalyzerBase.java
+++ b/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/plugins/TezAnalyzerBase.java
@@ -160,7 +160,6 @@ public abstract class TezAnalyzerBase extends Configured implements Tool, Analyz
       //Parse ATS data and verify results
       //Parse downloaded contents
       file = new File(outputDir
-          + Path.SEPARATOR + dagId
           + Path.SEPARATOR + dagId + ".zip");
     }
     


### PR DESCRIPTION
 hadoop jar /usr/hdp/current/tez-client/tez-job-analyzer-*.jar CriticalPath --dagId=dag_1475171170456_0002_1  --outputDir=tmp/
 fails with 

INFO history.ATSImportTool: Using baseURL=http://headnodehost:8188/ws/v1/timeline, dagId=dag_1475171170456_0002_1, batchSize=100, downloadDir=tmp
java.lang.IllegalArgumentException: Zipfile tmp/dag_1475171170456_0002_1/dag_1475171170456_0002_1.zip does not exist
        at com.google.common.base.Preconditions.checkArgument(Preconditions.java:88)
        at org.apache.tez.history.parser.ATSFileParser.<init>(ATSFileParser.java:65)
        at org.apache.tez.analyzer.plugins.TezAnalyzerBase.run(TezAnalyzerBase.java:169)
        at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:76)
        at org.apache.tez.analyzer.plugins.CriticalPathAnalyzer.main(CriticalPathAnalyzer.java:653)


The code is incorrectly expecting it to be in subfolder(dag_1475171170456_0002_1/dag_1475171170456_0002_1.zip). Moving the downloaded data location to the subfolder fixes the issue. This PR corrects the expected path.