### PR TITLE
Upgrade protobuf-java version to 3.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <pig.version>0.13.0</pig.version>
     <jersey.version>1.19</jersey.version>
     <slf4j.version>1.7.30</slf4j.version>
-    <protobuf.version>2.5.0</protobuf.version>
+    <protobuf.version>3.16.1</protobuf.version>
     <roaringbitmap.version>0.7.45</roaringbitmap.version>
     <protoc.path>${env.PROTOC_PATH}</protoc.path>
     <scm.url>scm:git:https://gitbox.apache.org/repos/asf/tez.git</scm.url>


### PR DESCRIPTION
Upgrade protobuf-java version to 3.16.1 due to security compliance issue CVE-2021-22569

Link: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569

TEZ-4410