### PR TITLE
TEZ-4183: Failed event AM propagation logic for Tez Unordered fetcher

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputReadErrorEvent.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputReadErrorEvent.java
@@ -51,26 +51,37 @@ public final class InputReadErrorEvent extends Event {
    */
   private final int numFailures;
 
-  private InputReadErrorEvent(final String diagnostics, final int index,
-                              final int version, final int numFailures) {
+  /**
+   * Disk read related error
+   */
+  private final boolean isReadError;
+
+  private InputReadErrorEvent(final String diagnostics, final int index, final int version,
+      final int numFailures, final boolean isReadError) {
     super();
     this.diagnostics = diagnostics;
     this.index = index;
     this.version = version;
     this.numFailures = numFailures;
+    this.isReadError = isReadError;
   }
 
   public static InputReadErrorEvent create(String diagnostics, int index,
                                            int version) {
-    return create(diagnostics, index, version, 1);
+    return create(diagnostics, index, version, 1, false);
+  }
+
+  public static InputReadErrorEvent create(String diagnostics, int index,
+                                           int version, boolean isReadError) {
+    return create(diagnostics, index, version, 1, isReadError);
   }
 
   /**
    * Create an InputReadErrorEvent.
    */
   public static InputReadErrorEvent create(final String diagnostics, final int index,
-      final int version, final int numFailures) {
-    return new InputReadErrorEvent(diagnostics, index, version, numFailures);
+      final int version, final int numFailures, final boolean isReadError) {
+    return new InputReadErrorEvent(diagnostics, index, version, numFailures, isReadError);
   }
 
   public String getDiagnostics() {
@@ -92,9 +103,16 @@ public final class InputReadErrorEvent extends Event {
     return numFailures;
   }
 
+  /**
+   * @return is its a Disk error
+   */
+  public boolean isReadError() {
+    return isReadError;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(index, version);
+    return Objects.hash(index, version, isReadError);
   }
 
   @Override
@@ -106,6 +124,7 @@ public final class InputReadErrorEvent extends Event {
       return false;
     }
     InputReadErrorEvent that = (InputReadErrorEvent) o;
-    return index == that.index && version == that.version;
+    return index == that.index && version == that.version &&
+            isReadError == that.isReadError;
   }
 }

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/FetcherCallback.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/FetcherCallback.java
@@ -24,10 +24,10 @@ import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 
 public interface FetcherCallback {
 
-  public void fetchSucceeded(String host, InputAttemptIdentifier srcAttemptIdentifier,
+  void fetchSucceeded(String host, InputAttemptIdentifier srcAttemptIdentifier,
       FetchedInput fetchedInput, long fetchedBytes, long decompressedLength, long copyDuration)
       throws IOException;
   
-  public void fetchFailed(String host, InputAttemptIdentifier srcAttemptIdentifier, boolean connectFailed);
+  void fetchFailed(String host, InputAttemptIdentifier srcAttemptIdentifier, boolean readError, boolean connectFailed);
 
 }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/TestFetcher.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/TestFetcher.java
@@ -79,7 +79,7 @@ public class TestFetcher {
     Fetcher fetcher = spy(builder.build());
 
     FetchResult fr = new FetchResult(HOST, PORT, 0, 1, Arrays.asList(srcAttempts));
-    Fetcher.HostFetchResult hfr = new Fetcher.HostFetchResult(fr, srcAttempts, false);
+    Fetcher.HostFetchResult hfr = new Fetcher.HostFetchResult(fr, srcAttempts, false, false);
     doReturn(hfr).when(fetcher).setupLocalDiskFetch();
     doReturn(null).when(fetcher).doHttpFetch();
     doNothing().when(fetcher).shutdown();
@@ -206,7 +206,7 @@ public class TestFetcher {
     doNothing().when(fetcher).shutdown();
     doNothing().when(callback).fetchSucceeded(anyString(), any(InputAttemptIdentifier.class),
         any(FetchedInput.class), anyLong(), anyLong(), anyLong());
-    doNothing().when(callback).fetchFailed(anyString(), any(InputAttemptIdentifier.class), eq(false));
+    doNothing().when(callback).fetchFailed(anyString(), any(InputAttemptIdentifier.class), eq(false), eq(false));
 
     FetchResult fetchResult = fetcher.call();
 
@@ -216,8 +216,8 @@ public class TestFetcher {
     for (int i : sucessfulAttempts) {
       verifyFetchSucceeded(callback, srcAttempts[i], conf);
     }
-    verify(callback).fetchFailed(eq(HOST), eq(srcAttempts[FIRST_FAILED_ATTEMPT_IDX]), eq(false));
-    verify(callback).fetchFailed(eq(HOST), eq(srcAttempts[SECOND_FAILED_ATTEMPT_IDX]), eq(false));
+    verify(callback).fetchFailed(eq(HOST), eq(srcAttempts[FIRST_FAILED_ATTEMPT_IDX]), eq(false), eq(false));
+    verify(callback).fetchFailed(eq(HOST), eq(srcAttempts[SECOND_FAILED_ATTEMPT_IDX]), eq(false), eq(false));
 
     Assert.assertEquals("fetchResult host", fetchResult.getHost(), HOST);
     Assert.assertEquals("fetchResult partition", fetchResult.getPartition(), partition);


### PR DESCRIPTION
New event propagation  logic for Tez unordered fetcher.
Inform AM:
       *    - Immediately if maxTimeToWaitForReportMillis is 0
       *    - When time exceeded SHUFFLE_BATCH_WAIT ms (batch events)
       *    - When more than THRESHOLD readErrors occurred for a particular task_attempt
       *    maxFetchFailuresBeforeReporting (5) (batch events)
Extending InputReadErrorEvent and HostFetchResult to track diskRead errors
ReporterCallable thread now sends events to AM either when there is a signal or time exceeded SHUFFLE_BATCH_WAIT