### PR TITLE
TEZ-4188 Link to NodeManager Logs doesn't consider yarnProtocol

### DIFF
--- a/tez-ui/src/main/webapp/app/serializers/dag.js
+++ b/tez-ui/src/main/webapp/app/serializers/dag.js
@@ -75,8 +75,9 @@ function getContainerLogs(source) {
   for (var key in otherinfo) {
     if (key.indexOf('inProgressLogsURL_') === 0) {
       let logs = Ember.get(source, 'otherinfo.' + key);
-      if (logs.indexOf('http') !== 0) {
-        logs = 'http://' + logs;
+      if (logs.indexOf("://") === -1) {
+        let yarnProtocol = this.get('env.app.yarnProtocol');
+        logs = yarnProtocol + '://' + logs;
       }
       let attemptID = key.substring(18);
       containerLogs.push({


### PR DESCRIPTION
Even if yarnProtocol of configs.env is set to 'https', the link to NodeManager 'Logs' always use 'http'.