### PR TITLE
TEZ-4093 Add hadoop-ozone-filesystem jar to ozone profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <clover.license>${user.home}/clover.license</clover.license>
     <hadoop.version>3.0.3</hadoop.version>
+    <ozone.version>0.5.0-SNAPSHOT</ozone.version>
     <jetty.version>9.3.24.v20180605</jetty.version>
     <netty.version>3.10.5.Final</netty.version>
     <pig.version>0.13.0</pig.version>
@@ -1371,6 +1372,20 @@
           <artifactId>hadoop-azure-datalake</artifactId>
           <scope>runtime</scope>
           <version>${hadoop.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <id>ozone</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-ozone-filesystem-lib-current</artifactId>
+          <scope>runtime</scope>
+          <version>${ozone.version}</version>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add Ozone Filesystem jar as a dependency under new profile in mvn "ozone", so that Tez can access Ozone Filesystem while running Hive queries. 


### What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/TEZ-4093

### How was this patch tested?
I tested by running `mvn clean package -DskipTests -Pozone` and verified that ozone filesystem jar is present in the dist by `ls tez-dist/target/tez-0.10.1-SNAPSHOT/lib/hadoop-ozone-filesystem-lib-current-0.5.0-SNAPSHOT.jar`