### PR TITLE
TEZ-4412 ensure mkDirForAM create directory with special permissions

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/common/TezCommonUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/common/TezCommonUtils.java
@@ -293,11 +293,11 @@ public class TezCommonUtils {
   public static void mkDirForAM(FileSystem fs, Path dir) throws IOException {
     FsPermission perm = new FsPermission(TEZ_AM_DIR_PERMISSION);
     fs.mkdirs(dir, perm);
-    if(!fs.getFileStatus(dir).getPermission().equals(perm)){
-        LOG.warn("Directory " + dir.toString() + " created with unexpected permissions : "
-          + fs.getFileStatus(dir).getPermission() + ". Fixing permissions to correct value : "
-          + perm.toString());
-        fs.setPermission(dir,perm);
+    if (!fs.getFileStatus(dir).getPermission().equals(perm)) {
+      LOG.warn("Directory " + dir.toString() + " created with unexpected permissions : "
+            + fs.getFileStatus(dir).getPermission() + ". Fixing permissions to correct value : "
+            + perm.toString());
+      fs.setPermission(dir, perm);
     }
   }
 

--- a/tez-api/src/main/java/org/apache/tez/common/TezCommonUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/common/TezCommonUtils.java
@@ -291,7 +291,14 @@ public class TezCommonUtils {
    * @throws IOException
    */
   public static void mkDirForAM(FileSystem fs, Path dir) throws IOException {
-    fs.mkdirs(dir, new FsPermission(TEZ_AM_DIR_PERMISSION));
+    FsPermission perm = new FsPermission(TEZ_AM_DIR_PERMISSION);
+    fs.mkdirs(dir, perm);
+    if(!fs.getFileStatus(dir).getPermission().equals(perm)){
+        LOG.warn("Directory " + dir.toString() + " created with unexpected permissions : "
+          + fs.getFileStatus(dir).getPermission() + ". Fixing permissions to correct value : "
+          + perm.toString());
+        fs.setPermission(dir,perm);
+    }
   }
 
   /**

--- a/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.LocalResourceType;

--- a/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
@@ -425,5 +425,6 @@ public class TestTezCommonUtils {
     Path path = new Path(TEST_ROOT_DIR + "/testMkDirForAM");
     TezCommonUtils.mkDirForAM(remoteFileSystem, path);
     Assert.assertEquals(TezCommonUtils.TEZ_AM_DIR_PERMISSION, remoteFileSystem.getFileStatus(path).getPermission());
+    miniDFS.shutdown();
   }
 }

--- a/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.LocalResourceType;
@@ -413,4 +414,10 @@ public class TestTezCommonUtils {
   }
 
 
+  @Test
+  public void testMkDirForAM() throws IOException {
+    Path path = new Path("/tmp/testMkDirForAM");
+    TezCommonUtils.mkDirForAM(remoteFs, path);
+    Assert.assertEquals(TezCommonUtils.TEZ_AM_DIR_PERMISSION, remoteFs.getFileStatus(path).getPermission());
+  }
 }

--- a/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -416,8 +417,14 @@ public class TestTezCommonUtils {
 
   @Test
   public void testMkDirForAM() throws IOException {
-    Path path = new Path("/tmp/testMkDirForAM");
-    TezCommonUtils.mkDirForAM(remoteFs, path);
-    Assert.assertEquals(TezCommonUtils.TEZ_AM_DIR_PERMISSION, remoteFs.getFileStatus(path).getPermission());
+    Configuration remoteConf = new Configuration();
+    remoteConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEST_ROOT_DIR);
+    remoteConf.set(CommonConfigurationKeys.FS_PERMISSIONS_UMASK_KEY, "777");
+    MiniDFSCluster miniDFS = new MiniDFSCluster.Builder(remoteConf).numDataNodes(3).format(true).racks(null)
+        .build();
+    FileSystem remoteFileSystem = miniDFS.getFileSystem();
+    Path path = new Path(TEST_ROOT_DIR + "/testMkDirForAM");
+    TezCommonUtils.mkDirForAM(remoteFileSystem, path);
+    Assert.assertEquals(TezCommonUtils.TEZ_AM_DIR_PERMISSION, remoteFileSystem.getFileStatus(path).getPermission());
   }
 }


### PR DESCRIPTION
TEZ-4412 ensure mkDirForAM create directory with special permissions

I found TezClientUtils has method ensureStagingDirExists.It will check whether the path "stagingArea" exists, if it exists, check the permission, if not, call the function "TezCommonUtils.mkDirForAM" to create.But in method mkDirForAM,it use mkdir(path, permission) to create, if umask too strict such as 777,this directory will set with 000 permission.So we need to ensure the directory has right permission.

In this patch, I compared the permissions of the files with the expected permissions. If they are inconsistent, then log this and use setPermission to grant directory permissions.