### PR TITLE
TEZ-4425: [WS-2020-0345] Upgrade jsonpointer version from 4.0.1 to 4.1.0

### DIFF
--- a/tez-ui/src/main/webapp/package.json
+++ b/tez-ui/src/main/webapp/package.json
@@ -67,6 +67,7 @@
     "**/form-data/async": "2.6.4",
     "**/mkdirp/minimist": "1.2.6",
     "**/optimist/minimist": "1.2.6",
-    "**/jsprim/json-schema": "0.4.0"
+    "**/jsprim/json-schema": "0.4.0",
+    "jsonpointer": "4.1.0"
   }
 }

--- a/tez-ui/src/main/webapp/yarn.lock
+++ b/tez-ui/src/main/webapp/yarn.lock
@@ -2821,9 +2821,9 @@ jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
-jsonpointer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
+jsonpointer@4.1.0, jsonpointer@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.1.0.tgz#501fb89986a2389765ba09e6053299ceb4f2c2cc"
 
 jsprim@^1.2.2:
   version "1.4.0"


### PR DESCRIPTION
[WS-2020-0345] Upgrade jsonpointer version from 4.0.1 to 4.1.0 to fix the vulnerability.
Link to JIRA : https://issues.apache.org/jira/browse/TEZ-4425

Link to parent JIRA : https://issues.apache.org/jira/browse/TEZ-4419

RFC documentation : https://github.com/yarnpkg/rfcs/blob/master/implemented/0000-selective-versions-resolutions.md