### PR TITLE
TEZ-4403: Upgrade SLF4J Version To 1.7.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <netty.version>4.1.72.Final</netty.version>
     <pig.version>0.13.0</pig.version>
     <jersey.version>1.19</jersey.version>
-    <slf4j.version>1.7.30</slf4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <protobuf.version>2.5.0</protobuf.version>
     <roaringbitmap.version>0.7.45</roaringbitmap.version>
     <protoc.path>${env.PROTOC_PATH}</protoc.path>


### PR DESCRIPTION
Currently we are on slf4j 1.7.30,  As per https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12/1.7.30 , There are four CVE's against this version.
1. CVE-2022-23305
2. CVE-2022-23302
3. CVE-2021-4104
4. CVE-2019-17571

Upgrading to 1.7.36 https://mvnrepository.com/artifact/org.slf4j/slf4j-log4j12/1.7.36 should solve the security concerns.

Reference
1. https://github.com/apache/tez/blob/master/pom.xml#L256
2. https://github.com/apache/tez/blob/master/pom.xml#L240