### PR TITLE
TEZ-4347: Add some diagnostic endpoints to TezAM's WebUIService

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/dag/api/TezConfiguration.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/TezConfiguration.java
@@ -1980,6 +1980,18 @@ public class TezConfiguration extends Configuration {
       + "tez-ui.webservice.enable";
   public static final boolean TEZ_AM_WEBSERVICE_ENABLE_DEFAULT = true;
 
+  /**
+   * String value. Range of ports that the AM can use for the WebUIService. Leave blank
+   * to use all possible ports. Expert level setting. It's hadoop standard range configuration.
+   * For example 50000-50050,50100-50200
+   */
+  @ConfigurationScope(Scope.AM)
+  @ConfigurationProperty(type="boolean")
+  public static final String TEZ_AM_WEBSERVICE_PORT_RANGE = TEZ_AM_PREFIX
+      + "tez-ui.webservice.port-range";
+
+  public static final String TEZ_AM_WEBSERVICE_PORT_RANGE_DEFAULT = "50000-50050";
+
   // TODO only validate property here, value can also be validated if necessary
   public static void validateProperty(String property, Scope usedScope) {
     Scope validScope = PropertyScope.get(property);

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClient.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClient.java
@@ -140,4 +140,13 @@ public abstract class DAGClient implements Closeable {
   public abstract DAGStatus waitForCompletionWithStatusUpdates(@Nullable Set<StatusGetOpts> statusGetOpts)
       throws IOException, TezException, InterruptedException;
 
+  /**
+   * Returns the Tez AM's web ui address if any.
+   *
+   * @return The http web UI address
+   * @throws IOException
+   * @throws TezException
+   */
+  public abstract String getWebUIAddress() throws IOException, TezException;
+
 }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientImpl.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientImpl.java
@@ -30,10 +30,10 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import com.google.common.annotations.VisibleForTesting;
+
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.tez.common.CachedEntity;
 import org.apache.tez.common.Preconditions;
-
 import org.apache.hadoop.yarn.exceptions.ApplicationNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -668,6 +668,11 @@ public class DAGClientImpl extends DAGClient {
   @VisibleForTesting
   public DAGClientInternal getRealClient() {
     return realClient;
+  }
+
+  @Override
+  public String getWebUIAddress() throws IOException, TezException {
+    return realClient.getWebUIAddress();
   }
 
   private double getProgress(Progress progress) {

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientInternal.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientInternal.java
@@ -125,4 +125,6 @@ public abstract class DAGClientInternal implements Closeable {
    */
   public abstract DAGStatus waitForCompletionWithStatusUpdates(@Nullable Set<StatusGetOpts> statusGetOpts)
       throws IOException, TezException, InterruptedException;
+
+  public abstract String getWebUIAddress() throws IOException, TezException;
 }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientTimelineImpl.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientTimelineImpl.java
@@ -523,4 +523,9 @@ public class DAGClientTimelineImpl extends DAGClientInternal {
     return getDAGStatus(statusOptions);
   }
 
+  @Override
+  public String getWebUIAddress() throws IOException, TezException {
+    throw new TezException("DAGClientTimelineImpl.getWebUIAddress is not supported");
+  }
+
 }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/rpc/DAGClientRPCImpl.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/rpc/DAGClientRPCImpl.java
@@ -48,6 +48,7 @@ import org.apache.tez.dag.api.client.StatusGetOpts;
 import org.apache.tez.dag.api.client.VertexStatus;
 import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetDAGStatusRequestProto;
 import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetVertexStatusRequestProto;
+import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetWebUIAddressRequestProto;
 import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.TryKillDAGRequestProto;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -303,4 +304,15 @@ public class DAGClientRPCImpl extends DAGClientInternal {
     throw new TezException("not supported");
   }
 
+  @Override
+  public String getWebUIAddress() throws IOException, TezException {
+    LOG.debug("getWebUIAddress via AM for app: {} dag: {}", appId, dagId);
+    GetWebUIAddressRequestProto.Builder requestProtoBuilder = GetWebUIAddressRequestProto.newBuilder();
+    try {
+      return proxy.getWebUIAddress(null, requestProtoBuilder.build()).getWebUiAddress();
+    } catch (ServiceException e) {
+      RPCUtil.unwrapAndThrowException(e);
+      throw new TezException(e);
+    }
+  }
 }

--- a/tez-api/src/main/proto/DAGClientAMProtocol.proto
+++ b/tez-api/src/main/proto/DAGClientAMProtocol.proto
@@ -90,6 +90,13 @@ message GetAMStatusResponseProto {
   required TezAppMasterStatusProto status = 1;
 }
 
+message GetWebUIAddressRequestProto {
+}
+
+message GetWebUIAddressResponseProto {
+  required string web_ui_address = 1;
+}
+
 service DAGClientAMProtocol {
   rpc getAllDAGs (GetAllDAGsRequestProto) returns (GetAllDAGsResponseProto);
   rpc getDAGStatus (GetDAGStatusRequestProto) returns (GetDAGStatusResponseProto);
@@ -98,4 +105,5 @@ service DAGClientAMProtocol {
   rpc submitDAG (SubmitDAGRequestProto) returns (SubmitDAGResponseProto);
   rpc shutdownSession (ShutdownSessionRequestProto) returns (ShutdownSessionResponseProto);
   rpc getAMStatus (GetAMStatusRequestProto) returns (GetAMStatusResponseProto);
+  rpc getWebUIAddress (GetWebUIAddressRequestProto) returns (GetWebUIAddressResponseProto);
 }

--- a/tez-common/src/main/java/org/apache/tez/common/web/AbstractServletToControllerAdapter.java
+++ b/tez-common/src/main/java/org/apache/tez/common/web/AbstractServletToControllerAdapter.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.common.web;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Enumeration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.hadoop.yarn.webapp.Controller;
+
+/**
+ * AbstractServletToControllerAdapter is a common ancestor for classes
+ * that wish to adapt servlets to yarn webapp controllers.
+ * The adapter is responsible for:
+ * 1. creating a servlet instance
+ * 2. creating a dummy ServletConfig
+ * 3. delegating calls to the servlet instance's doGet method
+ */
+public abstract class AbstractServletToControllerAdapter extends Controller {
+  private AtomicBoolean initialized = new AtomicBoolean(false);
+  protected HttpServlet servlet;
+
+  @Override
+  public void index() {
+    if (initialized.compareAndSet(false, true)) {
+      initServlet();
+    }
+    try {
+      /*
+       * This reflection workaround is needed because HttpServlet.doGet is protected
+       * (even if subclasses have it public).
+       */
+      Method doGetMethod =
+          this.servlet.getClass().getMethod("doGet", HttpServletRequest.class, HttpServletResponse.class);
+      doGetMethod.setAccessible(true);
+      doGetMethod.invoke(this.servlet, request(), response());
+    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException
+        | SecurityException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Creates a dummy servlet config which is suitable for initializing a servlet instance.
+   * @param servletName
+   * @return a ServletConfig instance initialized with a ServletContext
+   */
+  private ServletConfig getDummyServletConfig(String servletName) {
+    return new ServletConfig() {
+
+      @Override
+      public String getServletName() {
+        return servletName;
+      }
+
+      @Override
+      public ServletContext getServletContext() {
+        return request().getServletContext();
+      }
+
+      @Override
+      public Enumeration<String> getInitParameterNames() {
+        return null;
+      }
+
+      @Override
+      public String getInitParameter(String name) {
+        return null;
+      }
+    };
+  }
+
+  private void initServlet() {
+    try {
+      servlet.init(getDummyServletConfig(this.servlet.getClass().getSimpleName()));
+    } catch (ServletException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/tez-common/src/main/java/org/apache/tez/common/web/ServletToControllerAdapters.java
+++ b/tez-common/src/main/java/org/apache/tez/common/web/ServletToControllerAdapters.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tez.common.web;
+
+import javax.servlet.ServletException;
+
+import org.apache.hadoop.conf.ConfServlet;
+import org.apache.hadoop.http.HttpServer2.StackServlet;
+import org.apache.hadoop.jmx.JMXJsonServlet;
+
+public class ServletToControllerAdapters {
+  public static class JMXJsonServletController extends AbstractServletToControllerAdapter {
+    public JMXJsonServletController() throws ServletException {
+      this.servlet = new JMXJsonServlet();
+    }
+  }
+
+  public static class ConfServletController extends AbstractServletToControllerAdapter {
+    public ConfServletController() throws ServletException {
+      this.servlet = new ConfServlet();
+    }
+  }
+
+  public static class StackServletController extends AbstractServletToControllerAdapter {
+    public StackServletController() throws ServletException {
+      this.servlet = new StackServlet();
+    }
+  }
+}

--- a/tez-common/src/main/java/org/apache/tez/common/web/package-info.java
+++ b/tez-common/src/main/java/org/apache/tez/common/web/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Private
+package org.apache.tez.common.web;
+
+import org.apache.hadoop.classification.InterfaceAudience.Private;

--- a/tez-dag/src/main/java/org/apache/tez/dag/api/client/DAGClientHandler.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/api/client/DAGClientHandler.java
@@ -186,4 +186,7 @@ public class DAGClientHandler {
     return lastHeartbeatTime.get();
   }
 
+  public String getWebUIAddress() {
+    return dagAppMaster.getWebUIAddress();
+  }
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/api/client/rpc/DAGClientAMProtocolBlockingPBServerImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/api/client/rpc/DAGClientAMProtocolBlockingPBServerImpl.java
@@ -45,6 +45,8 @@ import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetDAGStatusRequ
 import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetDAGStatusResponseProto;
 import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetVertexStatusRequestProto;
 import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetVertexStatusResponseProto;
+import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetWebUIAddressRequestProto;
+import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.GetWebUIAddressResponseProto;
 import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.ShutdownSessionRequestProto;
 import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.ShutdownSessionResponseProto;
 import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.SubmitDAGRequestProto;
@@ -226,4 +228,10 @@ public class DAGClientAMProtocolBlockingPBServerImpl implements DAGClientAMProto
     }
   }
 
+  @Override
+  public GetWebUIAddressResponseProto getWebUIAddress(RpcController controller, GetWebUIAddressRequestProto request)
+      throws ServiceException {
+    String address = real.getWebUIAddress();
+    return GetWebUIAddressResponseProto.newBuilder().setWebUiAddress(address).build();
+  }
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java
@@ -2618,6 +2618,10 @@ public class DAGAppMaster extends AbstractService {
         TezConfiguration.TEZ_AM_WEBSERVICE_ENABLE_DEFAULT);
   }
 
+  public String getWebUIAddress() {
+    return webUIService == null ? null : webUIService.getBaseUrl();
+  }
+
   @VisibleForTesting
   static void parseAllPlugins(
       List<NamedEntityDescriptor> taskSchedulerDescriptors, BiMap<String, Integer> taskSchedulerPluginMap,

--- a/tez-mapreduce/src/main/java/org/apache/tez/dag/api/client/MRDAGClient.java
+++ b/tez-mapreduce/src/main/java/org/apache/tez/dag/api/client/MRDAGClient.java
@@ -106,4 +106,10 @@ public class MRDAGClient extends DAGClient {
       long timeout) throws IOException, TezException {
     return getDAGStatus(statusOptions);
   }
+
+  @Override
+  public String getWebUIAddress() throws IOException, TezException {
+    throw new TezException("MRDAGClient.getWebUIAddress is not supported");
+  }
+
 }

--- a/tez-tests/src/test/java/org/apache/tez/test/TestAM.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestAM.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configuration.IntegerRanges;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.tez.client.TezClient;
+import org.apache.tez.dag.api.DAG;
+import org.apache.tez.dag.api.ProcessorDescriptor;
+import org.apache.tez.dag.api.TezConfiguration;
+import org.apache.tez.dag.api.TezException;
+import org.apache.tez.dag.api.Vertex;
+import org.apache.tez.dag.api.client.DAGClient;
+import org.apache.tez.dag.api.client.DAGStatus;
+import org.apache.tez.runtime.library.processor.SleepProcessor;
+import org.apache.tez.runtime.library.processor.SleepProcessor.SleepProcessorConfig;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestAM {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestAM.class);
+
+  private static MiniTezCluster tezCluster;
+  private static MiniDFSCluster dfsCluster;
+
+  private static Configuration conf = new Configuration();
+  private static FileSystem remoteFs;
+
+  private static final String TEST_ROOT_DIR = "target" + Path.SEPARATOR + TestAM.class.getName() + "-tmpDir";
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    try {
+      conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEST_ROOT_DIR);
+      dfsCluster = new MiniDFSCluster.Builder(conf).numDataNodes(2).format(true).racks(null).build();
+      remoteFs = dfsCluster.getFileSystem();
+    } catch (IOException io) {
+      throw new RuntimeException("problem starting mini dfs cluster", io);
+    }
+
+    if (tezCluster == null) {
+      tezCluster = new MiniTezCluster(TestAM.class.getName(), 1, 1, 1);
+      Configuration tezClusterConf = new Configuration();
+      tezClusterConf.set("fs.defaultFS", remoteFs.getUri().toString()); // use HDFS
+      tezClusterConf.setInt("yarn.nodemanager.delete.debug-delay-sec", 20000);
+      tezClusterConf.setLong(TezConfiguration.TEZ_AM_SLEEP_TIME_BEFORE_EXIT_MILLIS, 1000);
+      tezClusterConf.set(YarnConfiguration.PROXY_ADDRESS, "localhost");
+      tezCluster.init(tezClusterConf);
+      tezCluster.start();
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    if (tezCluster != null) {
+      tezCluster.stop();
+      tezCluster = null;
+    }
+    if (dfsCluster != null) {
+      dfsCluster.shutdown();
+      dfsCluster = null;
+    }
+  }
+
+  @Test(timeout = 60000)
+  public void testAMWebUIService() throws TezException, IOException, InterruptedException {
+    SleepProcessorConfig spConf = new SleepProcessorConfig(1);
+
+    DAG dag = DAG.create("TezSleepProcessor");
+    Vertex vertex = Vertex.create("SleepVertex",
+        ProcessorDescriptor.create(SleepProcessor.class.getName()).setUserPayload(spConf.toUserPayload()), 1,
+        Resource.newInstance(1024, 1));
+    dag.addVertex(vertex);
+
+    TezConfiguration tezConf = new TezConfiguration(tezCluster.getConfig());
+    TezClient tezSession = TezClient.create("TezSleepProcessor", tezConf, false);
+    tezSession.start();
+
+    DAGClient dagClient = tezSession.submitDAG(dag);
+
+    DAGStatus dagStatus = dagClient.getDAGStatus(null);
+    while (!dagStatus.isCompleted()) {
+      Thread.sleep(500L);
+      dagStatus = dagClient.getDAGStatus(null);
+    }
+
+    String webUIAddress = dagClient.getWebUIAddress();
+    assertNotNull("getWebUIAddress should return TezAM's web UI address", webUIAddress);
+    LOG.info("TezAM webUI address: " + webUIAddress);
+
+    checkAddress(webUIAddress + "/jmx");
+    checkAddress(webUIAddress + "/conf");
+    checkAddress(webUIAddress + "/stacks");
+
+    URL url = new URL(webUIAddress);
+    IntegerRanges portRange = conf.getRange(TezConfiguration.TEZ_AM_WEBSERVICE_PORT_RANGE,
+        TezConfiguration.TEZ_AM_WEBSERVICE_PORT_RANGE_DEFAULT);
+    assertTrue("WebUIService port should be in the defined range (got: " + url.getPort() + ")",
+        portRange.getRangeStart() <= url.getPort());
+
+    tezSession.stop();
+  }
+
+  private void checkAddress(String url) {
+    boolean success = false;
+    try {
+      HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+      connection.connect();
+      success = (connection.getResponseCode() == 200);
+    } catch (Exception e) {
+      LOG.error("Error while checking url: " + url, e);
+    }
+    assertTrue(url + " should be available", success);
+  }
+}


### PR DESCRIPTION
Add some diagnostic endpoints to TezAM's WebUIService

- add new endpoints to webuiservice
- make port range configurable
- publish the web endpoint through dag client
- unit test included: TestAM
- checked in browser too