### PR TITLE
TEZ-4423[CVE-2021-44906] Upgrade minimist version from 0.0.8 to 1.2.6

### DIFF
--- a/tez-ui/src/main/webapp/package.json
+++ b/tez-ui/src/main/webapp/package.json
@@ -64,6 +64,8 @@
     "em-tgraph": "0.0.14"
   },
   "resolutions": {
-    "**/form-data/async": "2.6.4"
+    "**/form-data/async": "2.6.4",
+    "**/mkdirp/minimist": "1.2.6",
+    "**/optimist/minimist": "1.2.6"
   }
 }

--- a/tez-ui/src/main/webapp/yarn.lock
+++ b/tez-ui/src/main/webapp/yarn.lock
@@ -3290,9 +3290,9 @@ minimatch@~0.2.9:
     lru-cache "2"
     sigmund "~1.0.0"
 
-minimist@0.0.8, minimist@~0.0.1:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+minimist@0.0.8, minimist@1.2.6, minimist@~0.0.1:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
 
 minimist@^1.1.0, minimist@^1.1.1:
   version "1.2.0"


### PR DESCRIPTION
[TEZ-4423][CVE-2021-44906] Upgrade minimist version from 0.0.8 to 1.2.6 to fix the vulnerability.
Link to JIRA : https://issues.apache.org/jira/browse/TEZ-4423

Link to parent JIRA : https://issues.apache.org/jira/browse/TEZ-4419

RFC documentation : https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-selective-versions-resolutions.md
