### PR TITLE
TEZ-4179: [Kubernetes] Extend NodeId in tez to support unique worker identity

### DIFF
--- a/tez-dag/src/main/java/org/apache/tez/dag/app/rm/node/AMNodeEvent.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/rm/node/AMNodeEvent.java
@@ -25,15 +25,24 @@ public class AMNodeEvent extends AbstractEvent<AMNodeEventType> {
 
   private final NodeId nodeId;
   private final int schedulerId;
+  private ExtendedNodeId amNodeId;
 
   public AMNodeEvent(NodeId nodeId, int schedulerId, AMNodeEventType type) {
     super(type);
     this.nodeId = nodeId;
     this.schedulerId = schedulerId;
+    this.amNodeId = null;
+  }
+
+  public AMNodeEvent(ExtendedNodeId amNodeId, int schedulerId, AMNodeEventType type) {
+    super(type);
+    this.nodeId = null;
+    this.schedulerId = schedulerId;
+    this.amNodeId = amNodeId;
   }
 
   public NodeId getNodeId() {
-    return this.nodeId;
+    return amNodeId == null ? this.nodeId : this.amNodeId;
   }
 
   public int getSchedulerId() {

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/rm/node/ExtendedNodeId.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/rm/node/ExtendedNodeId.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.dag.app.rm.node;
+
+import java.util.Objects;
+
+import org.apache.hadoop.yarn.api.records.NodeId;
+import org.apache.tez.common.Preconditions;
+
+/**
+ * ExtendedNodeId extends NodeId with unique identifier in addition to hostname and port.
+ */
+public class ExtendedNodeId extends NodeId {
+  private NodeId nodeId;
+  private String host;
+  private int port;
+  private String uniqueIdentifier;
+
+  public ExtendedNodeId(NodeId nodeId, String uniqueIdentifier) {
+    Preconditions.checkArgument(nodeId != null);
+    this.nodeId = nodeId;
+    this.uniqueIdentifier = uniqueIdentifier == null ? "" : uniqueIdentifier.trim();
+  }
+
+  @Override
+  public String getHost() {
+    return nodeId.getHost();
+  }
+
+  @Override
+  protected void setHost(final String host) {
+    this.host = host;
+    build();
+  }
+
+  @Override
+  public int getPort() {
+    return nodeId.getPort();
+  }
+
+  @Override
+  protected void setPort(final int port) {
+    this.port = port;
+    build();
+  }
+
+  @Override
+  protected void build() {
+    this.nodeId = NodeId.newInstance(host, port);
+  }
+
+  @Override
+  public String toString() {
+    if (!uniqueIdentifier.isEmpty()) {
+      return super.toString() + ":" + uniqueIdentifier;
+    }
+    return super.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    if (!uniqueIdentifier.isEmpty()) {
+      return super.hashCode() + 31 * uniqueIdentifier.hashCode();
+    }
+    return super.hashCode();
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (obj == null) {
+      return false;
+    } else if (this.getClass() != obj.getClass()) {
+      return false;
+    } else {
+      ExtendedNodeId amNodeId = (ExtendedNodeId) obj;
+      return super.equals(obj) && Objects.equals(uniqueIdentifier, amNodeId.uniqueIdentifier);
+    }
+  }
+}


### PR DESCRIPTION
In kubernetes environment where pods can have same host name and port, there can be situations where node trackers could be retaining old instance of the pod in its cache. In case of Hive LLAP, where the llap tez task scheduler maintains the membership of nodes based on zookeeper registry events there can be cases where NODE_ADDED followed by NODE_REMOVED event could end up removing the node/host from node trackers because of stable hostname and service port. The NODE_REMOVED event in this case is old stale event of the already dead pod but ZK will send only after session timeout (in case of non-graceful shutdown). If this sequence of events happen, a node/host is completely lost form the schedulers perspective. 

To support this scenario, tez can extend yarn's NodeId to include uniqueIdentifier. Llap task scheduler can construct the container object with this new NodeId that includes uniqueIdentifier as well so that stale events like above will only remove the host/node that matches the old uniqueIdentifier. 