### PR TITLE
TEZ-4246[WIP]: Avoid uneven local disk usage for spills

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/task/local/output/TezTaskOutput.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/task/local/output/TezTaskOutput.java
@@ -123,6 +123,16 @@ public abstract class TezTaskOutput {
       throws IOException;
 
   /**
+   * Create a local output spill index file name on the same volume.
+   * The intended usage of this method is to write the index file on the same volume as the
+   * associated spill file.
+   *
+   * @param existing the path of the associated spill file
+   * @return path the path to write the spill index file for the specific spill file
+   */
+  public abstract Path getSpillIndexFileForWriteInVolume(Path existing);
+
+  /**
    * Create a local input file name.
    *
    * @param srcIdentifier The identifier for the source

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/task/local/output/TezTaskOutputFiles.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/task/local/output/TezTaskOutputFiles.java
@@ -234,6 +234,30 @@ public class TezTaskOutputFiles extends TezTaskOutput {
     return lDirAlloc.getLocalPathForWrite(outputDir.toString(), size, conf);
   }
 
+  /**
+   * Create a local output spill index file name on the same volume.
+   * The intended usage of this method is to write the index file on the same volume as the
+   * associated spill file.
+   *
+   * ${appDir}/output/${uniqueId}_${spillNumber}/file.out.index
+   * e.g.
+   * existing:
+   * application_1422270854961_0027/output/attempt_1422270854961_0027_1_00_000001_0_10003_1/file.out
+   *
+   * returnValue:
+   * application_1422270854961_0027/output/attempt_1422270854961_0027_1_00_000001_0_10003_1/file.out.index
+   *
+   * @param existing the path of the associated spill file
+   * @return path the path to write the spill index file for the specific spill file
+   */
+  @Override
+  public Path getSpillIndexFileForWriteInVolume(Path existing) {
+    Preconditions.checkArgument(existing.getParent() != null, "Parent directory can not be null");
+    Preconditions.checkArgument(
+        existing.getName().equals(Constants.TEZ_RUNTIME_TASK_OUTPUT_FILENAME_STRING),
+        "The given path is not a spill file " + existing);
+    return existing.suffix(Constants.TEZ_RUNTIME_TASK_OUTPUT_INDEX_SUFFIX_STRING);
+  }
 
   /**
    * Create a local input file name.

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/writers/UnorderedPartitionedKVWriter.java
@@ -1045,8 +1045,9 @@ public class UnorderedPartitionedKVWriter extends BaseUnorderedPartitionedKVWrit
         outputFilePath = outputFileHandler.getSpillFileForWrite(spillNumber, spillSize);
       }
     } else {
-      outputFilePath = outputFileHandler.getSpillFileForWrite(spillNumber, spillSize);
-      indexFilePath  = outputFileHandler.getSpillIndexFileForWrite(spillNumber, indexFileSizeEstimate);
+      outputFilePath = outputFileHandler
+          .getSpillFileForWrite(spillNumber, spillSize + indexFileSizeEstimate);
+      indexFilePath  = outputFileHandler.getSpillIndexFileForWriteInVolume(outputFilePath);
     }
 
     return new SpillPathDetails(outputFilePath, indexFilePath, spillNumber);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TEZ-4246

In case that there are just two disks, the current implementation is likely to use one of them to write spill data and the other one to store the index files. All `file.out`, bigger than `file.out.index`, are written on the same disk.

1. write spill data on `/data/0/..../file.out`
2. write a spill index file on the other directory, `/data/1/.../file.out.index`
3. write spill data on `/data/0/..../file.out`
4. ...

This PR would change the behavior so as to utilize both disks more proportionally.

1. write spill data on `/data0/..../file.out`
2. write the spill index file on the same directory, `/data/0/.../file.out
3. write spill data on `/data1/..../file.out`
4. ...

Index files are relatively small and I think it's reasonable to put it on the same directory as `file.out`.