### PR TITLE
TEZ-3958: Add internal vertex priority information into the tez dag.d…

### DIFF
--- a/tez-dag/src/main/java/org/apache/tez/Utils.java
+++ b/tez-dag/src/main/java/org/apache/tez/Utils.java
@@ -14,17 +14,29 @@
 
 package org.apache.tez;
 
+import javax.annotation.Nullable;
 import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.event.Event;
+import org.apache.tez.common.TezCommonUtils;
+import org.apache.tez.dag.api.records.DAGProtos;
 import org.apache.tez.dag.app.AppContext;
 import org.apache.tez.dag.app.dag.DAG;
+import org.apache.tez.dag.app.dag.DAGScheduler;
 import org.apache.tez.dag.app.dag.DAGTerminationCause;
+import org.apache.tez.dag.app.dag.Vertex;
 import org.apache.tez.dag.app.dag.event.DAGEventTerminateDag;
 import org.apache.tez.dag.records.TezDAGID;
+import org.apache.tez.dag.utils.Graph;
 import org.apache.tez.serviceplugins.api.DagInfo;
 import org.apache.tez.serviceplugins.api.ServicePluginError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @InterfaceAudience.Private
 /**
@@ -33,6 +45,11 @@ import org.slf4j.LoggerFactory;
 public class Utils {
 
   private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
+
+  /**
+   * Pattern to clean the labels in the .dot generation.
+   */
+  private static Pattern sanitizeLabelPattern = Pattern.compile("[:\\-\\W]+");
 
   public static String getContainerLauncherIdentifierString(int launcherIndex, AppContext appContext) {
     String name;
@@ -90,6 +107,156 @@ public class Utils {
     } else {
       LOG.warn("No current dag name provided. Not acting on " + message);
     }
+  }
+
+  /**
+   * Generate a visualization file.
+   * @param dag DAG.
+   * @param dagPB DAG plan.
+   * @param scheduler scheduler that provide the priorities of the vertexes.
+   */
+  public static void generateDAGVizFile(final DAG dag,
+      final DAGProtos.DAGPlan dagPB, @Nullable final DAGScheduler scheduler) {
+    generateDAGVizFile(dag, dagPB, TezCommonUtils.getTrimmedStrings(
+        System.getenv(ApplicationConstants.Environment.LOG_DIRS.name())),
+        scheduler);
+  }
+
+  /**
+   * Generate a visualization file.
+   * @param dag DAG.
+   * @param dagPB DAG plan.
+   * @param logDirs directories where the file will be written.
+   * @param scheduler scheduler that will provide the priorities
+   *                  of the vertexes.
+   */
+  public static void generateDAGVizFile(final DAG dag,
+      final DAGProtos.DAGPlan dagPB,
+      final String[] logDirs, final @Nullable DAGScheduler scheduler) {
+    TezDAGID dagId = dag.getID();
+
+    HashMap<String, Vertex> nameToVertex = null;
+    if (scheduler != null) {
+      nameToVertex = new HashMap<>(dag.getVertices().size());
+      for (Vertex v: dag.getVertices().values()) {
+        nameToVertex.put(v.getName(), v);
+      }
+    }
+
+    Graph graph = new Graph(sanitizeLabelForViz(dagPB.getName()));
+    for (DAGProtos.VertexPlan vertexPlan : dagPB.getVertexList()) {
+      StringBuilder nodeLabel = new StringBuilder(
+          sanitizeLabelForViz(vertexPlan.getName())
+          + "[" + getShortClassName(
+              vertexPlan.getProcessorDescriptor().getClassName()));
+
+      if (scheduler != null) {
+        Vertex vertex = nameToVertex.get(vertexPlan.getName());
+        if (vertex != null) {
+          try {
+            int priority = (scheduler.getPriorityLowLimit(vertex)
+                + scheduler.getPriorityHighLimit(vertex)) / 2;
+            nodeLabel.append(", priority=").append(priority).append("]");
+          } catch (UnsupportedOperationException e) {
+            LOG.info("The DAG graphviz file with priorities will not"
+                + " be generate since the scheduler "
+                + scheduler.getClass().getSimpleName() + " doesn't"
+                + " override the methods to get the priorities");
+            return;
+          }
+        }
+      }
+      Graph.Node n = graph.newNode(sanitizeLabelForViz(vertexPlan.getName()),
+          nodeLabel.toString());
+      for (DAGProtos.RootInputLeafOutputProto input
+          : vertexPlan.getInputsList()) {
+        Graph.Node inputNode = graph.getNode(
+            sanitizeLabelForViz(vertexPlan.getName())
+            + "_" + sanitizeLabelForViz(input.getName()));
+        inputNode.setLabel(sanitizeLabelForViz(vertexPlan.getName())
+            + "[" + sanitizeLabelForViz(input.getName()) + "]");
+        inputNode.setShape("box");
+        inputNode.addEdge(n, "Input"
+            + " [inputClass=" + getShortClassName(
+                  input.getIODescriptor().getClassName())
+            + ", initializer=" + getShortClassName(
+                  input.getControllerDescriptor().getClassName()) + "]");
+      }
+      for (DAGProtos.RootInputLeafOutputProto output
+          : vertexPlan.getOutputsList()) {
+        Graph.Node outputNode = graph.getNode(sanitizeLabelForViz(
+                vertexPlan.getName())
+            + "_" + sanitizeLabelForViz(output.getName()));
+        outputNode.setLabel(sanitizeLabelForViz(vertexPlan.getName())
+            + "[" + sanitizeLabelForViz(output.getName()) + "]");
+        outputNode.setShape("box");
+        n.addEdge(outputNode, "Output"
+            + " [outputClass=" + getShortClassName(
+                  output.getIODescriptor().getClassName())
+            + ", committer=" + getShortClassName(
+                  output.getControllerDescriptor().getClassName()) + "]");
+      }
+    }
+
+    for (DAGProtos.EdgePlan e : dagPB.getEdgeList()) {
+
+      Graph.Node n = graph.getNode(sanitizeLabelForViz(
+          e.getInputVertexName()));
+      n.addEdge(graph.getNode(sanitizeLabelForViz(
+          e.getOutputVertexName())),
+          "["
+              + "input=" + getShortClassName(e.getEdgeSource().getClassName())
+              + ", output=" + getShortClassName(
+                    e.getEdgeDestination().getClassName())
+              + ", dataMovement=" + e.getDataMovementType().name().trim()
+              + ", schedulingType="
+              + e.getSchedulingType().name().trim() + "]");
+    }
+
+    String outputFile = "";
+    if (logDirs != null && logDirs.length != 0) {
+      outputFile += logDirs[0];
+      outputFile += File.separator;
+    }
+    outputFile += dagId.toString();
+    // Means we have set the priorities
+    if (scheduler != null) {
+      outputFile += "_priority";
+    }
+    outputFile += ".dot";
+
+    try {
+      LOG.info("Generating DAG graphviz file"
+           + ", dagId=" + dagId.toString()
+           + ", filePath=" + outputFile);
+      graph.save(outputFile);
+    } catch (Exception e) {
+      LOG.warn("Error occurred when trying to save graph structure"
+          + " for dag " + dagId.toString(), e);
+    }
+  }
+
+  /**
+   * Get the short name of the class.
+   * @param className long name
+   * @return short name
+   */
+  private static String getShortClassName(final String className) {
+    int pos = className.lastIndexOf(".");
+    if (pos != -1 && pos < className.length() - 1) {
+      return className.substring(pos + 1);
+    }
+    return className;
+  }
+
+  /**
+   * Replace some characters with underscores.
+   * @param label label to sanitize
+   * @return the label with the replaced characters
+   */
+  private static String sanitizeLabelForViz(final String label) {
+    Matcher m = sanitizeLabelPattern.matcher(label);
+    return m.replaceAll("_");
   }
 
   @SuppressWarnings("unchecked")

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/DAG.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/DAG.java
@@ -38,6 +38,8 @@ import org.apache.tez.dag.records.TezDAGID;
 import org.apache.tez.dag.records.TezVertexID;
 import org.apache.tez.serviceplugins.api.DagInfo;
 
+import javax.annotation.Nullable;
+
 /**
  * Main interface to interact with the job.
  */
@@ -96,5 +98,12 @@ public interface DAG extends DagInfo {
   StateChangeNotifier getStateChangeNotifier();
 
   org.apache.tez.dag.api.Vertex.VertexExecutionContext getDefaultExecutionContext();
+
+  /**
+   *
+   * @return the DAGScheduler that will schedule
+   * this DAG, null if it doesn't exist
+   */
+  @Nullable DAGScheduler getDAGScheduler();
 
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/DAGScheduler.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/DAGScheduler.java
@@ -89,4 +89,24 @@ public abstract class DAGScheduler {
   public abstract void scheduleTaskEx(DAGEventSchedulerUpdate event);
   
   public abstract void taskCompletedEx(DAGEventSchedulerUpdate event);
+
+  /**
+   * Get the low limit priority for a particular vertex.
+   * @param vertex to get the priority of
+   * @return the priority
+   */
+  public int getPriorityLowLimit(Vertex vertex) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Get the low hight priority for a particular vertex. Default
+   * to the low limit priority minus two.
+   * @param vertex to get the priority of
+   * @return the priority
+   */
+  public int getPriorityHighLimit(final Vertex vertex) {
+    return  getPriorityLowLimit(vertex) - 2;
+  }
+
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/DAGImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/DAGImpl.java
@@ -42,6 +42,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.tez.Utils;
 import org.apache.tez.common.TezUtilsInternal;
 import org.apache.tez.common.counters.LimitExceededException;
 import org.apache.tez.dag.app.dag.event.DAGEventTerminateDag;
@@ -1620,6 +1621,9 @@ public class DAGImpl implements org.apache.tez.dag.app.dag.DAG,
       }
     }
 
+    // This is going to override the previously generated file
+    // which didn't have the priorities
+    Utils.generateDAGVizFile(this, jobPlan, dagScheduler);
     return DAGState.INITED;
   }
 
@@ -2380,6 +2384,11 @@ public class DAGImpl implements org.apache.tez.dag.app.dag.DAG,
     } finally {
       readLock.unlock();
     }
+  }
+
+  @Override
+  public DAGScheduler getDAGScheduler() {
+    return dagScheduler;
   }
 
   // output of either vertex or vertex group

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/DAGSchedulerNaturalOrder.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/DAGSchedulerNaturalOrder.java
@@ -46,11 +46,10 @@ public class DAGSchedulerNaturalOrder extends DAGScheduler {
   public void scheduleTaskEx(DAGEventSchedulerUpdate event) {
     TaskAttempt attempt = event.getAttempt();
     Vertex vertex = dag.getVertex(attempt.getVertexID());
-    int vertexDistanceFromRoot = vertex.getDistanceFromRoot();
 
     // natural priority. Handles failures and retries.
-    int priorityLowLimit = ((vertexDistanceFromRoot + 1) * dag.getTotalVertices() * 3) + (vertex.getVertexId().getId() * 3);
-    int priorityHighLimit = priorityLowLimit - 2;
+    int priorityLowLimit = getPriorityLowLimit(vertex);
+    int priorityHighLimit = getPriorityHighLimit(vertex);
 
     if (LOG.isDebugEnabled()) {
       LOG.debug("Scheduling " + attempt.getID() + " between priorityLow: " + priorityLowLimit
@@ -62,7 +61,15 @@ public class DAGSchedulerNaturalOrder extends DAGScheduler {
                                       
     sendEvent(attemptEvent);
   }
-  
+
+  @Override
+  public int getPriorityLowLimit(final Vertex vertex) {
+    final int vertexDistanceFromRoot = vertex.getDistanceFromRoot();
+    return ((vertexDistanceFromRoot + 1) * dag.getTotalVertices() * 3)
+        + (vertex.getVertexId().getId() * 3);
+  }
+
+
   @Override
   public void taskCompletedEx(DAGEventSchedulerUpdate event) {
   }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/DAGSchedulerNaturalOrderControlled.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/DAGSchedulerNaturalOrderControlled.java
@@ -76,11 +76,10 @@ public class DAGSchedulerNaturalOrderControlled extends DAGScheduler {
   public void scheduleTaskEx(DAGEventSchedulerUpdate event) {
     TaskAttempt attempt = event.getAttempt();
     Vertex vertex = dag.getVertex(attempt.getVertexID());
-    int vertexDistanceFromRoot = vertex.getDistanceFromRoot();
 
     // natural priority. Handles failures and retries.
-    int priorityLowLimit = ((vertexDistanceFromRoot + 1) * dag.getTotalVertices() * 3) + (vertex.getVertexId().getId() * 3);
-    int priorityHighLimit = priorityLowLimit - 2;
+    int priorityLowLimit = getPriorityLowLimit(vertex);
+    int priorityHighLimit = getPriorityHighLimit(vertex);
 
     TaskAttemptEventSchedule attemptEvent = new TaskAttemptEventSchedule(
         attempt.getID(), priorityLowLimit, priorityHighLimit);
@@ -116,6 +115,13 @@ public class DAGSchedulerNaturalOrderControlled extends DAGScheduler {
         pendingEvents.put(vertex.getName(), attemptEvent);
       }
     }
+  }
+
+  @Override
+  public int getPriorityLowLimit(final Vertex vertex) {
+    final int vertexDistanceFromRoot = vertex.getDistanceFromRoot();
+    return ((vertexDistanceFromRoot + 1) * dag.getTotalVertices() * 3)
+        + (vertex.getVertexId().getId() * 3);
   }
 
   private void taskAttemptSeen(String vertexName, TezTaskAttemptID taskAttemptID) {

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGScheduler.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGScheduler.java
@@ -58,14 +58,19 @@ public class TestDAGScheduler {
     TaskAttempt mockAttempt = mock(TaskAttempt.class);
     when(mockDag.getVertex((TezVertexID) any())).thenReturn(mockVertex);
     when(mockDag.getTotalVertices()).thenReturn(4);
-    when(mockVertex.getDistanceFromRoot()).thenReturn(0).thenReturn(1)
-        .thenReturn(2);
+    when(mockVertex.getDistanceFromRoot())
+        .thenReturn(0).thenReturn(0)
+        .thenReturn(1).thenReturn(1)
+        .thenReturn(2).thenReturn(2);
     TezVertexID vId0 = TezVertexID.fromString("vertex_1436907267600_195589_1_00");
     TezVertexID vId1 = TezVertexID.fromString("vertex_1436907267600_195589_1_01");
     TezVertexID vId2 = TezVertexID.fromString("vertex_1436907267600_195589_1_02");
     TezVertexID vId3 = TezVertexID.fromString("vertex_1436907267600_195589_1_03");
-    when(mockVertex.getVertexId()).thenReturn(vId0).thenReturn(vId1)
-        .thenReturn(vId2).thenReturn(vId3);
+    when(mockVertex.getVertexId())
+        .thenReturn(vId0).thenReturn(vId0)
+        .thenReturn(vId1).thenReturn(vId1)
+        .thenReturn(vId2).thenReturn(vId2)
+        .thenReturn(vId3).thenReturn(vId3);
     
     DAGEventSchedulerUpdate event = new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_SCHEDULE, mockAttempt);    


### PR DESCRIPTION
…ot debug information

This PR does the following:
* Move `generateDAGVizFile` from `DagAppMaster` to `Utils` so it can be called from `DAGImpl`. The priorities are initialized after `DAGImpl.initializeDAG`, that why this call is done there.
* There's still a call to `generateDAGVizFile` from `DagAppMaster` which would render the file but without the priorities. This file will be overwritten by the call in `DAGImpl`.
* Creates methods `getPriorityLowLimit` and `getPriorityLowLimit` in `DAGScheduler`.
* Creates `getDAGScheduler` in `DAG`.


A sample `.dot` file looks like:
```
digraph DAG_Iteration_0 {
graph [ label="DAG_Iteration_0", fontsize=24, fontname=Helvetica];
node [fontsize=12, fontname=Helvetica];
edge [fontsize=9, fontcolor=blue, fontname=Arial];
"DAG_Iteration_0.Sorter_Output" [ label = "Sorter[Output]", shape = "box" , color= "black"];
"DAG_Iteration_0.Tokenizer" [ label = "Tokenizer[WordCount$TokenProcessor,\n priority=8,\n ]" , color= "black" ];
"DAG_Iteration_0.Tokenizer" -> "DAG_Iteration_0.Summation" [ label = "[input=OrderedPartitionedKVOutput,\n output=OrderedGroupedKVInput,\n dataMovement=SCATTER_GATHER,\n schedulingType=SEQUENTIAL]" ];
"DAG_Iteration_0.Tokenizer_Input" [ label = "Tokenizer[Input]", shape = "box" , color= "black"];
"DAG_Iteration_0.Tokenizer_Input" -> "DAG_Iteration_0.Tokenizer" [ label = "Input [inputClass=MRInput,\n initializer=MRInputAMSplitGenerator]" ];
"DAG_Iteration_0.Summation" [ label = "Summation[OrderedWordCount$SumProcessor,\n priority=11,\n ]" , color= "black" ];
"DAG_Iteration_0.Summation" -> "DAG_Iteration_0.Sorter" [ label = "[input=OrderedPartitionedKVOutput,\n output=OrderedGroupedKVInput,\n dataMovement=SCATTER_GATHER,\n schedulingType=SEQUENTIAL]" ];
"DAG_Iteration_0.Sorter" [ label = "Sorter[OrderedWordCount$NoOpSorter,\n priority=14,\n ]" , color= "black" ];
"DAG_Iteration_0.Sorter" -> "DAG_Iteration_0.Sorter_Output" [ label = "Output [outputClass=MROutput,\n committer=MROutputCommitter]" ];
}
```