### PR TITLE
TEZ-3322: Add Apache license to the generated tez-configuration-template files

### DIFF
--- a/tez-tools/tez-javadoc-tools/src/main/java/org/apache/tez/tools/javadoc/util/XmlWriter.java
+++ b/tez-tools/tez-javadoc-tools/src/main/java/org/apache/tez/tools/javadoc/util/XmlWriter.java
@@ -21,13 +21,16 @@ package org.apache.tez.tools.javadoc.util;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 
 import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.tez.tools.javadoc.model.Config;
 import org.apache.tez.tools.javadoc.model.ConfigProperty;
+
+import com.google.common.io.ByteStreams;
 
 public class XmlWriter extends Writer {
 
@@ -46,9 +49,10 @@ public class XmlWriter extends Writer {
 
     try {
       File file = new File(fileName);
-      out = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), "UTF-8"));
+      writeApacheHeader(file);
 
-      out.println("<?xml version=\"1.0\"?>");
+      out = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file, true), "UTF-8"));
+
       out.println("<?xml-stylesheet type=\"text/xsl\" href=\"configuration.xsl\"?>");
       out.println();
       out.println("<!-- WARNING: THIS IS A GENERATED TEMPLATE PURELY FOR DOCUMENTATION PURPOSES");
@@ -95,5 +99,10 @@ public class XmlWriter extends Writer {
     }
   }
 
-
+  private void writeApacheHeader(File file) throws IOException {
+    try (InputStream in = this.getClass().getClassLoader().getResourceAsStream("apache-licence.xml.header");
+      OutputStream out = new FileOutputStream(file)) {
+      ByteStreams.copy(in, out);
+    }
+  }
 }

--- a/tez-tools/tez-javadoc-tools/src/main/resources/apache-licence.xml.header
+++ b/tez-tools/tez-javadoc-tools/src/main/resources/apache-licence.xml.header
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->


### PR DESCRIPTION
tested:
built tez-javadoc-tools procject
```
cd tez-runtime-library
mvn site
```
checked ./target/site/apidocs/configs/tez-runtime-default-template.xml