### PR TITLE
TEZ-4302: NullPointerException in CodecUtils when bufferSizeProp is null

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/TezRuntimeUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/TezRuntimeUtils.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.tez.dag.api.TezUncheckedException;
 import org.apache.tez.runtime.api.OutputContext;
 import org.apache.tez.runtime.api.TaskContext;
@@ -269,7 +270,9 @@ public class TezRuntimeUtils {
   public static String getBufferSizeProperty(String className) {
     switch (className) {
     case "org.apache.hadoop.io.compress.DefaultCodec":
-      return "io.file.buffer.size";
+    case "org.apache.hadoop.io.compress.BZip2Codec":
+    case "org.apache.hadoop.io.compress.GzipCodec":
+      return CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_KEY;
     case "org.apache.hadoop.io.compress.SnappyCodec":
       return CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_KEY;
     case "org.apache.hadoop.io.compress.ZStandardCodec":

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/utils/CodecUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/utils/CodecUtils.java
@@ -78,7 +78,8 @@ public final class CodecUtils {
       throws IOException {
     String bufferSizeProp = TezRuntimeUtils.getBufferSizeProperty(codec);
     Configurable configurableCodec = (Configurable) codec;
-    int originalSize = configurableCodec.getConf().getInt(bufferSizeProp, DEFAULT_BUFFER_SIZE);
+    int originalSize = bufferSizeProp == null ? DEFAULT_BUFFER_SIZE :
+            configurableCodec.getConf().getInt(bufferSizeProp, DEFAULT_BUFFER_SIZE);
 
     CompressionInputStream in = null;
 


### PR DESCRIPTION
Issue: [TEZ-4302](https://issues.apache.org/jira/browse/TEZ-4302) NullPointerException in CodecUtils when bufferSizeProp is null