### PR TITLE
TEZ-4086. Allow various examples to work when outputPath is on a FileSystem other than the default FileSystem.

### DIFF
--- a/tez-examples/src/main/java/org/apache/tez/examples/HashJoinExample.java
+++ b/tez-examples/src/main/java/org/apache/tez/examples/HashJoinExample.java
@@ -114,8 +114,7 @@ public class HashJoinExample extends TezExampleBase {
 
     // Verify output path existence
     FileSystem fs = outputPath.getFileSystem(tezConf);
-    outputPath = fs.resolvePath(
-        outputPath.makeQualified(fs.getUri(), fs.getWorkingDirectory()));
+    outputPath = fs.makeQualified(outputPath);
     if (fs.exists(outputPath)) {
       System.err.println("Output directory: " + outputDir + " already exists");
       return 3;

--- a/tez-examples/src/main/java/org/apache/tez/examples/HashJoinExample.java
+++ b/tez-examples/src/main/java/org/apache/tez/examples/HashJoinExample.java
@@ -113,7 +113,9 @@ public class HashJoinExample extends TezExampleBase {
     Path outputPath = new Path(outputDir);
 
     // Verify output path existence
-    FileSystem fs = FileSystem.get(tezConf);
+    FileSystem fs = outputPath.getFileSystem(tezConf);
+    outputPath = fs.resolvePath(
+        outputPath.makeQualified(fs.getUri(), fs.getWorkingDirectory()));
     if (fs.exists(outputPath)) {
       System.err.println("Output directory: " + outputDir + " already exists");
       return 3;

--- a/tez-examples/src/main/java/org/apache/tez/examples/JoinDataGen.java
+++ b/tez-examples/src/main/java/org/apache/tez/examples/JoinDataGen.java
@@ -102,10 +102,10 @@ public class JoinDataGen extends TezExampleBase {
     Path expectedOutputPath = new Path(expectedOutputDir);
 
     // Verify output path existence
-    FileSystem fs = FileSystem.get(tezConf);
     int res = 0;
-    res = checkOutputDirectory(fs, largeOutPath) + checkOutputDirectory(fs, smallOutPath)
-        + checkOutputDirectory(fs, expectedOutputPath);
+    res = checkOutputDirectory(tezConf, largeOutPath)
+        + checkOutputDirectory(tezConf, smallOutPath)
+        + checkOutputDirectory(tezConf, expectedOutputPath);
     if (res != 0) {
       return 3;
     }
@@ -279,7 +279,10 @@ public class JoinDataGen extends TezExampleBase {
 
   }
 
-  private int checkOutputDirectory(FileSystem fs, Path path) throws IOException {
+  private int checkOutputDirectory(Configuration conf, Path path) throws IOException {
+    FileSystem fs = path.getFileSystem(conf);
+    path = fs
+        .resolvePath(path.makeQualified(fs.getUri(), fs.getWorkingDirectory()));
     if (fs.exists(path)) {
       System.err.println("Output directory: " + path + " already exists");
       return 2;

--- a/tez-examples/src/main/java/org/apache/tez/examples/JoinDataGen.java
+++ b/tez-examples/src/main/java/org/apache/tez/examples/JoinDataGen.java
@@ -281,8 +281,7 @@ public class JoinDataGen extends TezExampleBase {
 
   private int checkOutputDirectory(Configuration conf, Path path) throws IOException {
     FileSystem fs = path.getFileSystem(conf);
-    path = fs
-        .resolvePath(path.makeQualified(fs.getUri(), fs.getWorkingDirectory()));
+    path = fs.makeQualified(path);
     if (fs.exists(path)) {
       System.err.println("Output directory: " + path + " already exists");
       return 2;

--- a/tez-examples/src/main/java/org/apache/tez/examples/SortMergeJoinExample.java
+++ b/tez-examples/src/main/java/org/apache/tez/examples/SortMergeJoinExample.java
@@ -106,8 +106,7 @@ public class SortMergeJoinExample extends TezExampleBase {
 
     // Verify output path existence
     FileSystem fs = outputPath.getFileSystem(tezConf);
-    outputPath = fs.resolvePath(
-        outputPath.makeQualified(fs.getUri(), fs.getWorkingDirectory()));
+    outputPath = fs.makeQualified(outputPath);
     if (fs.exists(outputPath)) {
       System.err.println("Output directory: " + outputDir + " already exists");
       return 3;

--- a/tez-examples/src/main/java/org/apache/tez/examples/SortMergeJoinExample.java
+++ b/tez-examples/src/main/java/org/apache/tez/examples/SortMergeJoinExample.java
@@ -105,7 +105,9 @@ public class SortMergeJoinExample extends TezExampleBase {
     Path outputPath = new Path(outputDir);
 
     // Verify output path existence
-    FileSystem fs = FileSystem.get(tezConf);
+    FileSystem fs = outputPath.getFileSystem(tezConf);
+    outputPath = fs.resolvePath(
+        outputPath.makeQualified(fs.getUri(), fs.getWorkingDirectory()));
     if (fs.exists(outputPath)) {
       System.err.println("Output directory: " + outputDir + " already exists");
       return 3;

--- a/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/FilterLinesByWord.java
+++ b/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/FilterLinesByWord.java
@@ -124,7 +124,12 @@ public class FilterLinesByWord extends Configured implements Tool {
     String filterWord = otherArgs[2];
 
     FileSystem fs = FileSystem.get(conf);
-    if (fs.exists(new Path(outputPath))) {
+
+    Path outputPathAsPath = new Path(outputPath);
+    FileSystem outputFs = outputPathAsPath.getFileSystem(conf);
+    outputPathAsPath = outputFs.resolvePath(outputPathAsPath
+        .makeQualified(outputFs.getUri(), outputFs.getWorkingDirectory()));
+    if (outputFs.exists(outputPathAsPath)) {
       System.err.println("Output directory : " + outputPath + " already exists");
       return 2;
     }

--- a/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/FilterLinesByWord.java
+++ b/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/FilterLinesByWord.java
@@ -127,8 +127,7 @@ public class FilterLinesByWord extends Configured implements Tool {
 
     Path outputPathAsPath = new Path(outputPath);
     FileSystem outputFs = outputPathAsPath.getFileSystem(conf);
-    outputPathAsPath = outputFs.resolvePath(outputPathAsPath
-        .makeQualified(outputFs.getUri(), outputFs.getWorkingDirectory()));
+    outputPathAsPath = outputFs.makeQualified(outputPathAsPath);
     if (outputFs.exists(outputPathAsPath)) {
       System.err.println("Output directory : " + outputPath + " already exists");
       return 2;

--- a/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/TestOrderedWordCount.java
+++ b/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/TestOrderedWordCount.java
@@ -497,8 +497,7 @@ public class TestOrderedWordCount extends Configured implements Tool {
 
         Path outputPathAsPath = new Path(outputPath);
         FileSystem fs = outputPathAsPath.getFileSystem(conf);
-        outputPathAsPath = fs.resolvePath(outputPathAsPath
-            .makeQualified(fs.getUri(), fs.getWorkingDirectory()));
+        outputPathAsPath = fs.makeQualified(outputPathAsPath);
         if (fs.exists(outputPathAsPath)) {
           throw new FileAlreadyExistsException("Output directory "
               + outputPath + " already exists");

--- a/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/TestOrderedWordCount.java
+++ b/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/TestOrderedWordCount.java
@@ -18,7 +18,6 @@
 
 package org.apache.tez.mapreduce.examples;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -441,8 +440,6 @@ public class TestOrderedWordCount extends Configured implements Tool {
     HadoopShim hadoopShim = new HadoopShimsLoader(tezConf).getHadoopShim();
     TestOrderedWordCount instance = new TestOrderedWordCount();
 
-    FileSystem fs = FileSystem.get(conf);
-
     String stagingDirStr =  conf.get(TezConfiguration.TEZ_AM_STAGING_DIR,
             TezConfiguration.TEZ_AM_STAGING_DIR_DEFAULT) + Path.SEPARATOR + 
             Long.toString(System.currentTimeMillis());
@@ -498,7 +495,11 @@ public class TestOrderedWordCount extends Configured implements Tool {
         String inputPath = inputPaths.get(dagIndex-1);
         String outputPath = outputPaths.get(dagIndex-1);
 
-        if (fs.exists(new Path(outputPath))) {
+        Path outputPathAsPath = new Path(outputPath);
+        FileSystem fs = outputPathAsPath.getFileSystem(conf);
+        outputPathAsPath = fs.resolvePath(outputPathAsPath
+            .makeQualified(fs.getUri(), fs.getWorkingDirectory()));
+        if (fs.exists(outputPathAsPath)) {
           throw new FileAlreadyExistsException("Output directory "
               + outputPath + " already exists");
         }

--- a/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/UnionExample.java
+++ b/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/UnionExample.java
@@ -262,7 +262,11 @@ public class UnionExample {
     DAGClient dagClient = null;
 
     try {
-        if (fs.exists(new Path(outputPath))) {
+        Path outputPathAsPath = new Path(outputPath);
+      FileSystem outputFs = outputPathAsPath.getFileSystem(tezConf);
+      outputPathAsPath = outputFs.resolvePath(outputPathAsPath
+          .makeQualified(outputFs.getUri(), outputFs.getWorkingDirectory()));
+        if (outputFs.exists(outputPathAsPath)) {
           throw new FileAlreadyExistsException("Output directory "
               + outputPath + " already exists");
         }

--- a/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/UnionExample.java
+++ b/tez-tests/src/main/java/org/apache/tez/mapreduce/examples/UnionExample.java
@@ -264,8 +264,7 @@ public class UnionExample {
     try {
         Path outputPathAsPath = new Path(outputPath);
       FileSystem outputFs = outputPathAsPath.getFileSystem(tezConf);
-      outputPathAsPath = outputFs.resolvePath(outputPathAsPath
-          .makeQualified(outputFs.getUri(), outputFs.getWorkingDirectory()));
+      outputPathAsPath = outputFs.makeQualified(outputPathAsPath);
         if (outputFs.exists(outputPathAsPath)) {
           throw new FileAlreadyExistsException("Output directory "
               + outputPath + " already exists");

--- a/tez-tests/src/test/java/org/apache/tez/test/TestTezJobs.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestTezJobs.java
@@ -138,7 +138,6 @@ public class TestTezJobs {
 
     if (mrrTezCluster == null) {
       mrrTezCluster = new MiniTezCluster(TestTezJobs.class.getName(), 1, 1, 1);
-      Configuration conf = new Configuration();
       conf.set("fs.defaultFS", remoteFs.getUri().toString()); // use HDFS
       conf.setLong(TezConfiguration.TEZ_AM_SLEEP_TIME_BEFORE_EXIT_MILLIS, 500);
       mrrTezCluster.init(conf);
@@ -163,7 +162,7 @@ public class TestTezJobs {
   @Test(timeout = 60000)
   public void testHashJoinExample() throws Exception {
     HashJoinExample hashJoinExample = new HashJoinExample();
-    hashJoinExample.setConf(mrrTezCluster.getConfig());
+    hashJoinExample.setConf(new Configuration(mrrTezCluster.getConfig()));
     Path stagingDirPath = new Path("/tmp/tez-staging-dir");
     Path inPath1 = new Path("/tmp/hashJoin/inPath1");
     Path inPath2 = new Path("/tmp/hashJoin/inPath2");
@@ -219,7 +218,7 @@ public class TestTezJobs {
   @Test(timeout = 60000)
   public void testHashJoinExampleDisableSplitGrouping() throws Exception {
     HashJoinExample hashJoinExample = new HashJoinExample();
-    hashJoinExample.setConf(conf);
+    hashJoinExample.setConf(new Configuration(mrrTezCluster.getConfig()));
     Path stagingDirPath = new Path(TEST_ROOT_DIR + "/tmp/tez-staging-dir");
     Path inPath1 = new Path(TEST_ROOT_DIR + "/tmp/hashJoin/inPath1");
     Path inPath2 = new Path(TEST_ROOT_DIR + "/tmp/hashJoin/inPath2");
@@ -431,7 +430,7 @@ public class TestTezJobs {
   @Test(timeout = 60000)
   public void testSortMergeJoinExampleDisableSplitGrouping() throws Exception {
     SortMergeJoinExample sortMergeJoinExample = new SortMergeJoinExample();
-    sortMergeJoinExample.setConf(conf);
+    sortMergeJoinExample.setConf(new Configuration(mrrTezCluster.getConfig()));
     Path stagingDirPath = new Path(TEST_ROOT_DIR + "/tmp/tez-staging-dir");
     Path inPath1 = new Path(TEST_ROOT_DIR + "/tmp/sortMerge/inPath1");
     Path inPath2 = new Path(TEST_ROOT_DIR + "/tmp/sortMerge/inPath2");


### PR DESCRIPTION
FileSystem other than the default FileSystem.