### PR TITLE
TEZ-4449: Upgrade jettison to 1.5.1 to fix CVE-2022-40149.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -738,7 +738,7 @@
       <dependency>
         <groupId>org.codehaus.jettison</groupId>
         <artifactId>jettison</artifactId>
-        <version>1.3.4</version>
+        <version>1.5.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
JIRA: [TEZ-4449](https://issues.apache.org/jira/projects/TEZ/issues/TEZ-4449?filter=allissues): Upgrade jettison to 1.5.1 to fix CVE-2022-40149.