### PR TITLE
TEZ-4429: Upgrade guava to 31.1 to fix CVE-2020-8908.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <distMgmtStagingUrl>https://repository.apache.org/service/local/staging/deploy/maven2</distMgmtStagingUrl>
 
     <clover.license>${user.home}/clover.license</clover.license>
-    <guava.version>27.0-jre</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <hadoop.version>3.3.1</hadoop.version>
     <netty.version>4.1.72.Final</netty.version>
     <pig.version>0.13.0</pig.version>


### PR DESCRIPTION
Change-Id: Iec3f325f146aba8ee4b6006d8bc70ea8dbfeabad