### PR TITLE
TEZ-4091: UnorderedPartitionedKVWriter::readDataForDME should check i…

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/IFile.java
@@ -98,7 +98,6 @@ public class IFile {
     private TezTaskOutput taskOutput;
     private int totalSize;
 
-    @VisibleForTesting
     private Path outputPath;
     private CompressionCodec fileCodec;
     private BoundedByteArrayOutputStream cacheStream;
@@ -260,6 +259,10 @@ public class IFile {
     @VisibleForTesting
     void setOutputPath(Path outputPath) {
       this.outputPath = outputPath;
+    }
+
+    public Path getOutputPath() {
+      return this.outputPath;
     }
   }
 


### PR DESCRIPTION
Changes:

1. It is possible that in-mem writer spilled over to disk. Need to use that path as finalOutPath and set its permission. Otherwise it would lead to NPE in `readDataForDME` as it may not have `finalOutPath`

2. Relevant permissions have to be setup in the file being written out by in-mem writer (i.e after spill)