### PR TITLE
TEZ-4089. Upgrade to hadoop 2.8.4 to make 0.9.x releases work with Hi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <clover.license>${user.home}/clover.license</clover.license>
-    <hadoop.version>2.7.2</hadoop.version>
+    <hadoop.version>2.8.4</hadoop.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
     <netty.version>3.6.2.Final</netty.version>
     <pig.version>0.13.0</pig.version>


### PR DESCRIPTION
…ve 3.x and up