### PR TITLE
TEZ-4424: [CVE-2021-3918] Upgrade json-schema from 0.2.3 to 0.4.0

### DIFF
--- a/tez-ui/src/main/webapp/package.json
+++ b/tez-ui/src/main/webapp/package.json
@@ -66,6 +66,7 @@
   "resolutions": {
     "**/form-data/async": "2.6.4",
     "**/mkdirp/minimist": "1.2.6",
-    "**/optimist/minimist": "1.2.6"
+    "**/optimist/minimist": "1.2.6",
+    "**/jsprim/json-schema": "0.4.0"
   }
 }

--- a/tez-ui/src/main/webapp/yarn.lock
+++ b/tez-ui/src/main/webapp/yarn.lock
@@ -2789,9 +2789,9 @@ json-parse-helpfulerror@^1.0.2:
   dependencies:
     jju "^1.1.0"
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
+json-schema@0.2.3, json-schema@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
 
 json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
[TEZ-4424] [CVE-2021-3918] Upgrade json-schema from 0.2.3 to 0.4.0 to fix the vulnerability. 
Link to JIRA : https://issues.apache.org/jira/browse/TEZ-4424

Link to parent JIRA : https://issues.apache.org/jira/browse/TEZ-4419

RFC documentation : https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-selective-versions-resolutions.md