### PR TITLE
TEZ-4245: Optimise split grouping when locality information is set to…

### DIFF
--- a/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/TezSplitGrouper.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/grouper/TezSplitGrouper.java
@@ -198,14 +198,12 @@ public abstract class TezSplitGrouper {
       String[] locations = locationProvider.getPreferredLocations(split);
       if (locations == null || locations.length == 0) {
         locations = emptyLocations;
-        allSplitsHaveLocalhost = false;
       }
       for (String location : locations ) {
         if (location == null) {
           location = emptyLocation;
-          allSplitsHaveLocalhost = false;
         }
-        if (!location.equalsIgnoreCase(localhost)) {
+        if (!location.equalsIgnoreCase(localhost) && !location.equalsIgnoreCase(emptyLocation)) {
           allSplitsHaveLocalhost = false;
         }
         distinctLocations.put(location, null);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TEZ-4245

Split information without any locality information (localhost/null/empty) should be treated equally, so that split grouping can do meaningful grouping based on cluster size. This is to avoid creating small split groups, which can significantly increase runtime due to sequential processing (i.e same map task getting lots of inputs and system ends up spending time in open/seek/close on objectstores).