### PR TITLE
TEZ-4087: Shuffle: Fix shuffle cleanup to prevent thread leaks

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -314,6 +314,16 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
       this.onDiskMerger = new OnDiskMerger(this);
   }
 
+  void setupParentThread(Thread shuffleSchedulerThread) {
+    LOG.info("Setting merger's parent thread to "
+        + shuffleSchedulerThread.getName());
+    if (this.memToMemMerger != null) {
+      memToMemMerger.setParentThread(shuffleSchedulerThread);
+    }
+    this.inMemoryMerger.setParentThread(shuffleSchedulerThread);;
+    this.onDiskMerger.setParentThread(shuffleSchedulerThread);
+  }
+
   @Private
   void configureAndStart() {
     if (this.memToMemMerger != null) {
@@ -714,7 +724,8 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
                                             int mergeFactor) {
       super(manager, mergeFactor, exceptionReporter);
       setName("MemToMemMerger [" + TezUtilsInternal
-          .cleanVertexName(inputContext.getSourceVertexName()) + "]");
+          .cleanVertexName(inputContext.getSourceVertexName())
+          + "_" + inputContext.getUniqueIdentifier() + "]");
       setDaemon(true);
     }
 
@@ -831,8 +842,9 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
     public InMemoryMerger(MergeManager manager) {
       super(manager, Integer.MAX_VALUE, exceptionReporter);
-      setName("MemtoDiskMerger [" + TezUtilsInternal
-          .cleanVertexName(inputContext.getSourceVertexName()) + "]");
+      setName("MemtoDiskMerger [" +  TezUtilsInternal
+          .cleanVertexName(inputContext.getSourceVertexName())
+          + "_" + inputContext.getUniqueIdentifier()  + "]");
       setDaemon(true);
     }
     
@@ -952,8 +964,9 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
 
     public OnDiskMerger(MergeManager manager) {
       super(manager, ioSortFactor, exceptionReporter);
-      setName("DiskToDiskMerger [" + TezUtilsInternal
-          .cleanVertexName(inputContext.getSourceVertexName()) + "]");
+      setName("DiskToDiskMerger [" +  TezUtilsInternal
+          .cleanVertexName(inputContext.getSourceVertexName())
+          + "_" + inputContext.getUniqueIdentifier() + "]");
       setDaemon(true);
     }
     

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleScheduler.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/ShuffleScheduler.java
@@ -440,6 +440,7 @@ class ShuffleScheduler {
 
   public void start() throws Exception {
     shuffleSchedulerThread = Thread.currentThread();
+    mergeManager.setupParentThread(shuffleSchedulerThread);
     ShuffleSchedulerCallable schedulerCallable = new ShuffleSchedulerCallable();
     schedulerCallable.call();
   }


### PR DESCRIPTION
Merger threads are not killed in long running daemons. Work is in progress to mine the logs of long running daemons. As of now, all tasks are effectively cleaning up. However, from tez side, it would be good to have a feature where merger threads stop if the parent thread dies.

Changes:

1. Pass ShuffleScheduler detail to merger threads
2. Add attempt_id detail to merger threads. This would help in identifying thread details. As of now, only vertex name is populated which is not very useful.
3. In merger thread, periodically check if the parent thread is alive. 
