### PR TITLE
Could org.apache.tez:hadoop-shim:0.10.1-SNAPSHOT drop off redundant dependencies to loose weight? 

### DIFF
--- a/hadoop-shim/pom.xml
+++ b/hadoop-shim/pom.xml
@@ -36,10 +36,46 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+		  </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-servlet</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>jackson-jaxrs</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.kerby</groupId>
+          <artifactId>kerby-xdr</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-json</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
@abstractdog Hi, I am a user of project **_org.apache.tez:hadoop-shim:0.10.1-SNAPSHOT_**. I found that its pom file introduced **_82_** dependencies. However, among them, **_9_** libraries (**_10%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_org.apache.tez:hadoop-shim:0.10.1-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
javax.xml.bind:jaxb-api:jar:2.2.11:compile
javax.servlet:javax.servlet-api:jar:3.1.0:compile
com.sun.jersey:jersey-servlet:jar:1.19:compile
com.sun.jersey:jersey-json:jar:1.19:compile
org.codehaus.jettison:jettison:jar:1.3.4:compile
com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
org.codehaus.jackson:jackson-jaxrs:jar:1.9.2:compile
org.codehaus.jackson:jackson-xc:jar:1.9.2:compile
org.apache.kerby:kerby-xdr:jar:1.0.1:compile
</code></pre>