### PR TITLE
TEZ-4399: ShuffleHandler fails with SSLHandshakeException not found when SSL is enabled

### DIFF
--- a/tez-dag/src/main/java/org/apache/tez/dag/app/launcher/DagDeleteRunnable.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/launcher/DagDeleteRunnable.java
@@ -54,7 +54,7 @@ class DagDeleteRunnable implements Runnable {
     try {
       URL baseURL = TezRuntimeUtils.constructBaseURIForShuffleHandlerDagComplete(
           nodeId.getHost(), shufflePort,
-          dag.getApplicationId().toString(), dag.getId(), false);
+          dag.getApplicationId().toString(), dag.getId(), httpConnectionParams.isSslShuffle());
       httpConnection = TezRuntimeUtils.getHttpConnection(true, baseURL, httpConnectionParams,
           "DAGDelete", jobTokenSecretManager);
       httpConnection.connect();

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/launcher/TaskAttemptFailedDeleteRunnable.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/launcher/TaskAttemptFailedDeleteRunnable.java
@@ -55,7 +55,7 @@ class TaskAttemptFailedRunnable implements Runnable {
       URL baseURL = TezRuntimeUtils.constructBaseURIForShuffleHandlerTaskAttemptFailed(
           nodeId.getHost(), shufflePort, taskAttemptID.getTaskID().getVertexID().getDAGID().
               getApplicationId().toString(), taskAttemptID.getTaskID().getVertexID().getDAGID().getId(),
-          taskAttemptID.toString(), false);
+          taskAttemptID.toString(), httpConnectionParams.isSslShuffle());
       httpConnection = TezRuntimeUtils.getHttpConnection(true, baseURL, httpConnectionParams,
           "FailedTaskAttemptDelete", jobTokenSecretManager);
       httpConnection.connect();

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/launcher/VertexDeleteRunnable.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/launcher/VertexDeleteRunnable.java
@@ -56,7 +56,8 @@ public class VertexDeleteRunnable implements Runnable {
     try {
       URL baseURL = TezRuntimeUtils.constructBaseURIForShuffleHandlerVertexComplete(
           nodeId.getHost(), shufflePort,
-          vertex.getDAGID().getApplicationId().toString(), vertex.getDAGID().getId(), vertexId, false);
+          vertex.getDAGID().getApplicationId().toString(), vertex.getDAGID().getId(), vertexId,
+          httpConnectionParams.isSslShuffle());
       httpConnection = TezRuntimeUtils.getHttpConnection(true, baseURL, httpConnectionParams,
           "VertexDelete", jobTokenSecretManager);
       httpConnection.connect();

--- a/tez-plugins/tez-aux-services/pom.xml
+++ b/tez-plugins/tez-aux-services/pom.xml
@@ -247,6 +247,7 @@
                   <excludes>
                     <exclude>javax.crypto.*</exclude>
                     <exclude>javax.security.**</exclude>
+                    <exclude>javax.net.**</exclude>
                   </excludes>
                 </relocation>
               </relocations>


### PR DESCRIPTION
Shuffle handler fails with ClassNotFound org.apache.tez.shaded.javax.net.ssl.SSLHandshakeException
when SSL is enabled. Excluding shading of javax.net.** from
tez-aux-services uber jar.

DagDeleteTracker is hardcoded to generate URL with http. Fixing it to
use https when SSL config is enabled.