### PR TITLE
TEZ-4305: Invoke hflush, only if the stream supports it

### DIFF
--- a/tez-common/src/main/java/org/apache/tez/common/StreamHelper.java
+++ b/tez-common/src/main/java/org/apache/tez/common/StreamHelper.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.common;
+
+import org.apache.hadoop.fs.StreamCapabilities;
+import org.apache.hadoop.fs.Syncable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public final class StreamHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StreamHelper.class);
+
+  private StreamHelper() {
+  }
+
+  public static void hflushIfSupported(Syncable syncable) throws IOException {
+    if (syncable instanceof StreamCapabilities) {
+      if (((StreamCapabilities) syncable).hasCapability(StreamCapabilities.HFLUSH)) {
+        syncable.hflush();
+      } else {
+        // it would be no-op, if hflush is not supported by a given writer.
+        LOG.debug("skipping hflush, since the writer doesn't support it");
+      }
+    } else {
+      // this is done for backward compatibility in order to make it work with
+      // older versions of Hadoop.
+      syncable.hflush();
+    }
+  }
+}

--- a/tez-dag/src/main/java/org/apache/tez/dag/history/logging/impl/SimpleHistoryLoggingService.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/history/logging/impl/SimpleHistoryLoggingService.java
@@ -23,6 +23,7 @@ import java.util.Random;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.tez.common.StreamHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -130,7 +131,7 @@ public class SimpleHistoryLoggingService extends HistoryLoggingService {
     }
     try {
       if (outputStream != null) {
-        outputStream.hflush();
+        StreamHelper.hflushIfSupported(outputStream);
         outputStream.close();
       }
     } catch (IOException ioe) {

--- a/tez-plugins/tez-protobuf-history-plugin/src/main/java/org/apache/tez/dag/history/logging/proto/ProtoMessageWriter.java
+++ b/tez-plugins/tez-protobuf-history-plugin/src/main/java/org/apache/tez/dag/history/logging/proto/ProtoMessageWriter.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.io.SequenceFile.Writer;
 
 import com.google.protobuf.MessageLite;
 import com.google.protobuf.Parser;
+import org.apache.tez.common.StreamHelper;
 
 public class ProtoMessageWriter<T extends MessageLite> implements Closeable {
   private final Path filePath;
@@ -61,7 +62,7 @@ public class ProtoMessageWriter<T extends MessageLite> implements Closeable {
   }
 
   public void hflush() throws IOException {
-    writer.hflush();
+    StreamHelper.hflushIfSupported(writer);
   }
 
   @Override


### PR DESCRIPTION
Following exception is thrown whenever we do ProtoMessageWriter.hflush on S3, which internally calls S3ABlockOutputStream.hflush which is not supported and it throws java.lang.UnsupportedOperationException. 

bdffe22d96ae [mdc@18060 class="yarn.YarnUncaughtExceptionHandler" level="ERROR" thread="HistoryEventHandlingThread"] Thread Thread[HistoryEventHandlingThread, 5,main] threw an Exception.^Mjava.lang.UnsupportedOperationException: S3A streams are not Syncable^M at org.apache.hadoop.fs.s3a.S3ABlockOutputStream.hflush(S3ABlockOutputStream.java:657)^M at org.apache.hadoop.fs.FS DataOutputStream.hflush(FSDataOutputStream.java:136)^M at org.apache.hadoop.io.SequenceFile$Writer.hflush(SequenceFile.java:1367)^M at org.apache.tez.dag.history.logging.proto.ProtoMessageWriter.hflush(ProtoMessageWr iter.java:64)^M at org.apache.tez.dag.history.logging.proto.ProtoHistoryLoggingService.finishCurrentDag(ProtoHistoryLoggingService.java:239)^M at org.apache.tez.dag.history.logging.proto.ProtoHistoryLoggingService.han dleEvent(ProtoHistoryLoggingService.java:198)^M at org.apache.tez.dag.history.logging.proto.ProtoHistoryLoggingService.loop(ProtoHistoryLoggingService.java:153)^M at java.lang.Thread.run(Thread.java:748)^M

In order to fix this issue, we should first check if the method is supported or not using StreamCapabilities, before invoking it. 