### PR TITLE
TEZ-4200: Precommit docker image build fails

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -18,7 +18,7 @@
 # Dockerfile for installing the necessary dependencies for building Hadoop.
 # See BUILDING.txt.
 
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 WORKDIR /root
 
@@ -55,7 +55,6 @@ RUN apt-get -q update \
         git \
         gnupg-agent \
         libbz2-dev \
-        libcurl4-openssl-dev \
         libfuse-dev \
         libprotobuf-dev \
         libprotoc-dev \
@@ -75,7 +74,6 @@ RUN apt-get -q update \
         python-wheel \
         rsync \
         software-properties-common \
-        snappy \
         sudo \
         valgrind \
         zlib1g-dev \
@@ -180,7 +178,6 @@ RUN apt-get -q update \
     && apt-get install -y --no-install-recommends nodejs npm \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && ln -s /usr/bin/nodejs /usr/bin/node \
     && npm install npm@latest -g \
     && npm install -g jshint
 


### PR DESCRIPTION
It fails due to an obscure pip error while installing pylint. Pip maintainers recommend upgrade to fix it. ubuntu:xenial does not have newer packages. ubuntu:focal does not have python2 natively. ubuntu:bionic is the middleground. We should upgrade to python3 and then ubuntu:focal in the future.

Change-Id: I9ae18ccc40f5690113dd590a0dcc3378d7cb011c