### PR TITLE
TEZ-4381: Speed up TestSecureShuffle

### DIFF
--- a/tez-tests/src/test/java/org/apache/tez/test/TestSecureShuffle.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestSecureShuffle.java
@@ -146,6 +146,8 @@ public class TestSecureShuffle {
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_READ_TIMEOUT, 3 * 1000);
     //set to low value so that it can detect failures quickly
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_FAILURES_LIMIT, 2);
+    //reduce the maximum number of failed attempts per task
+    conf.setInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS, 1);
 
     conf.setLong(TezConfiguration.TEZ_AM_SLEEP_TIME_BEFORE_EXIT_MILLIS, 500);
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_USE_ASYNC_HTTP, asyncHttp);


### PR DESCRIPTION
I've changed the recommended `TEZ_AM_TASK_MAX_FAILED_ATTEMPTS` configuration value and made some test run to see the run times. The default value for maximum failed attempts per task was 4 so I did 4 different run for each test where I reduced the config value by 1 in each run.

`[sslInCluster:true, resultWithTezSSL:0, resultWithoutTezSSL:1, asyncHttp:false, taskMaxFailed:4]`	**1min 25sec**
`[sslInCluster:true, resultWithTezSSL:0, resultWithoutTezSSL:1, asyncHttp:false, taskMaxFailed:3]`	**1min 0sec**
`[sslInCluster:true, resultWithTezSSL:0, resultWithoutTezSSL:1, asyncHttp:false, taskMaxFailed:2]`	**48sec 655ms**
`[sslInCluster:true, resultWithTezSSL:0, resultWithoutTezSSL:1, asyncHttp:false, taskMaxFailed:1]`	**53sec 320ms**

`[sslInCluster:true, resultWithTezSSL:0, resultWithoutTezSSL:1, asyncHttp:true, taskMaxFailed:4]`	**7min 59sec**
`[sslInCluster:true, resultWithTezSSL:0, resultWithoutTezSSL:1, asyncHttp:true, taskMaxFailed:3]`	**5min 55sec**
`[sslInCluster:true, resultWithTezSSL:0, resultWithoutTezSSL:1, asyncHttp:true, taskMaxFailed:2]`	**3min 47sec**
`[sslInCluster:true, resultWithTezSSL:0, resultWithoutTezSSL:1, asyncHttp:true, taskMaxFailed:1]`	**1min 41sec**

`[sslInCluster:false, resultWithTezSSL:1, resultWithoutTezSSL:0, asyncHttp:true, taskMaxFailed:4]`	**51sec 613ms**
`[sslInCluster:false, resultWithTezSSL:1, resultWithoutTezSSL:0, asyncHttp:true, taskMaxFailed:3]`	**44sec 417ms**
`[sslInCluster:false, resultWithTezSSL:1, resultWithoutTezSSL:0, asyncHttp:true, taskMaxFailed:2]`	**41sec 378ms**
`[sslInCluster:false, resultWithTezSSL:1, resultWithoutTezSSL:0, asyncHttp:true, taskMaxFailed:1]`	**39sec 172ms**

`[sslInCluster:false, resultWithTezSSL:1, resultWithoutTezSSL:0, asyncHttp:false, taskMaxFailed:4]`  **51sec 87ms**
`[sslInCluster:false, resultWithTezSSL:1, resultWithoutTezSSL:0, asyncHttp:false, taskMaxFailed:3]`  **47sec 374ms**
`[sslInCluster:false, resultWithTezSSL:1, resultWithoutTezSSL:0, asyncHttp:false, taskMaxFailed:2]`  **55sec 452ms**
`[sslInCluster:false, resultWithTezSSL:1, resultWithoutTezSSL:0, asyncHttp:false, taskMaxFailed:1]`   **39sec 101ms**