### PR TITLE
fs.getFukeStatus NullPointException deal

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/client/TezClientUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/client/TezClientUtils.java
@@ -1047,6 +1047,10 @@ public class TezClientUtils {
     }
 
     while (pathComponent != null) {
+      int depth = pathComponent.depth();
+      if (0 == depth) {
+        break;
+      }
       if (!fs.getFileStatus(pathComponent).getPermission().getOtherAction().implies(permission)) {
         return false;
       }


### PR DESCRIPTION
when the path is root and it has the excute permisson, it will continue get parent path to judge permisson. but the parent path of root will cause the NullPointException.

the statck trace:

```
2020-05-15T14:57:17,544 ERROR [HiveServer2-Background-Pool: Thread-117] exec.Task: Failed to execute tez graph.
org.apache.hadoop.ipc.RemoteException: java.lang.NullPointerException

        at org.apache.hadoop.ipc.Client.call(Client.java:1476) ~[hadoop-common-2.7.7.jar:?]
        at org.apache.hadoop.ipc.Client.call(Client.java:1413) ~[hadoop-common-2.7.7.jar:?]
        at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:229) ~[hadoop-common-2.7.7.jar:?]
        at com.sun.proxy.$Proxy30.getFileInfo(Unknown Source) ~[?:?]
        at org.apache.hadoop.hdfs.protocolPB.ClientNamenodeProtocolTranslatorPB.getFileInfo(ClientNamenodeProtocolTranslatorPB.java:776) ~[hadoop-hdfs-2.7.7.jar:?]
        at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source) ~[?:?]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_221]
        at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_221]
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:191) ~[hadoop-common-2.7.7.jar:?]
        at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:102) ~[hadoop-common-2.7.7.jar:?]
        at com.sun.proxy.$Proxy31.getFileInfo(Unknown Source) ~[?:?]
        at org.apache.hadoop.hdfs.DFSClient.getFileInfo(DFSClient.java:2117) ~[hadoop-hdfs-2.7.7.jar:?]
        at org.apache.hadoop.hdfs.DistributedFileSystem$22.doCall(DistributedFileSystem.java:1305) ~[hadoop-hdfs-2.7.7.jar:?]
        at org.apache.hadoop.hdfs.DistributedFileSystem$22.doCall(DistributedFileSystem.java:1301) ~[hadoop-hdfs-2.7.7.jar:?]
        at org.apache.hadoop.fs.FileSystemLinkResolver.resolve(FileSystemLinkResolver.java:81) ~[hadoop-common-2.7.7.jar:?]
        at org.apache.hadoop.hdfs.DistributedFileSystem.getFileStatus(DistributedFileSystem.java:1301) ~[hadoop-hdfs-2.7.7.jar:?]
        at org.apache.tez.client.TezClientUtils.checkAncestorPermissionsForAllUsers(TezClientUtils.java:1033) ~[tez-api-0.9.2.jar:0.9.2]
        at org.apache.tez.client.TezClientUtils.addLocalResources(TezClientUtils.java:277) ~[tez-api-0.9.2.jar:0.9.2]
        at org.apache.tez.client.TezClientUtils.setupTezJarsLocalResources(TezClientUtils.java:185) ~[tez-api-0.9.2.jar:0.9.2]
        at org.apache.tez.client.TezClient.getTezJarResources(TezClient.java:1156) ~[tez-api-0.9.2.jar:0.9.2]
        at org.apache.tez.client.TezClient.setupApplicationContext(TezClient.java:473) ~[tez-api-0.9.2.jar:0.9.2]
        at org.apache.tez.client.TezClient.start(TezClient.java:401) ~[tez-api-0.9.2.jar:0.9.2]
        at org.apache.hadoop.hive.ql.exec.tez.TezSessionState.startSessionAndContainers(TezSessionState.java:376) ~[hive-exec-2.3.6.jar:2.3.6]
        at org.apache.hadoop.hive.ql.exec.tez.TezSessionState.openInternal(TezSessionState.java:323) ~[hive-exec-2.3.6.jar:2.3.6]
        at org.apache.hadoop.hive.ql.exec.tez.TezSessionPoolManager$TezSessionPoolSession.openInternal(TezSessionPoolManager.java:703) ~[hive-exec-2.3.6.jar:2.3.6]
        at org.apache.hadoop.hive.ql.exec.tez.TezSessionState.open(TezSessionState.java:196) ~[hive-exec-2.3.6.jar:2.3.6]
        at org.apache.hadoop.hive.ql.exec.tez.TezTask.updateSession(TezTask.java:303) ~[hive-exec-2.3.6.jar:2.3.6]
        at org.apache.hadoop.hive.ql.exec.tez.TezTask.execute(TezTask.java:168) ~[hive-exec-2.3.6.jar:2.3.6]
        at org.apache.hadoop.hive.ql.exec.Task.executeTask(Task.java:199) ~[hive-exec-2.3.6.jar:2.3.6]
```