### PR TITLE
Solved the problem of incorrect printing information.

### DIFF
--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/TezSplitGrouper.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/TezSplitGrouper.java
@@ -253,18 +253,20 @@ public abstract class TezSplitGrouper {
          * This is a workaround for systems like S3 that pass the same
          * fake hostname for all splits.
          */
-        if (!allSplitsHaveLocalhost) {
-          desiredNumSplits = newDesiredNumSplits;
-        }
 
         LOG.info("Desired splits: " + desiredNumSplits + " too large. " +
             " Desired splitLength: " + lengthPerGroup +
             " Min splitLength: " + minLengthPerGroup +
             " New desired splits: " + newDesiredNumSplits +
-            " Final desired splits: " + desiredNumSplits +
+            " Final desired splits: " + newDesiredNumSplits +
             " All splits have localhost: " + allSplitsHaveLocalhost +
             " Total length: " + totalLength +
             " Original splits: " + originalSplits.size());
+
+        if (!allSplitsHaveLocalhost) {
+          desiredNumSplits = newDesiredNumSplits;
+        }
+
       }
     }
 


### PR DESCRIPTION
I was a bit confused when i saw the log print below .Through calculation and analysis ,it is found that the information is not printed correctly because the parameter assignment time is too early.

![image](https://user-images.githubusercontent.com/32100330/93660690-01243a80-fa84-11ea-87e5-d26891f57a8f.png)


After modification:

![image](https://user-images.githubusercontent.com/32100330/93660697-1c8f4580-fa84-11ea-838e-dcca7c88624b.png)


PS:  Desired splits * Desired splitLength = totalLength