### PR TITLE
[WIP][TEZ-3904] An API to update tokens for Tez AM and the DAG

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClient.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClient.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
+import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.tez.dag.api.TezException;
 
@@ -140,4 +141,10 @@ public abstract class DAGClient implements Closeable {
   public abstract DAGStatus waitForCompletionWithStatusUpdates(@Nullable Set<StatusGetOpts> statusGetOpts)
       throws IOException, TezException, InterruptedException;
 
+  /**
+   * Update the credentials of a running DAG. This is usually done for
+   * long running DAGs which tokens would expire.
+   * @param credentials
+   */
+  public abstract void updateDAGCredentials(Credentials credentials) throws IOException, TezException;
 }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientImpl.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientImpl.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
+import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -334,6 +335,15 @@ public class DAGClientImpl extends DAGClient {
       realClient.tryKillDAG();
     } else {
       LOG.info("TryKill for app: " + appId + " dag:" + dagId + " dag already completed.");
+    }
+  }
+
+  @Override
+  public void updateDAGCredentials(Credentials credentials) throws IOException, TezException {
+    if (!dagCompleted) {
+      realClient.updateDAGCredentials(credentials);
+    } else {
+      LOG.info("Can't update credentials for app: " + appId + " dag:" + dagId + ", dag already completed.");
     }
   }
 

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientInternal.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientInternal.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
+import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException;
 import org.apache.tez.dag.api.TezException;
@@ -125,4 +126,11 @@ public abstract class DAGClientInternal implements Closeable {
    */
   public abstract DAGStatus waitForCompletionWithStatusUpdates(@Nullable Set<StatusGetOpts> statusGetOpts)
       throws IOException, TezException, InterruptedException;
+
+  /**
+   * Update the credentials of a running DAG. This is usually done for
+   * long running DAGs which tokens would expire.
+   * @param credentials
+   */
+  public abstract void updateDAGCredentials(Credentials credentials) throws IOException, TezException;
 }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientTimelineImpl.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientTimelineImpl.java
@@ -195,6 +195,13 @@ public class DAGClientTimelineImpl extends DAGClientInternal {
     throw new TezException("tryKillDAG is unsupported for DAGClientTimelineImpl");
   }
 
+  // TODO implement this
+  @Override
+  public void updateDAGCredentials(org.apache.hadoop.security.Credentials credentials)
+      throws IOException, TezException {
+    throw new TezException("updateDAGCredentials is unsupported for DAGClientTimelineImpl");
+  }
+
   @Override
   public DAGStatus waitForCompletion() throws IOException, TezException, InterruptedException {
     return getDAGStatus(null);

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/events/UpdateCredentialsEvent.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/events/UpdateCredentialsEvent.java
@@ -16,21 +16,24 @@
  * limitations under the License.
  */
 
-package org.apache.tez.runtime.api.impl;
 
-public enum EventType {
-  TASK_ATTEMPT_COMPLETED_EVENT,
-  TASK_ATTEMPT_FAILED_EVENT,
-  TASK_ATTEMPT_KILLED_EVENT,
-  DATA_MOVEMENT_EVENT,
-  INPUT_READ_ERROR_EVENT,
-  INPUT_FAILED_EVENT,
-  TASK_STATUS_UPDATE_EVENT,
-  VERTEX_MANAGER_EVENT,
-  ROOT_INPUT_DATA_INFORMATION_EVENT,
-  COMPOSITE_DATA_MOVEMENT_EVENT,
-  ROOT_INPUT_INITIALIZER_EVENT,
-  COMPOSITE_ROUTED_DATA_MOVEMENT_EVENT,
-  CUSTOM_PROCESSOR_EVENT,
-  UPDATE_CREDENTIALS_EVENT,
+package org.apache.tez.runtime.api.events;
+
+import org.apache.hadoop.security.Credentials;
+import org.apache.tez.runtime.api.Event;
+
+public class UpdateCredentialsEvent extends Event {
+  private final Credentials credentials;
+
+  private UpdateCredentialsEvent(Credentials credentials) {
+    this.credentials = credentials;
+  }
+
+  public static UpdateCredentialsEvent create(Credentials credentials) {
+    return new UpdateCredentialsEvent(credentials);
+  }
+
+  public Credentials getCredentials() {
+    return credentials;
+  }
 }

--- a/tez-api/src/main/proto/DAGClientAMProtocol.proto
+++ b/tez-api/src/main/proto/DAGClientAMProtocol.proto
@@ -90,6 +90,24 @@ message GetAMStatusResponseProto {
   required TezAppMasterStatusProto status = 1;
 }
 
+message UpdateCredentialsAMRequestProto {
+  required bytes credentials_binary = 1;
+}
+
+message UpdateCredentialsSessionRequestProto {
+  required bytes credentials_binary = 1;
+}
+
+message UpdateCredentialsDAGRequestProto {
+  required string dagID = 1;
+  required bytes credentials_binary = 2;
+}
+
+message UpdateCredentialsResponseProto {
+  // Nothing yet
+}
+
+
 service DAGClientAMProtocol {
   rpc getAllDAGs (GetAllDAGsRequestProto) returns (GetAllDAGsResponseProto);
   rpc getDAGStatus (GetDAGStatusRequestProto) returns (GetDAGStatusResponseProto);
@@ -98,4 +116,7 @@ service DAGClientAMProtocol {
   rpc submitDAG (SubmitDAGRequestProto) returns (SubmitDAGResponseProto);
   rpc shutdownSession (ShutdownSessionRequestProto) returns (ShutdownSessionResponseProto);
   rpc getAMStatus (GetAMStatusRequestProto) returns (GetAMStatusResponseProto);
+  rpc updateAMCredentials(UpdateCredentialsAMRequestProto) returns (UpdateCredentialsResponseProto);
+  rpc updateSessionCredentials(UpdateCredentialsSessionRequestProto) returns (UpdateCredentialsResponseProto);
+  rpc updateDAGCredentials(UpdateCredentialsDAGRequestProto) returns (UpdateCredentialsResponseProto);
 }

--- a/tez-api/src/main/proto/Events.proto
+++ b/tez-api/src/main/proto/Events.proto
@@ -74,3 +74,7 @@ message CustomProcessorEventProto {
   optional bytes user_payload = 1;
   required int32 version = 2;
 }
+
+message UpdateCredentialsEventProto {
+  required bytes credentials_binary = 1;
+}

--- a/tez-dag/src/main/java/org/apache/tez/dag/api/client/DAGClientHandler.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/api/client/DAGClientHandler.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.hadoop.security.Credentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.ipc.Server;
@@ -141,6 +142,22 @@ public class DAGClientHandler {
   public synchronized String submitDAG(DAGPlan dagPlan,
       Map<String, LocalResource> additionalAmResources) throws TezException {
     return dagAppMaster.submitDAGToAppMaster(dagPlan, additionalAmResources);
+  }
+
+  public void updateAMCredentials(Credentials credentials) throws TezException {
+    LOG.info("Updating AM credentials");
+    dagAppMaster.updateAMCredentials(credentials);
+  }
+
+  public void updateSessionCredentials(Credentials credentials) throws TezException {
+    LOG.info("Updating session credentials");
+    dagAppMaster.updateSessionCredentials(credentials);
+  }
+
+  public void updateDAGCredentials(String dagIdStr, Credentials credentials) throws TezException {
+    LOG.info("Updating credentials from DAG with id: " + dagIdStr);
+    DAG dag = getDAG(dagIdStr);
+    dagAppMaster.updateDAGCredentials(credentials, dag);
   }
 
   // Only to be invoked by the DAGClient.

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/event/TaskEventType.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/event/TaskEventType.java
@@ -25,6 +25,7 @@ public enum TaskEventType {
 
   //Producer:Client, Job
   T_TERMINATE,
+  T_UPDATE_CREDENTIALS,
   
   //Producer:Job
   T_SCHEDULE,

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/event/TaskEventUpdateCredentials.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/event/TaskEventUpdateCredentials.java
@@ -16,21 +16,26 @@
  * limitations under the License.
  */
 
-package org.apache.tez.runtime.api.impl;
+package org.apache.tez.dag.app.dag.event;
 
-public enum EventType {
-  TASK_ATTEMPT_COMPLETED_EVENT,
-  TASK_ATTEMPT_FAILED_EVENT,
-  TASK_ATTEMPT_KILLED_EVENT,
-  DATA_MOVEMENT_EVENT,
-  INPUT_READ_ERROR_EVENT,
-  INPUT_FAILED_EVENT,
-  TASK_STATUS_UPDATE_EVENT,
-  VERTEX_MANAGER_EVENT,
-  ROOT_INPUT_DATA_INFORMATION_EVENT,
-  COMPOSITE_DATA_MOVEMENT_EVENT,
-  ROOT_INPUT_INITIALIZER_EVENT,
-  COMPOSITE_ROUTED_DATA_MOVEMENT_EVENT,
-  CUSTOM_PROCESSOR_EVENT,
-  UPDATE_CREDENTIALS_EVENT,
+import org.apache.hadoop.security.Credentials;
+import org.apache.tez.dag.records.TezTaskID;
+
+public class TaskEventUpdateCredentials extends TaskEvent {
+  private final Credentials credentials;
+  private final String vertexName;
+
+  public TaskEventUpdateCredentials(TezTaskID taskId, Credentials credentials, String vertexName) {
+    super(taskId, TaskEventType.T_UPDATE_CREDENTIALS);
+    this.credentials = credentials;
+    this.vertexName = vertexName;
+  }
+
+  public Credentials getCredentials() {
+    return credentials;
+  }
+
+  public String getVertexName() {
+    return vertexName;
+  }
 }

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/service/impl/ContainerRunnerImpl.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/service/impl/ContainerRunnerImpl.java
@@ -461,7 +461,7 @@ public class ContainerRunnerImpl extends AbstractService implements ContainerRun
           request.getAppAttemptNumber(),
           serviceConsumerMetadata, envMap, startedInputsMap, taskReporter, executor, objectRegistry,
           pid,
-          executionContext, memoryAvailable, false, new DefaultHadoopShim(), sharedExecutor);
+          executionContext, memoryAvailable, false, new DefaultHadoopShim(), sharedExecutor, null);
 
       boolean shouldDie;
       try {

--- a/tez-mapreduce/src/main/java/org/apache/tez/dag/api/client/MRDAGClient.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/dag/api/client/MRDAGClient.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Set;
 
 import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.tez.dag.api.TezException;
 
@@ -105,5 +106,9 @@ public class MRDAGClient extends DAGClient {
   public DAGStatus getDAGStatus(@Nullable Set<StatusGetOpts> statusOptions,
       long timeout) throws IOException, TezException {
     return getDAGStatus(statusOptions);
+  }
+
+  public void updateDAGCredentials(Credentials credentials) throws IOException, TezException {
+    realClient.updateDAGCredentials(credentials);
   }
 }

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMROutput.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMROutput.java
@@ -265,7 +265,7 @@ public class TestMROutput {
         null,
         new HashMap<String, String>(),
         HashMultimap.<String, String>create(), null, "", new ExecutionContextImpl("localhost"),
-        Runtime.getRuntime().maxMemory(), true, new DefaultHadoopShim(), sharedExecutor);
+        Runtime.getRuntime().maxMemory(), true, new DefaultHadoopShim(), sharedExecutor, null);
   }
 
   public static class TestOutputCommitter extends OutputCommitter {

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/processor/MapUtils.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/processor/MapUtils.java
@@ -238,7 +238,7 @@ public class MapUtils {
         serviceConsumerMetadata,
         envMap,
         HashMultimap.<String, String>create(), null, "", new ExecutionContextImpl("localhost"),
-        Runtime.getRuntime().maxMemory(), true, new DefaultHadoopShim(), sharedExecutor);
+        Runtime.getRuntime().maxMemory(), true, new DefaultHadoopShim(), sharedExecutor, null);
     return task;
   }
 }

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/processor/reduce/TestReduceProcessor.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/processor/reduce/TestReduceProcessor.java
@@ -231,7 +231,7 @@ public class TestReduceProcessor {
         serviceConsumerMetadata,
         serviceProviderEnvMap,
         HashMultimap.<String, String>create(), null, "", new ExecutionContextImpl("localhost"),
-        Runtime.getRuntime().maxMemory(), true, new DefaultHadoopShim(), sharedExecutor);
+        Runtime.getRuntime().maxMemory(), true, new DefaultHadoopShim(), sharedExecutor, null);
 
     List<Event> destEvents = new LinkedList<Event>();
     destEvents.add(dme);

--- a/tez-runtime-internals/src/main/java/org/apache/tez/SystemEventHandler.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/SystemEventHandler.java
@@ -1,0 +1,43 @@
+package org.apache.tez;
+
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+import org.apache.tez.runtime.LogicalIOProcessorRuntimeTask;
+import org.apache.tez.runtime.api.events.UpdateCredentialsEvent;
+import org.apache.tez.runtime.api.impl.TezEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SystemEventHandler {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(LogicalIOProcessorRuntimeTask.class);
+
+  private final UserGroupInformation umbilicalUGI;
+  private UserGroupInformation taskUGI;
+  private final boolean ownUmbilical;
+
+  public SystemEventHandler(UserGroupInformation umbilicalUGI, boolean ownUmbilical,
+      UserGroupInformation taskUGI) {
+    this.umbilicalUGI = umbilicalUGI;
+    this.taskUGI = taskUGI;
+    this.ownUmbilical = ownUmbilical;
+  }
+
+  public void handleEvents(TezEvent event) {
+    if (event.getEvent() instanceof UpdateCredentialsEvent) {
+      taskUGI.addCredentials(((UpdateCredentialsEvent)event.getEvent()).getCredentials());
+
+      LOG.info("Task credentials updated");
+      if (ownUmbilical) {
+        umbilicalUGI.addCredentials(((UpdateCredentialsEvent)event.getEvent()).getCredentials());
+      }
+    } else {
+      LOG.warn("Unrecognized system event with class " + event.getClass().getName());
+    }
+  }
+
+  public void setTaskUGI(UserGroupInformation taskUGI) {
+    this.taskUGI = taskUGI;
+  }
+}

--- a/tez-runtime-internals/src/main/java/org/apache/tez/runtime/LogicalIOProcessorRuntimeTask.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/runtime/LogicalIOProcessorRuntimeTask.java
@@ -45,6 +45,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.tez.SystemEventHandler;
 import org.apache.tez.hadoop.shim.HadoopShim;
 import org.apache.tez.runtime.api.TaskFailureType;
 import org.apache.tez.runtime.api.TaskContext;
@@ -160,6 +161,7 @@ public class LogicalIOProcessorRuntimeTask extends RuntimeTask {
   private final boolean initializeProcessorFirst;
   private final boolean initializeProcessorIOSerially;
   private final TezExecutors sharedExecutor;
+  private final SystemEventHandler systemEventHandler;
 
   public LogicalIOProcessorRuntimeTask(TaskSpec taskSpec, int appAttemptNumber,
       Configuration tezConf, String[] localDirs, TezUmbilical tezUmbilical,
@@ -167,7 +169,7 @@ public class LogicalIOProcessorRuntimeTask extends RuntimeTask {
       Multimap<String, String> startedInputsMap, ObjectRegistry objectRegistry,
       String pid, ExecutionContext ExecutionContext, long memAvailable,
       boolean updateSysCounters, HadoopShim hadoopShim,
-      TezExecutors sharedExecutor) throws IOException {
+      TezExecutors sharedExecutor, SystemEventHandler systemEventHandler) throws IOException {
     // Note: If adding any fields here, make sure they're cleaned up in the cleanupContext method.
     // TODO Remove jobToken from here post TEZ-421
     super(taskSpec, tezConf, tezUmbilical, pid, updateSysCounters);
@@ -221,6 +223,7 @@ public class LogicalIOProcessorRuntimeTask extends RuntimeTask {
     this.maxEventBacklog = tezConf.getInt(TezConfiguration.TEZ_TASK_MAX_EVENT_BACKLOG,
         TezConfiguration.TEZ_TASK_MAX_EVENT_BACKLOG_DEFAULT);
     this.sharedExecutor = sharedExecutor;
+    this.systemEventHandler = systemEventHandler;
   }
 
   /**
@@ -736,7 +739,11 @@ public class LogicalIOProcessorRuntimeTask extends RuntimeTask {
         processor.handleEvents(Collections.singletonList(e.getEvent()));
         break;
       case SYSTEM:
-        LOG.warn("Trying to send a System event in a Task: " + e);
+        if (systemEventHandler != null) {
+          systemEventHandler.handleEvents(e);
+        } else {
+          LOG.warn("Received system event but the systemEventHandler is not set");
+        }
         break;
       }
     } catch (Throwable t) {

--- a/tez-runtime-internals/src/main/java/org/apache/tez/runtime/api/impl/TezEvent.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/runtime/api/impl/TezEvent.java
@@ -29,18 +29,11 @@ import org.apache.tez.common.ProtoConverters;
 import org.apache.tez.common.TezConverterUtils;
 import org.apache.tez.dag.api.TezUncheckedException;
 import org.apache.tez.runtime.api.Event;
+
 import org.apache.tez.runtime.api.events.CompositeDataMovementEvent;
 import org.apache.tez.runtime.api.events.CustomProcessorEvent;
 import org.apache.tez.runtime.api.events.DataMovementEvent;
 import org.apache.tez.runtime.api.events.CompositeRoutedDataMovementEvent;
-import org.apache.tez.runtime.api.events.EventProtos;
-import org.apache.tez.runtime.api.events.EventProtos.CompositeEventProto;
-import org.apache.tez.runtime.api.events.EventProtos.DataMovementEventProto;
-import org.apache.tez.runtime.api.events.EventProtos.CompositeRoutedDataMovementEventProto;
-import org.apache.tez.runtime.api.events.EventProtos.InputFailedEventProto;
-import org.apache.tez.runtime.api.events.EventProtos.InputReadErrorEventProto;
-import org.apache.tez.runtime.api.events.EventProtos.RootInputDataInformationEventProto;
-import org.apache.tez.runtime.api.events.EventProtos.VertexManagerEventProto;
 import org.apache.tez.runtime.api.events.InputDataInformationEvent;
 import org.apache.tez.runtime.api.events.InputFailedEvent;
 import org.apache.tez.runtime.api.events.InputInitializerEvent;
@@ -49,7 +42,17 @@ import org.apache.tez.runtime.api.events.TaskAttemptCompletedEvent;
 import org.apache.tez.runtime.api.events.TaskAttemptFailedEvent;
 import org.apache.tez.runtime.api.events.TaskAttemptKilledEvent;
 import org.apache.tez.runtime.api.events.TaskStatusUpdateEvent;
+import org.apache.tez.runtime.api.events.UpdateCredentialsEvent;
 import org.apache.tez.runtime.api.events.VertexManagerEvent;
+
+import org.apache.tez.runtime.api.events.EventProtos;
+import org.apache.tez.runtime.api.events.EventProtos.CompositeEventProto;
+import org.apache.tez.runtime.api.events.EventProtos.DataMovementEventProto;
+import org.apache.tez.runtime.api.events.EventProtos.CompositeRoutedDataMovementEventProto;
+import org.apache.tez.runtime.api.events.EventProtos.InputFailedEventProto;
+import org.apache.tez.runtime.api.events.EventProtos.InputReadErrorEventProto;
+import org.apache.tez.runtime.api.events.EventProtos.RootInputDataInformationEventProto;
+import org.apache.tez.runtime.api.events.EventProtos.VertexManagerEventProto;
 import org.apache.tez.runtime.internals.api.events.SystemEventProtos.TaskAttemptCompletedEventProto;
 import org.apache.tez.runtime.internals.api.events.SystemEventProtos.TaskAttemptFailedEventProto;
 import org.apache.tez.runtime.internals.api.events.SystemEventProtos.TaskAttemptKilledEventProto;
@@ -109,6 +112,8 @@ public class TezEvent implements Writable {
       eventType = EventType.ROOT_INPUT_DATA_INFORMATION_EVENT;
     } else if (event instanceof InputInitializerEvent) {
       eventType = EventType.ROOT_INPUT_INITIALIZER_EVENT;
+    } else if (event instanceof UpdateCredentialsEvent) {
+      eventType = EventType.UPDATE_CREDENTIALS_EVENT;
     } else {
       throw new TezUncheckedException("Unknown event, event="
           + event.getClass().getName());
@@ -223,6 +228,9 @@ public class TezEvent implements Writable {
         message = ProtoConverters
             .convertRootInputInitializerEventToProto((InputInitializerEvent) event);
         break;
+      case UPDATE_CREDENTIALS_EVENT:
+        message = ProtoConverters.convertUpdateCredentialsEventToProto((UpdateCredentialsEvent) event);
+        break;
       default:
         throw new TezUncheckedException("Unknown TezEvent"
            + ", type=" + eventType);
@@ -325,6 +333,10 @@ public class TezEvent implements Writable {
       case ROOT_INPUT_INITIALIZER_EVENT:
         EventProtos.RootInputInitializerEventProto riiProto = EventProtos.RootInputInitializerEventProto.parseFrom(input);
         event = ProtoConverters.convertRootInputInitializerEventFromProto(riiProto);
+        break;
+      case UPDATE_CREDENTIALS_EVENT:
+        EventProtos.UpdateCredentialsEventProto ucProto = EventProtos.UpdateCredentialsEventProto.parseFrom(input);
+        event = ProtoConverters.convertUpdateCredentialsEventFromProto(ucProto);
         break;
       default:
         // RootInputUpdatePayload event not wrapped in a TezEvent.

--- a/tez-runtime-internals/src/main/java/org/apache/tez/runtime/task/TezTaskRunner2.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/runtime/task/TezTaskRunner2.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSError;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.tez.SystemEventHandler;
 import org.apache.tez.common.TezExecutors;
 import org.apache.tez.common.TezSharedExecutor;
 import org.apache.tez.dag.api.TezException;
@@ -108,6 +109,8 @@ public class TezTaskRunner2 {
   // when this task is finished.
   private final TezSharedExecutor localExecutor;
 
+  private final SystemEventHandler systemEventHandler;
+
   @Deprecated
   public TezTaskRunner2(Configuration tezConf, UserGroupInformation ugi, String[] localDirs,
       TaskSpec taskSpec, int appAttemptNumber,
@@ -120,7 +123,7 @@ public class TezTaskRunner2 {
       boolean updateSysCounters, HadoopShim hadoopShim) throws IOException {
     this(tezConf, ugi, localDirs, taskSpec, appAttemptNumber, serviceConsumerMetadata,
         serviceProviderEnvMap, startedInputsMap, taskReporter, executor, objectRegistry,
-        pid, executionContext, memAvailable, updateSysCounters, hadoopShim, null);
+        pid, executionContext, memAvailable, updateSysCounters, hadoopShim, null, null);
   }
 
   public TezTaskRunner2(Configuration tezConf, UserGroupInformation ugi, String[] localDirs,
@@ -132,7 +135,7 @@ public class TezTaskRunner2 {
                         ObjectRegistry objectRegistry, String pid,
                         ExecutionContext executionContext, long memAvailable,
                         boolean updateSysCounters, HadoopShim hadoopShim,
-                        TezExecutors sharedExecutor) throws
+                        TezExecutors sharedExecutor, SystemEventHandler systemEventHandler) throws
       IOException {
     this.ugi = ugi;
     this.taskReporter = taskReporter;
@@ -151,7 +154,8 @@ public class TezTaskRunner2 {
     this.task = new LogicalIOProcessorRuntimeTask(taskSpec, appAttemptNumber, taskConf, localDirs,
         umbilicalAndErrorHandler, serviceConsumerMetadata, serviceProviderEnvMap, startedInputsMap,
         objectRegistry, pid, executionContext, memAvailable, updateSysCounters, hadoopShim,
-        sharedExecutor == null ? localExecutor : sharedExecutor);
+        sharedExecutor == null ? localExecutor : sharedExecutor, systemEventHandler);
+    this.systemEventHandler = systemEventHandler;
   }
 
   /**

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/TestLogicalIOProcessorRuntimeTask.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/TestLogicalIOProcessorRuntimeTask.java
@@ -86,7 +86,7 @@ public class TestLogicalIOProcessorRuntimeTask {
     LogicalIOProcessorRuntimeTask lio1 = new LogicalIOProcessorRuntimeTask(task1, 0, tezConf, null,
         umbilical, serviceConsumerMetadata, new HashMap<String, String>(), startedInputsMap, null,
         "", new ExecutionContextImpl("localhost"), Runtime.getRuntime().maxMemory(), true,
-        new DefaultHadoopShim(), sharedExecutor);
+        new DefaultHadoopShim(), sharedExecutor, null);
 
     try {
       lio1.initialize();
@@ -117,7 +117,7 @@ public class TestLogicalIOProcessorRuntimeTask {
     LogicalIOProcessorRuntimeTask lio2 = new LogicalIOProcessorRuntimeTask(task2, 0, tezConf, null,
         umbilical, serviceConsumerMetadata, new HashMap<String, String>(), startedInputsMap, null,
         "", new ExecutionContextImpl("localhost"), Runtime.getRuntime().maxMemory(), true,
-        new DefaultHadoopShim(), sharedExecutor);
+        new DefaultHadoopShim(), sharedExecutor, null);
     try {
       lio2.initialize();
       lio2.run();

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/api/impl/TestProcessorContext.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/api/impl/TestProcessorContext.java
@@ -66,7 +66,7 @@ public class TestProcessorContext {
     TezSharedExecutor sharedExecutor = new TezSharedExecutor(conf);
     LogicalIOProcessorRuntimeTask runtimeTask = new LogicalIOProcessorRuntimeTask(mockSpec, 1, conf,
         new String[]{"/"}, tezUmbilical, null, null, null, null, "", null, 1024, false,
-        new DefaultHadoopShim(), sharedExecutor);
+        new DefaultHadoopShim(), sharedExecutor, null);
     LogicalIOProcessorRuntimeTask mockTask = spy(runtimeTask);
     Map<String, ByteBuffer> serviceConsumerMetadata = Maps.newHashMap();
     Map<String, String> auxServiceEnv = Maps.newHashMap();

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestTaskExecution2.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestTaskExecution2.java
@@ -794,7 +794,7 @@ public class TestTaskExecution2 {
           HashMultimap.<String, String>create(), taskReporter,
           executor, null, "", new ExecutionContextImpl("localhost"),
           Runtime.getRuntime().maxMemory(), updateSysCounters, new DefaultHadoopShim(),
-          sharedExecutor);
+          sharedExecutor, null);
     }
 
     return taskRunner;
@@ -824,7 +824,7 @@ public class TestTaskExecution2 {
       super(tezConf, ugi, localDirs, taskSpec, appAttemptNumber, serviceConsumerMetadata,
           serviceProviderEnvMap, startedInputsMap, taskReporter, executor, objectRegistry, pid,
           executionContext, memAvailable, updateSysCounters, new DefaultHadoopShim(),
-          sharedExecutor);
+          sharedExecutor, null);
     }
 
 

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestTezTaskRunner2.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestTezTaskRunner2.java
@@ -55,7 +55,7 @@ public class TestTezTaskRunner2 {
     TezExecutors sharedExecutor = new TezSharedExecutor(conf);
     TezTaskRunner2 taskRunner2 = new TezTaskRunner2(conf, mock(UserGroupInformation.class),
         localDirs, taskSpec, 1, null, null, null, mock(TaskReporter.class), null, null, "pid",
-        null, 1000, false, new DefaultHadoopShim(), sharedExecutor);
+        null, 1000, false, new DefaultHadoopShim(), sharedExecutor, null);
 
     Assert.assertEquals("global1", taskRunner2.task.getTaskConf().get("global"));
     Assert.assertEquals("task1", taskRunner2.task.getTaskConf().get("global_override"));

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOnFileUnorderedKVOutput.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOnFileUnorderedKVOutput.java
@@ -229,7 +229,7 @@ public class TestOnFileUnorderedKVOutput {
     when(mockSpec.getOutputs()).thenReturn(Collections.singletonList(mock(OutputSpec.class)));
     task = new LogicalIOProcessorRuntimeTask(mockSpec, appAttemptNumber, new Configuration(),
         new String[]{"/"}, tezUmbilical, null, null, null, null, "", null, 1024, false,
-        new DefaultHadoopShim(), sharedExecutor);
+        new DefaultHadoopShim(), sharedExecutor, null);
 
     LogicalIOProcessorRuntimeTask runtimeTask = spy(task);
     

--- a/tez-tests/src/test/java/org/apache/tez/test/TestFaultTolerance.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestFaultTolerance.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
 
+import org.apache.hadoop.security.Credentials;
 import org.apache.tez.common.TezUtils;
 import org.apache.tez.dag.api.EdgeManagerPluginDescriptor;
 import org.apache.tez.dag.api.ProcessorDescriptor;
@@ -191,6 +192,10 @@ public class TestFaultTolerance {
 
     DAGClient dagClient = tezSession.submitDAG(dag);
     dagClient.waitForCompletion();
+
+    // Checking no exceptions happens here
+    dagClient.updateDAGCredentials(new Credentials());
+
     // kill the session now
     tezSession.stop();
 


### PR DESCRIPTION
This PR has ended up bigger than what I expected so I wanted to ask for some feedback before going forward. This is what is does mainly:
* Adds `updateAMCredentials` and `updateDAGCredentials` to `TezClient`. This is not the final API but this functions will be useful anyway to send the credentials
* Add two corresponding functions to the DAGClientAMProtocol
* Add a `SystemEventHandler` in the runtime internals to process the `UpdateCredentialsEvent`s
* Add the `UpdateCredentialsEvent` event and some transitions to the `TaskImpl`'s state machine that represent the credentials being updated.

TODO:
* Add more tests. Will do after the feedback
* Log to history the credentials change?
* I've added some logic to renew the session credentials, these credentials should be updated as well?