### PR TITLE
TEZ-4338: Tez should consider node information to realize OUTPUT_LOST as early as possible - upstream(mapper) problems

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/dag/api/TezConfiguration.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/TezConfiguration.java
@@ -301,6 +301,21 @@ public class TezConfiguration extends Configuration {
   public static final int TEZ_AM_MAX_ALLOWED_TIME_FOR_TASK_READ_ERROR_SEC_DEFAULT = 300;
 
   /**
+   * int value. The maximum number of distinct downstream hosts that can report a fetch failure
+   * for a single upstream host before the upstream task attempt is marked as failed (so blamed for
+   * the fetch failure). E.g. if this set to 1, in case of 2 different hosts reporting fetch failure
+   * for the same upstream host the upstream task is immediately blamed for the fetch failure.
+   * TODO: could this be proportional to the number of hosts running consumer/downstream tasks ?
+   *
+   * Expert level setting.
+   */
+  @ConfigurationScope(Scope.AM)
+  @ConfigurationProperty(type="integer")
+  public static final String TEZ_AM_MAX_ALLOWED_DOWNSTREAM_HOSTS_REPORTING_FETCH_FAILURE =
+      TEZ_AM_PREFIX + "max.allowed.downstream.hosts.reporting.fetch.failure";
+  public static final int TEZ_AM_MAX_ALLOWED_DOWNSTREAM_HOSTS_REPORTING_FETCH_FAILURE_DEFAULT = 1;
+
+  /**
    * Boolean value. Determines when the final outputs to data sinks are committed. Commit is an
    * output specific operation and typically involves making the output visible for consumption.
    * If the config is true, then the outputs are committed at the end of DAG completion after all

--- a/tez-api/src/main/java/org/apache/tez/dag/api/TezConfiguration.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/TezConfiguration.java
@@ -301,19 +301,22 @@ public class TezConfiguration extends Configuration {
   public static final int TEZ_AM_MAX_ALLOWED_TIME_FOR_TASK_READ_ERROR_SEC_DEFAULT = 300;
 
   /**
-   * int value. The maximum number of distinct downstream hosts that can report a fetch failure
-   * for a single upstream host before the upstream task attempt is marked as failed (so blamed for
-   * the fetch failure). E.g. if this set to 1, in case of 2 different hosts reporting fetch failure
-   * for the same upstream host the upstream task is immediately blamed for the fetch failure.
-   * TODO: could this be proportional to the number of hosts running consumer/downstream tasks ?
+   * Double value. Assuming that a certain number of downstream hosts reported fetch failure for a
+   * given upstream host, this config drives the max allowed ratio of (downstream hosts) / (all hosts).
+   * The total number of used hosts are tracked by AMNodeTracker, which divides the distinct number of
+   * downstream hosts blaming source(upstream) tasks in a given vertex. If the fraction is beyond this
+   * limit, the upstream task attempt is marked as failed (so blamed for the fetch failure).
+   * E.g. if this set to 0.2, in case of 3 different hosts reporting fetch failure
+   * for the same upstream host in a cluster which currently utilizes 10 nodes, the upstream task
+   * is immediately blamed for the fetch failure.
    *
    * Expert level setting.
    */
   @ConfigurationScope(Scope.AM)
   @ConfigurationProperty(type="integer")
-  public static final String TEZ_AM_MAX_ALLOWED_DOWNSTREAM_HOSTS_REPORTING_FETCH_FAILURE =
-      TEZ_AM_PREFIX + "max.allowed.downstream.hosts.reporting.fetch.failure";
-  public static final int TEZ_AM_MAX_ALLOWED_DOWNSTREAM_HOSTS_REPORTING_FETCH_FAILURE_DEFAULT = 1;
+  public static final String TEZ_AM_MAX_ALLOWED_DOWNSTREAM_HOST_FAILURES_FRACTION =
+      TEZ_AM_PREFIX + "max.allowed.downstream.host.failures.fraction";
+  public static final double TEZ_AM_MAX_ALLOWED_DOWNSTREAM_HOST_FAILURES_FRACTION_DEFAULT = 0.2;
 
   /**
    * Boolean value. Determines when the final outputs to data sinks are committed. Commit is an

--- a/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputReadErrorEvent.java
+++ b/tez-api/src/main/java/org/apache/tez/runtime/api/events/InputReadErrorEvent.java
@@ -62,8 +62,13 @@ public final class InputReadErrorEvent extends Event {
    */
   private final boolean isDiskErrorAtSource;
 
+  /**
+   * The localhostName of the destination task attempt.
+   */
+  private final String destinationLocalhostName;
+
   private InputReadErrorEvent(final String diagnostics, final int index, final int version,
-      final int numFailures, boolean isLocalFetch, boolean isDiskErrorAtSource) {
+      final int numFailures, boolean isLocalFetch, boolean isDiskErrorAtSource, String destinationLocalhostName) {
     super();
     this.diagnostics = diagnostics;
     this.index = index;
@@ -71,24 +76,30 @@ public final class InputReadErrorEvent extends Event {
     this.numFailures = numFailures;
     this.isLocalFetch = isLocalFetch;
     this.isDiskErrorAtSource = isDiskErrorAtSource;
+    this.destinationLocalhostName = destinationLocalhostName;
   }
 
   public static InputReadErrorEvent create(String diagnostics, int index, int version,
       boolean isLocalFetch, boolean isDiskErrorAtSource) {
-    return create(diagnostics, index, version, 1, isLocalFetch, isDiskErrorAtSource);
+    return create(diagnostics, index, version, 1, isLocalFetch, isDiskErrorAtSource, null);
   }
 
   public static InputReadErrorEvent create(String diagnostics, int index, int version) {
-    return create(diagnostics, index, version, 1, false, false);
+    return create(diagnostics, index, version, 1, false, false, null);
+  }
+
+  public static InputReadErrorEvent create(String diagnostics, int index, int version, boolean isLocalFetch,
+      boolean isDiskErrorAtSource, String destinationLocalhostName) {
+    return create(diagnostics, index, version, 1, isLocalFetch, isDiskErrorAtSource, destinationLocalhostName);
   }
 
   /**
    * Create an InputReadErrorEvent.
    */
-  public static InputReadErrorEvent create(final String diagnostics, final int index,
-      final int version, final int numFailures, boolean isLocalFetch, boolean isDiskErrorAtSource) {
-    return new InputReadErrorEvent(diagnostics, index, version, numFailures, isLocalFetch,
-        isDiskErrorAtSource);
+  public static InputReadErrorEvent create(final String diagnostics, final int index, final int version,
+      final int numFailures, boolean isLocalFetch, boolean isDiskErrorAtSource, String destinationLocalhostName) {
+    return new InputReadErrorEvent(diagnostics, index, version, numFailures, isLocalFetch, isDiskErrorAtSource,
+        destinationLocalhostName);
   }
 
   public String getDiagnostics() {
@@ -116,6 +127,10 @@ public final class InputReadErrorEvent extends Event {
 
   public boolean isDiskErrorAtSource() {
     return isDiskErrorAtSource;
+  }
+
+  public String getDestinationLocalhostName(){
+    return destinationLocalhostName;
   }
 
   @Override

--- a/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerLauncherContext.java
+++ b/tez-api/src/main/java/org/apache/tez/serviceplugins/api/ContainerLauncherContext.java
@@ -80,7 +80,7 @@ public interface ContainerLauncherContext extends ServicePluginContextBase {
    * Get the number of nodes being handled by the specified source
    *
    * @param sourceName the relevant source name
-   * @return the initial payload
+   * @return the number of nodes
    */
   int getNumNodes(String sourceName);
 

--- a/tez-api/src/main/proto/Events.proto
+++ b/tez-api/src/main/proto/Events.proto
@@ -41,6 +41,7 @@ message InputReadErrorEventProto {
   optional int32 version = 3;
   optional bool is_local_fetch = 4;
   optional bool is_disk_error_at_source = 5;
+  optional string destination_localhost_name = 6;
 }
 
 message InputFailedEventProto {

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/Vertex.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/Vertex.java
@@ -231,9 +231,9 @@ public interface Vertex extends Comparable<Vertex> {
      */
     int getMaxAllowedTimeForTaskReadErrorSec();
     /**
-     * @return tez.am.max.allowed.downstream.hosts.reporting.fetch.failure.
+     * @return tez.am.max.allowed.downstream.host.failures.fraction.
      */
-    int getMaxAllowedDownstreamHostsReportingFetchFailure();
+    double getMaxAllowedDownstreamHostFailuresFraction();
   }
 
   void incrementRejectedTaskAttemptCount();

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/Vertex.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/Vertex.java
@@ -230,8 +230,13 @@ public interface Vertex extends Comparable<Vertex> {
      * @return tez.am.max.allowed.time-sec.for-read-error.
      */
     int getMaxAllowedTimeForTaskReadErrorSec();
+    /**
+     * @return tez.am.max.allowed.downstream.hosts.reporting.fetch.failure.
+     */
+    int getMaxAllowedDownstreamHostsReportingFetchFailure();
   }
 
   void incrementRejectedTaskAttemptCount();
   int getRejectedTaskAttemptCount();
+  Map<String, Set<String>> getDownstreamBlamingHosts();
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/event/TaskAttemptEventOutputFailed.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/event/TaskAttemptEventOutputFailed.java
@@ -28,9 +28,9 @@ public class TaskAttemptEventOutputFailed extends TaskAttemptEvent
   private TezEvent inputFailedEvent;
   private int consumerTaskNumber;
   
-  public TaskAttemptEventOutputFailed(TezTaskAttemptID attemptId,
+  public TaskAttemptEventOutputFailed(TezTaskAttemptID sourceTaskAttemptId,
       TezEvent tezEvent, int numConsumers) {
-    super(attemptId, TaskAttemptEventType.TA_OUTPUT_FAILED);
+    super(sourceTaskAttemptId, TaskAttemptEventType.TA_OUTPUT_FAILED);
     this.inputFailedEvent = tezEvent;
     this.consumerTaskNumber = numConsumers;
   }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/Edge.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/Edge.java
@@ -374,7 +374,7 @@ public class Edge {
     if (!bufferEvents.get()) {
       switch (tezEvent.getEventType()) {
       case INPUT_READ_ERROR_EVENT:
-        InputReadErrorEvent event = (InputReadErrorEvent) tezEvent.getEvent();
+        InputReadErrorEvent inputReadErrorEvent = (InputReadErrorEvent) tezEvent.getEvent();
         TezTaskAttemptID destAttemptId = tezEvent.getSourceInfo()
             .getTaskAttemptID();
         int destTaskIndex = destAttemptId.getTaskID().getId();
@@ -383,10 +383,10 @@ public class Edge {
         try {
           if (onDemandRouting) {
             srcTaskIndex = ((EdgeManagerPluginOnDemand) edgeManager).routeInputErrorEventToSource(
-                destTaskIndex, event.getIndex());            
+                destTaskIndex, inputReadErrorEvent.getIndex());
           } else {
-            srcTaskIndex = edgeManager.routeInputErrorEventToSource(event,
-                destTaskIndex, event.getIndex());
+            srcTaskIndex = edgeManager.routeInputErrorEventToSource(inputReadErrorEvent,
+                destTaskIndex, inputReadErrorEvent.getIndex());
           }
           Preconditions.checkArgument(srcTaskIndex >= 0,
               "SourceTaskIndex should not be negative,"
@@ -414,11 +414,10 @@ public class Edge {
               " edgeManager=" + edgeManager.getClass().getName());
         }
         TezTaskID srcTaskId = srcTask.getTaskId();
-        int taskAttemptIndex = event.getVersion();
+        int srcTaskAttemptIndex = inputReadErrorEvent.getVersion();
         TezTaskAttemptID srcTaskAttemptId = TezTaskAttemptID.getInstance(srcTaskId,
-            taskAttemptIndex);
-        sendEvent(new TaskAttemptEventOutputFailed(srcTaskAttemptId,
-            tezEvent, numConsumers));
+            srcTaskAttemptIndex);
+        sendEvent(new TaskAttemptEventOutputFailed(srcTaskAttemptId, tezEvent, numConsumers));
         break;
       default:
         throw new TezUncheckedException("Unhandled tez event type: "

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/TaskAttemptImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/TaskAttemptImpl.java
@@ -194,7 +194,7 @@ public class TaskAttemptImpl implements TaskAttempt,
   private Container container;
   private long allocationTime;
   private ContainerId containerId;
-  private NodeId containerNodeId;
+  protected NodeId containerNodeId;
   private String nodeHttpAddress;
   private String nodeRackName;
   
@@ -1793,80 +1793,107 @@ public class TaskAttemptImpl implements TaskAttempt,
   MultipleArcTransition<TaskAttemptImpl, TaskAttemptEvent, TaskAttemptStateInternal> {
 
     @Override
-    public TaskAttemptStateInternal transition(TaskAttemptImpl attempt,
+    public TaskAttemptStateInternal transition(TaskAttemptImpl sourceAttempt,
         TaskAttemptEvent event) {
       TaskAttemptEventOutputFailed outputFailedEvent = 
           (TaskAttemptEventOutputFailed) event;
-      TezEvent tezEvent = outputFailedEvent.getInputFailedEvent();
-      TezTaskAttemptID failedDestTaId = tezEvent.getSourceInfo().getTaskAttemptID();
-      InputReadErrorEvent readErrorEvent = (InputReadErrorEvent)tezEvent.getEvent();
+      TezEvent inputFailedEvent = outputFailedEvent.getInputFailedEvent();
+      TezTaskAttemptID failedDestTaId = inputFailedEvent.getSourceInfo().getTaskAttemptID();
+
+      InputReadErrorEvent readErrorEvent = (InputReadErrorEvent)inputFailedEvent.getEvent();
       int failedInputIndexOnDestTa = readErrorEvent.getIndex();
-      if (readErrorEvent.getVersion() != attempt.getID().getId()) {
-        throw new TezUncheckedException(attempt.getID()
+
+      if (readErrorEvent.getVersion() != sourceAttempt.getID().getId()) {
+        throw new TezUncheckedException(sourceAttempt.getID()
             + " incorrectly blamed for read error from " + failedDestTaId
             + " at inputIndex " + failedInputIndexOnDestTa + " version"
             + readErrorEvent.getVersion());
       }
-      LOG.info(attempt.getID()
-            + " blamed for read error from " + failedDestTaId
-            + " at inputIndex " + failedInputIndexOnDestTa);
-      long time = attempt.clock.getTime();
-      Long firstErrReportTime = attempt.uniquefailedOutputReports.get(failedDestTaId);
+      // source host: where the data input is supposed to come from
+      String sHost = sourceAttempt.getNodeId().getHost();
+      // destination: where the data is tried to be fetched to
+      String dHost = readErrorEvent.getDestinationLocalhostName();
 
+      LOG.info("{} (on {}) blamed for read error from {} (on {}) at inputIndex {}", sourceAttempt.getID(),
+          sHost, failedDestTaId, dHost, failedInputIndexOnDestTa);
+
+      boolean tooManyDownstreamHostsBlamedTheSameUpstreamHost = false;
+      Map<String, Set<String>> downstreamBlamingHosts = sourceAttempt.getVertex().getDownstreamBlamingHosts();
+      if (!downstreamBlamingHosts.containsKey(sHost)) {
+        LOG.info("Host {} is blamed for fetch failure from {} for the first time", sHost, dHost);
+        downstreamBlamingHosts.put(sHost, new HashSet<String>());
+      }
+
+      downstreamBlamingHosts.get(sHost).add(dHost);
+      int currentNumberOfFailingDownstreamHosts = downstreamBlamingHosts.get(sHost).size();
+      if (currentNumberOfFailingDownstreamHosts > sourceAttempt.getVertex().getVertexConfig()
+          .getMaxAllowedDownstreamHostsReportingFetchFailure()) {
+        LOG.info("Host will be marked fail: {} because of {} distinct upstream hosts having fetch failures", sHost,
+            currentNumberOfFailingDownstreamHosts);
+        tooManyDownstreamHostsBlamedTheSameUpstreamHost = true;
+      }
+
+      long time = sourceAttempt.clock.getTime();
+
+      Long firstErrReportTime = sourceAttempt.uniquefailedOutputReports.get(failedDestTaId);
       if (firstErrReportTime == null) {
-        attempt.uniquefailedOutputReports.put(failedDestTaId, time);
+        sourceAttempt.uniquefailedOutputReports.put(failedDestTaId, time);
         firstErrReportTime = time;
       }
 
-      int maxAllowedOutputFailures = attempt.getVertex().getVertexConfig()
+      int maxAllowedOutputFailures = sourceAttempt.getVertex().getVertexConfig()
           .getMaxAllowedOutputFailures();
-      int maxAllowedTimeForTaskReadErrorSec = attempt.getVertex()
+      int maxAllowedTimeForTaskReadErrorSec = sourceAttempt.getVertex()
           .getVertexConfig().getMaxAllowedTimeForTaskReadErrorSec();
-      double maxAllowedOutputFailuresFraction = attempt.getVertex()
+      double maxAllowedOutputFailuresFraction = sourceAttempt.getVertex()
           .getVertexConfig().getMaxAllowedOutputFailuresFraction();
 
       int readErrorTimespanSec = (int)((time - firstErrReportTime)/1000);
       boolean crossTimeDeadline = readErrorTimespanSec >= maxAllowedTimeForTaskReadErrorSec;
 
-      int runningTasks = attempt.appContext.getCurrentDAG().getVertex(
+      int runningTasks = sourceAttempt.appContext.getCurrentDAG().getVertex(
           failedDestTaId.getTaskID().getVertexID()).getRunningTasks();
-      float failureFraction = runningTasks > 0 ? ((float) attempt.uniquefailedOutputReports.size()) / runningTasks : 0;
+      float failureFraction =
+          runningTasks > 0 ? ((float) sourceAttempt.uniquefailedOutputReports.size()) / runningTasks : 0;
       boolean withinFailureFractionLimits =
           (failureFraction <= maxAllowedOutputFailuresFraction);
       boolean withinOutputFailureLimits =
-          (attempt.uniquefailedOutputReports.size() < maxAllowedOutputFailures);
+          (sourceAttempt.uniquefailedOutputReports.size() < maxAllowedOutputFailures);
 
       // If needed we can launch a background task without failing this task
       // to generate a copy of the output just in case.
       // If needed we can consider only running consumer tasks
       if (!crossTimeDeadline && withinFailureFractionLimits && withinOutputFailureLimits
-          && !(readErrorEvent.isLocalFetch() || readErrorEvent.isDiskErrorAtSource())) {
-        return attempt.getInternalState();
+          && !(readErrorEvent.isLocalFetch() || readErrorEvent.isDiskErrorAtSource())
+          && !tooManyDownstreamHostsBlamedTheSameUpstreamHost) {
+        return sourceAttempt.getInternalState();
       }
-      String message = attempt.getID() + " being failed for too many output errors. "
+      String message = sourceAttempt.getID() + " being failed for too many output errors. "
           + "failureFraction=" + failureFraction
           + ", MAX_ALLOWED_OUTPUT_FAILURES_FRACTION="
           + maxAllowedOutputFailuresFraction
-          + ", uniquefailedOutputReports=" + attempt.uniquefailedOutputReports.size()
+          + ", uniquefailedOutputReports=" + sourceAttempt.uniquefailedOutputReports.size()
           + ", MAX_ALLOWED_OUTPUT_FAILURES=" + maxAllowedOutputFailures
           + ", MAX_ALLOWED_TIME_FOR_TASK_READ_ERROR_SEC="
           + maxAllowedTimeForTaskReadErrorSec
+          + ", tooManyDownstreamHostsBlamedTheSameUpstreamHost: " + tooManyDownstreamHostsBlamedTheSameUpstreamHost
+          + " ("+currentNumberOfFailingDownstreamHosts+")"
           + ", readErrorTimespan=" + readErrorTimespanSec
           + ", isLocalFetch=" + readErrorEvent.isLocalFetch()
           + ", isDiskErrorAtSource=" + readErrorEvent.isDiskErrorAtSource();
 
       LOG.info(message);
-      attempt.addDiagnosticInfo(message);
+      sourceAttempt.addDiagnosticInfo(message);
       // send input failed event
-      attempt.sendInputFailedToConsumers();
+      sourceAttempt.sendInputFailedToConsumers();
       // Not checking for leafVertex since a READ_ERROR should only be reported for intermediate tasks.
-      if (attempt.getInternalState() == TaskAttemptStateInternal.SUCCEEDED) {
+      if (sourceAttempt.getInternalState() == TaskAttemptStateInternal.SUCCEEDED) {
         (new TerminatedAfterSuccessHelper(FAILED_HELPER)).transition(
-            attempt, event);
+            sourceAttempt, event);
         return TaskAttemptStateInternal.FAILED;
       } else {
         (new TerminatedWhileRunningTransition(FAILED_HELPER)).transition(
-            attempt, event);
+            sourceAttempt, event);
         return TaskAttemptStateInternal.FAIL_IN_PROGRESS;
       }
       // TODO at some point. Nodes may be interested in FetchFailure info.

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/VertexImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/VertexImpl.java
@@ -4841,9 +4841,9 @@ public class VertexImpl implements org.apache.tez.dag.app.dag.Vertex, EventHandl
      */
     private final int maxAllowedTimeForTaskReadErrorSec;
     /**
-     * See tez.am.max.allowed.downstream.hosts.reporting.fetch.failure.
+     * See tez.am.max.allowed.downstream.host.failures.fraction.
      */
-    private final int maxAllowedDownstreamHostsReportingFetchFailure;
+    private final double maxAllowedDownstreamHostFailuresFraction;
 
     public VertexConfigImpl(Configuration conf) {
       this.maxFailedTaskAttempts = conf.getInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS,
@@ -4869,9 +4869,9 @@ public class VertexImpl implements org.apache.tez.dag.app.dag.Vertex, EventHandl
           TezConfiguration.TEZ_AM_MAX_ALLOWED_TIME_FOR_TASK_READ_ERROR_SEC,
           TezConfiguration.TEZ_AM_MAX_ALLOWED_TIME_FOR_TASK_READ_ERROR_SEC_DEFAULT);
 
-      this.maxAllowedDownstreamHostsReportingFetchFailure = conf.getInt(
-          TezConfiguration.TEZ_AM_MAX_ALLOWED_DOWNSTREAM_HOSTS_REPORTING_FETCH_FAILURE,
-          TezConfiguration.TEZ_AM_MAX_ALLOWED_DOWNSTREAM_HOSTS_REPORTING_FETCH_FAILURE_DEFAULT);
+      this.maxAllowedDownstreamHostFailuresFraction = conf.getDouble(
+          TezConfiguration.TEZ_AM_MAX_ALLOWED_DOWNSTREAM_HOST_FAILURES_FRACTION,
+          TezConfiguration.TEZ_AM_MAX_ALLOWED_DOWNSTREAM_HOST_FAILURES_FRACTION_DEFAULT);
     }
 
     @Override
@@ -4918,8 +4918,8 @@ public class VertexImpl implements org.apache.tez.dag.app.dag.Vertex, EventHandl
     /**
      * @return maxAllowedDownstreamHostsReportingFetchFailure.
      */
-    @Override public int getMaxAllowedDownstreamHostsReportingFetchFailure() {
-      return maxAllowedDownstreamHostsReportingFetchFailure;
+    @Override public double getMaxAllowedDownstreamHostFailuresFraction() {
+      return maxAllowedDownstreamHostFailuresFraction;
     }
   }
 

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/rm/node/AMNodeImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/rm/node/AMNodeImpl.java
@@ -509,4 +509,10 @@ public class AMNodeImpl implements AMNode {
       this.writeLock.unlock();
     }
   }
+
+  public String toString() {
+    return String.format(
+        "{AMNodeImpl: nodeId: %s, state: %s, containers: %d, completed containers: %d, healthy: %s, blackListed: %s}",
+        nodeId, getState(), getContainers().size(), completedContainers.size(), !isUnhealthy(), isBlacklisted());
+  }
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/rm/node/AMNodeTracker.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/rm/node/AMNodeTracker.java
@@ -134,6 +134,17 @@ public class AMNodeTracker extends AbstractService implements
     return perSourceNodeTrackers.get(schedulerId).getNumNodes();
   }
 
+  /**
+   * Retrieve the number of nodes in ACTIVE state. This number is suitable for deciding
+   * how many nodes can be potentially used for running containers at the moment.
+   *
+   * @param schedulerId the schedulerId for which the node count is required
+   * @return the number of nodes from the scheduler being in ACTIVE state
+   */
+  public int getNumActiveNodes(int schedulerId) {
+    return perSourceNodeTrackers.get(schedulerId).getNumActiveNodes();
+  }
+
   @Private
   @VisibleForTesting
   public boolean isBlacklistingIgnored(int schedulerId) {
@@ -158,6 +169,4 @@ public class AMNodeTracker extends AbstractService implements
     }
     return nodeTracker;
   }
-
-
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/rm/node/PerSourceNodeTracker.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/rm/node/PerSourceNodeTracker.java
@@ -84,6 +84,10 @@ public class PerSourceNodeTracker {
     return nodeMap.size();
   }
 
+  public int getNumActiveNodes() {
+    return (int) nodeMap.values().stream().filter(node -> node.getState() == AMNodeState.ACTIVE).count();
+  }
+
   public void handle(AMNodeEvent rEvent) {
     // No synchronization required until there's multiple dispatchers.
     NodeId nodeId = rEvent.getNodeId();

--- a/tez-runtime-internals/src/main/java/org/apache/tez/runtime/api/impl/TezEvent.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/runtime/api/impl/TezEvent.java
@@ -193,6 +193,7 @@ public class TezEvent implements Writable {
             .setVersion(ideEvt.getVersion())
             .setIsLocalFetch(ideEvt.isLocalFetch())
             .setIsDiskErrorAtSource(ideEvt.isDiskErrorAtSource())
+            .setDestinationLocalhostName(ideEvt.getDestinationLocalhostName())
             .build();
         break;
       case TASK_ATTEMPT_FAILED_EVENT:
@@ -298,7 +299,8 @@ public class TezEvent implements Writable {
       case INPUT_READ_ERROR_EVENT:
         InputReadErrorEventProto ideProto = InputReadErrorEventProto.parseFrom(input);
         event = InputReadErrorEvent.create(ideProto.getDiagnostics(), ideProto.getIndex(),
-            ideProto.getVersion(), ideProto.getIsLocalFetch(), ideProto.getIsDiskErrorAtSource());
+            ideProto.getVersion(), ideProto.getIsLocalFetch(), ideProto.getIsDiskErrorAtSource(),
+            ideProto.getDestinationLocalhostName());
         break;
       case TASK_ATTEMPT_FAILED_EVENT:
         TaskAttemptFailedEventProto tfProto =

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/TezRuntimeConfiguration.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/TezRuntimeConfiguration.java
@@ -424,12 +424,13 @@ public class TezRuntimeConfiguration {
 
   /**
    * Configures the injectable fetch failures, in a form of:
-   * maphost#probability#comma,separated,features
+   * maphost#mapvertex#probability#comma,separated,features
    * Possible values are (fetch fails...):
-   * "*#50": from all map hosts with 50% likelihood
-   * "_first_#80": for the first ever seen map host with 80% likelihood (user doesn't want to use hostnames)
-   * "host1#100": from host1 with 100% likelihood (simulates single node failure)
-   * "host1#100#fail_only_first": as above but only for input attempts with index 0
+   * "*#*#50": from all map hosts with 50% likelihood
+   * "_first_#*#80": for the first ever seen map host with 80% likelihood (user doesn't want to use hostnames)
+   * "host1#*#100": from host1 with 100% likelihood (simulates single node failure)
+   * "host1#Map_1#100": from host1 for Map 1 source tasks with 100% likelihood
+   * "host1#Map_1#100#fail_only_first": as above but only for input attempts with index 0
    */
   @ConfigurationProperty(type = "string")
   public static final String TEZ_RUNTIME_SHUFFLE_FETCH_TESTING_ERRORS_CONFIG =

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/TezRuntimeConfiguration.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/api/TezRuntimeConfiguration.java
@@ -414,6 +414,28 @@ public class TezRuntimeConfiguration {
   public static final float TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT_DEFAULT =
       0.90f;
 
+  /**
+   * Enables fetch failures by a configuration. Should be used for testing only.
+   */
+  @ConfigurationProperty(type = "boolean")
+  public static final String TEZ_RUNTIME_SHUFFLE_FETCH_ENABLE_TESTING_ERRORS =
+      TEZ_RUNTIME_PREFIX + "shuffle.fetch.testing.errors.enable";
+  public static final boolean TEZ_RUNTIME_SHUFFLE_FETCH_ENABLE_TESTING_ERRORS_DEFAULT = false;
+
+  /**
+   * Configures the injectable fetch failures, in a form of:
+   * maphost#probability#comma,separated,features
+   * Possible values are (fetch fails...):
+   * "*#50": from all map hosts with 50% likelihood
+   * "_first_#80": for the first ever seen map host with 80% likelihood (user doesn't want to use hostnames)
+   * "host1#100": from host1 with 100% likelihood (simulates single node failure)
+   * "host1#100#fail_only_first": as above but only for input attempts with index 0
+   */
+  @ConfigurationProperty(type = "string")
+  public static final String TEZ_RUNTIME_SHUFFLE_FETCH_TESTING_ERRORS_CONFIG =
+      TEZ_RUNTIME_PREFIX + "shuffle.fetch.testing.errors.config";
+  public static final String TEZ_RUNTIME_SHUFFLE_FETCH_TESTING_ERRORS_CONFIG_DEFAULT = "*#50";
+
   @ConfigurationProperty(type = "float")
   public static final String TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT = TEZ_RUNTIME_PREFIX +
       "shuffle.memory.limit.percent";
@@ -543,7 +565,7 @@ public class TezRuntimeConfiguration {
 
 
   /**
-   * Share data fetched between tasks running on the same host if applicable
+   * Share data fetched between tasks running on the same host if applicable.
    */
   @ConfigurationProperty(type = "boolean")
   public static final String TEZ_RUNTIME_OPTIMIZE_SHARED_FETCH = TEZ_RUNTIME_PREFIX
@@ -626,6 +648,8 @@ public class TezRuntimeConfiguration {
     tezRuntimeKeys.add(TEZ_RUNTIME_SHUFFLE_MAX_ALLOWED_FAILED_FETCH_ATTEMPT_FRACTION);
     tezRuntimeKeys.add(TEZ_RUNTIME_SHUFFLE_MIN_REQUIRED_PROGRESS_FRACTION);
     tezRuntimeKeys.add(TEZ_RUNTIME_SHUFFLE_FAILED_CHECK_SINCE_LAST_COMPLETION);
+    tezRuntimeKeys.add(TEZ_RUNTIME_SHUFFLE_FETCH_TESTING_ERRORS_CONFIG);
+    tezRuntimeKeys.add(TEZ_RUNTIME_SHUFFLE_FETCH_ENABLE_TESTING_ERRORS);
     tezRuntimeKeys.add(TEZ_RUNTIME_REPORT_PARTITION_STATS);
     tezRuntimeKeys.add(TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT);
     tezRuntimeKeys.add(TEZ_RUNTIME_GROUP_COMPARATOR_CLASS);

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/FetcherErrorTestingConfig.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/FetcherErrorTestingConfig.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.runtime.library.common.shuffle;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.tez.runtime.api.ObjectRegistry;
+import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
+import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FetcherErrorTestingConfig {
+  private static final Logger LOG = LoggerFactory.getLogger(FetcherErrorTestingConfig.class);
+  private static final String KEY_CACHED_HOSTNAME = "FetcherErrorTestingConfig.host";
+
+  private String hostToFail = "*";
+  private int probabilityPercent = 50;
+  private Random random = new Random();
+  /**
+   * Whether to fail only in case of input attempts with index 0,
+   * this prevents continuous failure, and helps simulating a real-life node failure.
+   */
+  private boolean failForFirstAttemptOnly = false;
+  private ObjectRegistry objectRegistry;
+
+  public FetcherErrorTestingConfig(Configuration conf, ObjectRegistry objectRegistry) {
+    String errorConfig = conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_TESTING_ERRORS_CONFIG,
+        TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_TESTING_ERRORS_CONFIG_DEFAULT);
+    String[] configParts = errorConfig.split("#");
+    if (configParts.length > 0) {
+      hostToFail = configParts[0];
+    }
+
+    if (configParts.length > 1) {
+      probabilityPercent = Integer.parseInt(configParts[1]);
+    }
+
+    if (configParts.length > 2) {
+      List<String> features = Arrays.asList(configParts[2].split(","));
+      if (features.contains("fail_only_first")) {
+        failForFirstAttemptOnly = true;
+      }
+    }
+
+    this.objectRegistry = objectRegistry;
+    if (hostToFail.equals("_first_")) {
+      String host = (String) objectRegistry.get(KEY_CACHED_HOSTNAME);
+      if (host != null) {
+        LOG.info("Get already stored hostname for fetcher test failures: " + host);
+        hostToFail = host;
+      }
+    }
+  }
+
+  public boolean shouldFail(String host, InputAttemptIdentifier inputAttemptIdentifier) {
+    if (matchHost(host)) {
+      return (!failForFirstAttemptOnly || failForFirstAttemptOnly && inputAttemptIdentifier.getAttemptNumber() == 0)
+          && random.nextInt(100) < probabilityPercent;
+    }
+    return false;
+  }
+
+  private boolean matchHost(String host) {
+    if (hostToFail.equals("_first_")) {
+      objectRegistry.cacheForVertex(KEY_CACHED_HOSTNAME, host);
+      hostToFail = host;
+    }
+    return "*".equals(hostToFail) || host.equalsIgnoreCase(hostToFail);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("[FetcherErrorTestingConfig: host: %s, probability: %d%%, failForFirstAttemptOnly: %s]",
+        hostToFail, probabilityPercent, failForFirstAttemptOnly);
+  }
+}

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/FetcherWithInjectableErrors.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/FetcherWithInjectableErrors.java
@@ -32,6 +32,7 @@ public class FetcherWithInjectableErrors extends Fetcher {
   private static final Logger LOG = LoggerFactory.getLogger(FetcherWithInjectableErrors.class);
 
   private FetcherErrorTestingConfig fetcherErrorTestingConfig;
+  private String srcNameTrimmed;
 
   protected FetcherWithInjectableErrors(FetcherCallback fetcherCallback, HttpConnectionParams params,
       FetchedInputAllocator inputManager, ApplicationId appId, int dagIdentifier,
@@ -43,6 +44,7 @@ public class FetcherWithInjectableErrors extends Fetcher {
         localFs, localDirAllocator, lockPath, localDiskFetchEnabled, sharedFetchEnabled, localHostname, shufflePort,
         asyncHttp, verifyDiskChecksum, compositeFetch);
     this.fetcherErrorTestingConfig = new FetcherErrorTestingConfig(conf, objectRegistry);
+    this.srcNameTrimmed = srcNameTrimmed;
     LOG.info("Initialized FetcherWithInjectableErrors with config: {}", fetcherErrorTestingConfig);
   }
 
@@ -51,7 +53,7 @@ public class FetcherWithInjectableErrors extends Fetcher {
       throws IOException, InterruptedException {
     LOG.info("Checking if fetcher should fail for host: {} ...", host);
     for (InputAttemptIdentifier inputAttemptIdentifier : attempts) {
-      if (fetcherErrorTestingConfig.shouldFail(host, inputAttemptIdentifier)) {
+      if (fetcherErrorTestingConfig.shouldFail(host, srcNameTrimmed, inputAttemptIdentifier)) {
         throw new IOException(String.format(
             "FetcherWithInjectableErrors tester made failure for host: %s, input attempt: %s", host,
             inputAttemptIdentifier.getAttemptNumber()));

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/FetcherWithInjectableErrors.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/FetcherWithInjectableErrors.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.runtime.library.common.shuffle;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.LocalDirAllocator;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.tez.common.security.JobTokenSecretManager;
+import org.apache.tez.http.HttpConnectionParams;
+import org.apache.tez.runtime.api.ObjectRegistry;
+import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FetcherWithInjectableErrors extends Fetcher {
+  private static final Logger LOG = LoggerFactory.getLogger(FetcherWithInjectableErrors.class);
+
+  private FetcherErrorTestingConfig fetcherErrorTestingConfig;
+
+  protected FetcherWithInjectableErrors(FetcherCallback fetcherCallback, HttpConnectionParams params,
+      FetchedInputAllocator inputManager, ApplicationId appId, int dagIdentifier,
+      JobTokenSecretManager jobTokenSecretManager, String srcNameTrimmed, Configuration conf,
+      RawLocalFileSystem localFs, LocalDirAllocator localDirAllocator, Path lockPath, boolean localDiskFetchEnabled,
+      boolean sharedFetchEnabled, String localHostname, int shufflePort, boolean asyncHttp, boolean verifyDiskChecksum,
+      boolean compositeFetch, ObjectRegistry objectRegistry) {
+    super(fetcherCallback, params, inputManager, appId, dagIdentifier, jobTokenSecretManager, srcNameTrimmed, conf,
+        localFs, localDirAllocator, lockPath, localDiskFetchEnabled, sharedFetchEnabled, localHostname, shufflePort,
+        asyncHttp, verifyDiskChecksum, compositeFetch);
+    this.fetcherErrorTestingConfig = new FetcherErrorTestingConfig(conf, objectRegistry);
+    LOG.info("Initialized FetcherWithInjectableErrors with config: {}", fetcherErrorTestingConfig);
+  }
+
+  @Override
+  protected void setupConnectionInternal(String host, Collection<InputAttemptIdentifier> attempts)
+      throws IOException, InterruptedException {
+    LOG.info("Checking if fetcher should fail for host: {} ...", host);
+    for (InputAttemptIdentifier inputAttemptIdentifier : attempts) {
+      if (fetcherErrorTestingConfig.shouldFail(host, inputAttemptIdentifier)) {
+        throw new IOException(String.format(
+            "FetcherWithInjectableErrors tester made failure for host: %s, input attempt: %s", host,
+            inputAttemptIdentifier.getAttemptNumber()));
+      }
+    }
+    super.setupConnectionInternal(host, attempts);
+  }
+
+  @Override
+  public int hashCode() {
+    return fetcherIdentifier;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    FetcherWithInjectableErrors other = (FetcherWithInjectableErrors) obj;
+    if (fetcherIdentifier != other.fetcherIdentifier) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGrouped.java
@@ -81,7 +81,7 @@ class FetcherOrderedGrouped extends CallableWithNdc<Void> {
   private final int localShufflePort;
   private final String applicationId;
   private final int dagId;
-  private final MapHost mapHost;
+  protected final MapHost mapHost;
 
   private final int minPartition;
   private final int maxPartition;
@@ -350,8 +350,7 @@ class FetcherOrderedGrouped extends CallableWithNdc<Void> {
         LOG.debug("Detected fetcher has been shutdown after connection establishment. Returning");
         return false;
       }
-      input = httpConnection.getInputStream();
-      httpConnection.validate();
+      setupConnectionInternal(host, attempts);
       return true;
     } catch (IOException | InterruptedException ie) {
       if (ie instanceof InterruptedException) {
@@ -383,6 +382,12 @@ class FetcherOrderedGrouped extends CallableWithNdc<Void> {
       }
       return false;
     }
+  }
+
+  protected void setupConnectionInternal(MapHost host, Collection<InputAttemptIdentifier> attempts)
+      throws IOException, InterruptedException {
+    input = httpConnection.getInputStream();
+    httpConnection.validate();
   }
 
   @VisibleForTesting
@@ -426,7 +431,7 @@ class FetcherOrderedGrouped extends CallableWithNdc<Void> {
   }
 
   protected InputAttemptFetchFailure[] copyMapOutput(MapHost host, DataInputStream input,
-      InputAttemptIdentifier inputAttemptIdentifier) throws FetcherReadTimeoutException {
+      InputAttemptIdentifier inputAttemptIdentifier) throws FetcherReadTimeoutException, IOException {
     MapOutput mapOutput = null;
     InputAttemptIdentifier srcAttemptId = null;
     long decompressedLength = 0;

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGroupedWithInjectableErrors.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGroupedWithInjectableErrors.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.hadoop.io.compress.CompressionCodec;
+import org.apache.tez.common.counters.TezCounter;
+import org.apache.tez.common.security.JobTokenSecretManager;
+import org.apache.tez.http.HttpConnectionParams;
+import org.apache.tez.runtime.api.ObjectRegistry;
+import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.shuffle.FetcherErrorTestingConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FetcherOrderedGroupedWithInjectableErrors extends FetcherOrderedGrouped {
+  private static final Logger LOG = LoggerFactory.getLogger(FetcherOrderedGroupedWithInjectableErrors.class);
+
+  private FetcherErrorTestingConfig fetcherErrorTestingConfig;
+
+  public FetcherOrderedGroupedWithInjectableErrors(HttpConnectionParams httpConnectionParams,
+      ShuffleScheduler scheduler, FetchedInputAllocatorOrderedGrouped allocator, ExceptionReporter exceptionReporter,
+      JobTokenSecretManager jobTokenSecretMgr, boolean ifileReadAhead, int ifileReadAheadLength, CompressionCodec codec,
+      Configuration conf, RawLocalFileSystem localFs, boolean localDiskFetchEnabled, String localHostname,
+      int shufflePort, String srcNameTrimmed, MapHost mapHost, TezCounter ioErrsCounter,
+      TezCounter wrongLengthErrsCounter, TezCounter badIdErrsCounter, TezCounter wrongMapErrsCounter,
+      TezCounter connectionErrsCounter, TezCounter wrongReduceErrsCounter, String applicationId, int dagId,
+      boolean asyncHttp, boolean sslShuffle, boolean verifyDiskChecksum, boolean compositeFetch,
+      ObjectRegistry objectRegistry) {
+    super(httpConnectionParams, scheduler, allocator, exceptionReporter, jobTokenSecretMgr, ifileReadAhead,
+        ifileReadAheadLength, codec, conf, localFs, localDiskFetchEnabled, localHostname, shufflePort, srcNameTrimmed,
+        mapHost, ioErrsCounter, wrongLengthErrsCounter, badIdErrsCounter, wrongMapErrsCounter, connectionErrsCounter,
+        wrongReduceErrsCounter, applicationId, dagId, asyncHttp, sslShuffle, verifyDiskChecksum, compositeFetch);
+    this.fetcherErrorTestingConfig = new FetcherErrorTestingConfig(conf, objectRegistry);
+    LOG.info("Initialized FetcherOrderedGroupedWithInjectableErrors with config: {}", fetcherErrorTestingConfig);
+  }
+
+  @Override
+  protected void setupConnectionInternal(MapHost host, Collection<InputAttemptIdentifier> attempts)
+      throws IOException, InterruptedException {
+    LOG.info("Checking if fetcher should fail for host: {} ...", mapHost.getHost());
+    for (InputAttemptIdentifier inputAttemptIdentifier : attempts) {
+      if (fetcherErrorTestingConfig.shouldFail(mapHost.getHost(), inputAttemptIdentifier)) {
+        throw new IOException(String.format(
+            "FetcherOrderedGroupedWithInjectableErrors tester made failure for host: %s, input attempt: %s",
+            mapHost.getHost(), inputAttemptIdentifier.getAttemptNumber()));
+      }
+    }
+    super.setupConnectionInternal(host, attempts);
+  }
+}

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGroupedWithInjectableErrors.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/FetcherOrderedGroupedWithInjectableErrors.java
@@ -32,6 +32,7 @@ public class FetcherOrderedGroupedWithInjectableErrors extends FetcherOrderedGro
   private static final Logger LOG = LoggerFactory.getLogger(FetcherOrderedGroupedWithInjectableErrors.class);
 
   private FetcherErrorTestingConfig fetcherErrorTestingConfig;
+  private String srcNameTrimmed;
 
   public FetcherOrderedGroupedWithInjectableErrors(HttpConnectionParams httpConnectionParams,
       ShuffleScheduler scheduler, FetchedInputAllocatorOrderedGrouped allocator, ExceptionReporter exceptionReporter,
@@ -47,6 +48,7 @@ public class FetcherOrderedGroupedWithInjectableErrors extends FetcherOrderedGro
         mapHost, ioErrsCounter, wrongLengthErrsCounter, badIdErrsCounter, wrongMapErrsCounter, connectionErrsCounter,
         wrongReduceErrsCounter, applicationId, dagId, asyncHttp, sslShuffle, verifyDiskChecksum, compositeFetch);
     this.fetcherErrorTestingConfig = new FetcherErrorTestingConfig(conf, objectRegistry);
+    this.srcNameTrimmed = srcNameTrimmed;
     LOG.info("Initialized FetcherOrderedGroupedWithInjectableErrors with config: {}", fetcherErrorTestingConfig);
   }
 
@@ -55,7 +57,7 @@ public class FetcherOrderedGroupedWithInjectableErrors extends FetcherOrderedGro
       throws IOException, InterruptedException {
     LOG.info("Checking if fetcher should fail for host: {} ...", mapHost.getHost());
     for (InputAttemptIdentifier inputAttemptIdentifier : attempts) {
-      if (fetcherErrorTestingConfig.shouldFail(mapHost.getHost(), inputAttemptIdentifier)) {
+      if (fetcherErrorTestingConfig.shouldFail(mapHost.getHost(), srcNameTrimmed, inputAttemptIdentifier)) {
         throw new IOException(String.format(
             "FetcherOrderedGroupedWithInjectableErrors tester made failure for host: %s, input attempt: %s",
             mapHost.getHost(), inputAttemptIdentifier.getAttemptNumber()));


### PR DESCRIPTION
The fix is actually to store downstreamBlamingHosts on vertex level. This is a map which simply stores a set of downstream hosts that reported fetch failure for every upstream host. The idea is to detect the upstream node failure better, and I'm trying to achieve this by assuming if downstream tasks from at least n nodes (n is configurable) reported failures for an upstream host, then the upstream tasks will be marked as OUTPUT_LOST and will rerun. As we're handling this on vertex level, we can fail a mapper task even if we get the first fetch failure reported blaming that, as we already figured out the mapper host itself has been reported as a possible root cause of failures.

Changes in this patch:
1. propagating host of the downstream task through tez event
2. handling hosts in the transition, actual fix is:
```
      if (currentNumberOfFailingDownstreamHosts > sourceAttempt.getVertex().getVertexConfig()
          .getMaxAllowedDownstreamHostsReportingFetchFailure()) {
        LOG.info("Host will be marked fail: {} because of {} distinct upstream hosts having fetch failures", sHost,
            currentNumberOfFailingDownstreamHosts);
        tooManyDownstreamHostsBlamedTheSameUpstreamHost = true;
      }
```
3. testing improvement, configurable fetch errors (on both ordered, unordered codepaths), e.g.
```
tez.runtime.shuffle.fetch.testing.errors.enable=true;
tez.runtime.shuffle.fetch.testing.errors.config=samplehost#100#fail_only_first
```
more examples in javadoc