### PR TITLE
TEZ-4137: Merge runtime component configs with session config

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/runtime/api/InputInitializerContext.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/InputInitializerContext.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.classification.InterfaceStability.Unstable;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.tez.common.counters.TezCounters;
@@ -49,7 +50,13 @@ public interface InputInitializerContext {
    * @return DAG name
    */
   String getDAGName();
-  
+
+  /**
+   * Get vertex configuration
+   * @return Vertex configuration
+   */
+  Configuration getVertexConfiguration();
+
   /**
    * Get the name of the input
    * @return Input name

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/TaskContext.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/TaskContext.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.classification.InterfaceStability.Unstable;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.common.counters.TezCounters;
 import org.apache.tez.dag.api.UserPayload;
@@ -61,6 +62,12 @@ public interface TaskContext {
    * @return Task Attempt Number
    */
   public int getTaskAttemptNumber();
+
+  /**
+   * Get container configuration
+   * @return Container configuration
+   */
+  public Configuration getContainerConfiguration();
 
   /**
    * Get the name of the DAG

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/TezRootInputInitializerContextImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/TezRootInputInitializerContextImpl.java
@@ -23,6 +23,7 @@ package org.apache.tez.dag.app.dag.impl;
 import java.util.Set;
 import java.util.Objects;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.tez.common.counters.TezCounters;
@@ -85,7 +86,12 @@ public class TezRootInputInitializerContextImpl implements
   public UserPayload getUserPayload() {
     return this.input.getControllerDescriptor().getUserPayload();
   }
-  
+
+  @Override
+  public Configuration getVertexConfiguration() {
+    return vertex.getConf();
+  }
+
   @Override 
   public int getNumTasks() {
     return vertex.getTotalTasks();

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/common/MRInputAMSplitGenerator.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/common/MRInputAMSplitGenerator.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.classification.InterfaceStability.Evolving;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapreduce.split.TezMapReduceSplitsGrouper;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.tez.common.TezUtils;
 import org.apache.tez.dag.api.VertexLocationHint;
@@ -80,8 +79,8 @@ public class MRInputAMSplitGenerator extends InputInitializer {
           + sw.now(TimeUnit.MILLISECONDS));
     }
     sw.reset().start();
-    Configuration conf = TezUtils.createConfFromByteString(userPayloadProto
-        .getConfigurationBytes());
+    Configuration conf = new JobConf(getContext().getVertexConfiguration());
+    TezUtils.addToConfFromByteString(conf, userPayloadProto.getConfigurationBytes());
     
     sendSerializedEvents = conf.getBoolean(
         MRJobConfig.MR_TEZ_INPUT_INITIALIZER_SERIALIZE_EVENT_PAYLOAD,

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/input/base/MRInputBase.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/input/base/MRInputBase.java
@@ -72,8 +72,9 @@ public abstract class MRInputBase extends AbstractLogicalInput {
     boolean isGrouped = mrUserPayload.getGroupingEnabled();
     Preconditions.checkArgument(mrUserPayload.hasSplits() == false,
         "Split information not expected in " + this.getClass().getName());
-    Configuration conf = TezUtils
-        .createConfFromByteString(mrUserPayload.getConfigurationBytes());
+
+    Configuration conf = new JobConf(getContext().getContainerConfiguration());
+    TezUtils.addToConfFromByteString(conf, mrUserPayload.getConfigurationBytes());
     this.jobConf = new JobConf(conf);
     useNewApi = this.jobConf.getUseNewMapper();
     if (isGrouped) {

--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/output/MROutput.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/output/MROutput.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.ByteString;
 import org.apache.tez.common.Preconditions;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.mapreduce.lib.output.LazyOutputFormat;
@@ -398,8 +399,9 @@ public class MROutput extends AbstractLogicalOutput {
     taskNumberFormat.setGroupingUsed(false);
     nonTaskNumberFormat.setMinimumIntegerDigits(3);
     nonTaskNumberFormat.setGroupingUsed(false);
-    Configuration conf = TezUtils.createConfFromUserPayload(getContext().getUserPayload());
-    this.jobConf = new JobConf(conf);
+    UserPayload userPayload = getContext().getUserPayload();
+    this.jobConf = new JobConf(getContext().getContainerConfiguration());
+    TezUtils.addToConfFromByteString(this.jobConf, ByteString.copyFrom(userPayload.getPayload()));
     // Add tokens to the jobConf - in case they are accessed within the RW / OF
     jobConf.getCredentials().mergeAll(UserGroupInformation.getCurrentUser().getCredentials());
     this.isMapperOutput = jobConf.getBoolean(MRConfig.IS_MAP_PROCESSOR,

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/TezTestUtils.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/TezTestUtils.java
@@ -17,6 +17,7 @@
  */
 package org.apache.tez.mapreduce;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.tez.common.counters.TezCounters;
@@ -59,10 +60,12 @@ public class TezTestUtils {
 
     private final ApplicationId appId;
     private final UserPayload payload;
+    private final Configuration vertexConfig;
 
-    public TezRootInputInitializerContextForTest(UserPayload payload) throws IOException {
+    public TezRootInputInitializerContextForTest(UserPayload payload, Configuration vertexConfig) throws IOException {
       appId = ApplicationId.newInstance(1000, 200);
       this.payload = payload == null ? UserPayload.create(null) : payload;
+      this.vertexConfig = vertexConfig;
     }
 
     @Override
@@ -73,6 +76,11 @@ public class TezTestUtils {
     @Override
     public String getDAGName() {
       return "FakeDAG";
+    }
+
+    @Override
+    public Configuration getVertexConfiguration() {
+      return vertexConfig;
     }
 
     @Override

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/common/TestMRInputAMSplitGenerator.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/common/TestMRInputAMSplitGenerator.java
@@ -96,7 +96,7 @@ public class TestMRInputAMSplitGenerator {
     UserPayload userPayload = dataSource.getInputDescriptor().getUserPayload();
 
     InputInitializerContext context =
-        new TezTestUtils.TezRootInputInitializerContextForTest(userPayload);
+        new TezTestUtils.TezRootInputInitializerContextForTest(userPayload, new Configuration(false));
     MRInputAMSplitGenerator splitGenerator =
         new MRInputAMSplitGenerator(context);
 

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/common/TestMRInputSplitDistributor.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/common/TestMRInputSplitDistributor.java
@@ -70,7 +70,8 @@ public class TestMRInputSplitDistributor {
     UserPayload userPayload =
         UserPayload.create(payloadProto.build().toByteString().asReadOnlyByteBuffer());
 
-    InputInitializerContext context = new TezTestUtils.TezRootInputInitializerContextForTest(userPayload);
+    InputInitializerContext context = new TezTestUtils.TezRootInputInitializerContextForTest(userPayload,
+        new Configuration(false));
     MRInputSplitDistributor splitDist = new MRInputSplitDistributor(context);
 
     List<Event> events = splitDist.initialize();
@@ -119,7 +120,8 @@ public class TestMRInputSplitDistributor {
     UserPayload userPayload =
         UserPayload.create(payloadProto.build().toByteString().asReadOnlyByteBuffer());
 
-    InputInitializerContext context = new TezTestUtils.TezRootInputInitializerContextForTest(userPayload);
+    InputInitializerContext context = new TezTestUtils.TezRootInputInitializerContextForTest(userPayload,
+        new Configuration(false));
     MRInputSplitDistributor splitDist = new MRInputSplitDistributor(context);
 
     List<Event> events = splitDist.initialize();

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/MRInputForTest.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/MRInputForTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.mapreduce.input;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.tez.runtime.api.InputContext;
+
+/**
+ * This is used for inspecting jobConf in test.
+ */
+public class MRInputForTest extends MRInput {
+  public MRInputForTest(InputContext inputContext, int numPhysicalInputs) {
+    super(inputContext, numPhysicalInputs);
+  }
+
+  public Configuration getConfiguration() {
+    return jobConf;
+  }
+}

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/MultiMRInputForTest.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/MultiMRInputForTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.mapreduce.input;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.tez.runtime.api.InputContext;
+
+/**
+ * This is used for inspecting jobConf in test.
+ */
+public class MultiMRInputForTest extends MultiMRInput {
+  public MultiMRInputForTest(InputContext inputContext, int numPhysicalInputs) {
+    super(inputContext, numPhysicalInputs);
+  }
+
+  public Configuration getConfiguration() {
+    return jobConf;
+  }
+}

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMROutputLegacy.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMROutputLegacy.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
@@ -182,6 +183,7 @@ public class TestMROutputLegacy {
     when(outputContext.getTaskVertexIndex()).thenReturn(1);
     when(outputContext.getTaskAttemptNumber()).thenReturn(1);
     when(outputContext.getCounters()).thenReturn(new TezCounters());
+    when(outputContext.getContainerConfiguration()).thenReturn(new Configuration(false));
     return outputContext;
   }
 }

--- a/tez-runtime-internals/src/main/java/org/apache/tez/runtime/api/impl/TezTaskContextImpl.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/runtime/api/impl/TezTaskContextImpl.java
@@ -56,6 +56,7 @@ public abstract class TezTaskContextImpl implements TaskContext, Closeable {
   protected final String taskVertexName;
   protected final TezTaskAttemptID taskAttemptID;
   private final TezCounters counters;
+  private Configuration configuration;
   private String[] workDirs;
   private String uniqueIdentifier;
   protected final LogicalIOProcessorRuntimeTask runtimeTask;
@@ -91,6 +92,7 @@ public abstract class TezTaskContextImpl implements TaskContext, Closeable {
     Objects.requireNonNull(descriptor, "descriptor is null");
     Objects.requireNonNull(sharedExecutor, "sharedExecutor is null");
     this.dagName = dagName;
+    this.configuration = conf;
     this.taskVertexName = taskVertexName;
     this.taskAttemptID = taskAttemptID;
     this.counters = counters;
@@ -133,6 +135,11 @@ public abstract class TezTaskContextImpl implements TaskContext, Closeable {
   @Override
   public int getTaskAttemptNumber() {
     return taskAttemptID.getId();
+  }
+
+  @Override
+  public Configuration getContainerConfiguration() {
+    return configuration;
   }
 
   @Override

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/OrderedGroupedKVInput.java
@@ -28,6 +28,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.tez.common.TezUtils;
 import org.apache.tez.runtime.api.ProgressFailedException;
 import org.apache.tez.runtime.library.api.IOInterruptedException;
 import org.apache.tez.runtime.library.common.Constants;
@@ -37,7 +38,6 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.RawComparator;
-import org.apache.tez.common.TezUtils;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.counters.TaskCounter;
 import org.apache.tez.common.counters.TezCounter;
@@ -97,7 +97,7 @@ public class OrderedGroupedKVInput extends AbstractLogicalInput {
 
   @Override
   public synchronized List<Event> initialize() throws IOException {
-    this.conf = TezUtils.createConfFromUserPayload(getContext().getUserPayload());
+    this.conf = TezUtils.createConfFromBaseConfAndPayload(getContext());
 
     if (this.getNumPhysicalInputs() == 0) {
       getContext().requestInitialMemory(0l, null);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/UnorderedKVInput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/input/UnorderedKVInput.java
@@ -24,6 +24,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.tez.common.TezUtils;
 import org.apache.tez.common.TezUtilsInternal;
 import org.apache.tez.runtime.api.ProgressFailedException;
 import org.apache.tez.runtime.library.common.Constants;
@@ -36,7 +37,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.util.ReflectionUtils;
-import org.apache.tez.common.TezUtils;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.counters.TaskCounter;
 import org.apache.tez.common.counters.TezCounter;
@@ -88,7 +88,7 @@ public class UnorderedKVInput extends AbstractLogicalInput {
   @Override
   public synchronized List<Event> initialize() throws Exception {
     Preconditions.checkArgument(getNumPhysicalInputs() != -1, "Number of Inputs has not been set");
-    this.conf = TezUtils.createConfFromUserPayload(getContext().getUserPayload());
+    this.conf = TezUtils.createConfFromBaseConfAndPayload(getContext());
 
     if (getNumPhysicalInputs() == 0) {
       getContext().requestInitialMemory(0l, null);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/OrderedPartitionedKVOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/OrderedPartitionedKVOutput.java
@@ -30,6 +30,7 @@ import java.util.zip.Deflater;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 
+import org.apache.tez.common.TezUtils;
 import org.apache.tez.runtime.library.conf.OrderedPartitionedKVOutputConfig.SorterImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +41,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.tez.common.TezCommonUtils;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
-import org.apache.tez.common.TezUtils;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.runtime.api.AbstractLogicalOutput;
 import org.apache.tez.runtime.api.Event;
@@ -90,7 +90,7 @@ public class OrderedPartitionedKVOutput extends AbstractLogicalOutput {
   @Override
   public synchronized List<Event> initialize() throws IOException {
     this.startTime = System.nanoTime();
-    this.conf = TezUtils.createConfFromUserPayload(getContext().getUserPayload());
+    this.conf = TezUtils.createConfFromBaseConfAndPayload(getContext());
     this.localFs = (RawLocalFileSystem) FileSystem.getLocal(conf).getRaw();
 
     // Initializing this parametr in this conf since it is used in multiple

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/UnorderedKVOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/UnorderedKVOutput.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.tez.common.TezUtils;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +33,6 @@ import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.tez.common.TezUtils;
 import org.apache.tez.common.TezCommonUtils;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.counters.TaskCounter;
@@ -62,8 +62,9 @@ public class UnorderedKVOutput extends AbstractLogicalOutput {
 
   @VisibleForTesting
   UnorderedPartitionedKVWriter kvWriter;
-  
-  private Configuration conf;
+
+  @VisibleForTesting
+  Configuration conf;
   
   private MemoryUpdateCallbackHandler memoryUpdateCallbackHandler;
   private final AtomicBoolean isStarted = new AtomicBoolean(false);
@@ -76,7 +77,7 @@ public class UnorderedKVOutput extends AbstractLogicalOutput {
   @Override
   public synchronized List<Event> initialize()
       throws Exception {
-    this.conf = TezUtils.createConfFromUserPayload(getContext().getUserPayload());
+    this.conf = TezUtils.createConfFromBaseConfAndPayload(getContext());
     this.conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS,
         getContext().getWorkDirs());
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/UnorderedPartitionedKVOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/output/UnorderedPartitionedKVOutput.java
@@ -26,14 +26,15 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.tez.common.Preconditions;
+import com.google.common.annotations.VisibleForTesting;
 
+import org.apache.tez.common.TezUtils;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceAudience.Public;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.tez.common.TezUtils;
 import org.apache.tez.common.TezCommonUtils;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
 import org.apache.tez.common.counters.TaskCounter;
@@ -57,7 +58,8 @@ public class UnorderedPartitionedKVOutput extends AbstractLogicalOutput {
 
   private static final Logger LOG = LoggerFactory.getLogger(UnorderedPartitionedKVOutput.class);
 
-  private Configuration conf;
+  @VisibleForTesting
+  Configuration conf;
   private MemoryUpdateCallbackHandler memoryUpdateCallbackHandler;
   private UnorderedPartitionedKVWriter kvWriter;
   private final AtomicBoolean isStarted = new AtomicBoolean(false);
@@ -68,7 +70,7 @@ public class UnorderedPartitionedKVOutput extends AbstractLogicalOutput {
 
   @Override
   public synchronized List<Event> initialize() throws Exception {
-    this.conf = TezUtils.createConfFromUserPayload(getContext().getUserPayload());
+    this.conf = TezUtils.createConfFromBaseConfAndPayload(getContext());
     this.conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS, getContext().getWorkDirs());
     this.conf.setInt(TezRuntimeFrameworkConfigs.TEZ_RUNTIME_NUM_EXPECTED_PARTITIONS,
         getNumPhysicalOutputs());

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/OutputTestHelpers.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/OutputTestHelpers.java
@@ -51,10 +51,12 @@ class OutputTestHelpers {
     doReturn(200 * 1024 * 1024l).when(outputContext).getTotalMemoryAvailableToTask();
     doReturn(counters).when(outputContext).getCounters();
     doReturn(statsReporter).when(outputContext).getStatisticsReporter();
+    doReturn(new Configuration(false)).when(outputContext).getContainerConfiguration();
     return outputContext;
   }
 
-  static OutputContext createOutputContext(Configuration conf, Path workingDir) throws IOException {
+  static OutputContext createOutputContext(Configuration conf, Configuration userPayloadConf, Path workingDir)
+      throws IOException {
     OutputContext ctx = mock(OutputContext.class);
     doAnswer(new Answer<Void>() {
       @Override public Void answer(InvocationOnMock invocation) throws Throwable {
@@ -65,7 +67,8 @@ class OutputTestHelpers {
         return null;
       }
     }).when(ctx).requestInitialMemory(anyLong(), any(MemoryUpdateCallback.class));
-    doReturn(TezUtils.createUserPayloadFromConf(conf)).when(ctx).getUserPayload();
+    doReturn(conf).when(ctx).getContainerConfiguration();
+    doReturn(TezUtils.createUserPayloadFromConf(userPayloadConf)).when(ctx).getUserPayload();
     doReturn("destinationVertex").when(ctx).getDestinationVertexName();
     doReturn("UUID").when(ctx).getUniqueIdentifier();
     doReturn(new String[] { workingDir.toString() }).when(ctx).getWorkDirs();

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOnFileSortedOutput.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOnFileSortedOutput.java
@@ -44,7 +44,6 @@ import org.apache.tez.runtime.library.common.MemoryUpdateCallbackHandler;
 import org.apache.tez.runtime.library.common.sort.impl.dflt.DefaultSorter;
 import org.apache.tez.runtime.library.conf.OrderedPartitionedKVOutputConfig.SorterImpl;
 import org.apache.tez.runtime.library.partitioner.HashPartitioner;
-import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.apache.tez.runtime.library.shuffle.impl.ShuffleUserPayloads;
 import org.junit.After;
 import org.junit.Assert;
@@ -378,6 +377,7 @@ public class TestOnFileSortedOutput {
 
   private OutputContext createTezOutputContext() throws IOException {
     String[] workingDirs = { workingDir.toString() };
+    Configuration localConf = new Configuration(false);
     UserPayload payLoad = TezUtils.createUserPayloadFromConf(conf);
     DataOutputBuffer serviceProviderMetaData = new DataOutputBuffer();
     serviceProviderMetaData.writeInt(PORT);
@@ -400,6 +400,7 @@ public class TestOnFileSortedOutput {
 
     
     OutputContext context = mock(OutputContext.class);
+    doReturn(localConf).when(context).getContainerConfiguration();
     doReturn(counters).when(context).getCounters();
     doReturn(workingDirs).when(context).getWorkDirs();
     doReturn(payLoad).when(context).getUserPayload();

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOrderedPartitionedKVOutput2.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOrderedPartitionedKVOutput2.java
@@ -69,7 +69,7 @@ public class TestOrderedPartitionedKVOutput2 {
 
   @Test(timeout = 5000)
   public void testNonStartedOutput() throws IOException {
-    OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, workingDir);
+    OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, conf, workingDir);
     int numPartitions = 10;
     OrderedPartitionedKVOutput output = new OrderedPartitionedKVOutput(outputContext, numPartitions);
     output.initialize();
@@ -94,9 +94,24 @@ public class TestOrderedPartitionedKVOutput2 {
     }
   }
 
+  @Test(timeout = 5000)
+  public void testConfigMerge() throws IOException {
+    Configuration localConf = new Configuration(conf);
+    localConf.set("config-from-local", "config-from-local-value");
+    Configuration payload = new Configuration(false);
+    payload.set("config-from-payload", "config-from-payload-value");
+    OutputContext outputContext = OutputTestHelpers.createOutputContext(localConf, payload, workingDir);
+    int numPartitions = 10;
+    OrderedPartitionedKVOutput output = new OrderedPartitionedKVOutput(outputContext, numPartitions);
+    output.initialize();
+    Configuration configAfterMerge = output.conf;
+    assertEquals("config-from-local-value", configAfterMerge.get("config-from-local"));
+    assertEquals("config-from-payload-value", configAfterMerge.get("config-from-payload"));
+  }
+
   @Test(timeout = 10000)
   public void testClose() throws Exception {
-    OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, workingDir);
+    OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, conf, workingDir);
     int numPartitions = 10;
     OrderedPartitionedKVOutput output = new OrderedPartitionedKVOutput(outputContext, numPartitions);
     output.initialize();

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestUnorderedKVOutput2.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestUnorderedKVOutput2.java
@@ -93,9 +93,24 @@ public class TestUnorderedKVOutput2 {
     }
   }
 
+  @Test(timeout = 5000)
+  public void testConfigMerge() throws Exception {
+    Configuration localConf = new Configuration(conf);
+    localConf.set("config-from-local", "config-from-local-value");
+    Configuration payload = new Configuration(false);
+    payload.set("config-from-payload", "config-from-payload-value");
+    OutputContext outputContext = OutputTestHelpers.createOutputContext(localConf, payload, workingDir);
+    int numPartitions = 10;
+    UnorderedKVOutput output = new UnorderedKVOutput(outputContext, numPartitions);
+    output.initialize();
+    Configuration configAfterMerge = output.conf;
+    assertEquals("config-from-local-value", configAfterMerge.get("config-from-local"));
+    assertEquals("config-from-payload-value", configAfterMerge.get("config-from-payload"));
+  }
+
   @Test(timeout = 10000)
   public void testClose() throws Exception {
-    OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, workingDir);
+    OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, conf, workingDir);
     int numPartitions = 1;
     UnorderedKVOutput output = new UnorderedKVOutput(outputContext, numPartitions);
     output.initialize();

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestUnorderedPartitionedKVOutput2.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestUnorderedPartitionedKVOutput2.java
@@ -22,6 +22,8 @@ import java.util.BitSet;
 import java.util.List;
 
 import com.google.protobuf.ByteString;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.tez.common.TezCommonUtils;
 import org.apache.tez.common.TezUtilsInternal;
 import org.apache.tez.runtime.api.Event;
@@ -58,5 +60,22 @@ public class TestUnorderedPartitionedKVOutput2 {
     for (int i = 0; i < numPartitions; i++) {
       assertTrue(emptyPartionsBitSet.get(i));
     }
+  }
+
+  @Test
+  public void testConfigMerge() throws Exception {
+    Configuration userPayloadConf = new Configuration(false);
+    Configuration baseConf = new Configuration(false);
+
+    userPayloadConf.set("local-key", "local-value");
+    baseConf.set("base-key", "base-value");
+    OutputContext outputContext = OutputTestHelpers.createOutputContext(
+        userPayloadConf, baseConf, new Path("/"));
+    UnorderedPartitionedKVOutput output =
+        new UnorderedPartitionedKVOutput(outputContext, 1);
+    output.initialize();
+    Configuration mergedConf = output.conf;
+    assertEquals("base-value", mergedConf.get("base-key"));
+    assertEquals("local-value", mergedConf.get("local-key"));
   }
 }


### PR DESCRIPTION
Runtime components do not have access to session config. Because of that, we have to send all config options to every task eventhough a large part of the configs are in session config, just not accessible to the task. This patch makes it accessible to the tasks. All input/output/processor s can merge their user payload config to this session config. Therefore, we can send less bytes over the wire, saving time in serializing and transmitting configs client-to-am and am-to-task communication.

Change-Id: I995ed36ae0f5a71e12783802237b768d4fda56ca