### PR TITLE
TEZ-4247 Disable UI build and tests on ARM64 CPU architecture

### DIFF
--- a/tez-ui/pom.xml
+++ b/tez-ui/pom.xml
@@ -86,6 +86,33 @@
         <allow-root-build>--allow-root=true</allow-root-build>
       </properties>
     </profile>
+    <profile>
+      <!-- Disables UI build and tests on ARM64 because there is no binary for PhantomJS -->
+      <id>arm64</id>
+      <activation>
+        <os>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <build>


### PR DESCRIPTION
PhantomJS is not available for aarch64 and it will never be because it is not maintained for few years now.

https://issues.apache.org/jira/browse/TEZ-4247