### PR TITLE
TEZ-4454: remove extra semicolons

### DIFF
--- a/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
@@ -49,7 +49,7 @@ public class TestTezCommonUtils {
   private static final File LOCAL_STAGING_DIR = new File(System.getProperty("test.build.data"),
       TestTezCommonUtils.class.getSimpleName()).getAbsoluteFile();
   private static String RESOLVED_STAGE_DIR;
-  private static Configuration conf = new Configuration();;
+  private static Configuration conf = new Configuration();
   private static String TEST_ROOT_DIR = "target" + Path.SEPARATOR
       + TestTezCommonUtils.class.getName() + "-tmpDir";
   private static MiniDFSCluster dfsCluster = null;

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/VertexImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/VertexImpl.java
@@ -681,7 +681,7 @@ public class VertexImpl implements org.apache.tez.dag.app.dag.Vertex, EventHandl
         .registerStateEnteredCallback(VertexState.RUNNING,
             STATE_CHANGED_CALLBACK)
         .registerStateEnteredCallback(VertexState.INITIALIZING,
-            STATE_CHANGED_CALLBACK);;
+            STATE_CHANGED_CALLBACK);
   }
 
   private final StateMachineTez<VertexState, VertexEventType, VertexEvent, VertexImpl> stateMachine;
@@ -3886,7 +3886,7 @@ public class VertexImpl implements org.apache.tez.dag.app.dag.Vertex, EventHandl
     } else {
       String diag = "Commit failed for output:" + commitCompletedEvent.getOutputName()
           + ", vertexId=" + logIdentifier + ", "
-          + ExceptionUtils.getStackTrace(commitCompletedEvent.getException());;
+          + ExceptionUtils.getStackTrace(commitCompletedEvent.getException());
       LOG.info(diag);
       addDiagnostic(diag);
       trySetTerminationCause(VertexTerminationCause.COMMIT_FAILURE);
@@ -4398,7 +4398,7 @@ public class VertexImpl implements org.apache.tez.dag.app.dag.Vertex, EventHandl
         addIO(vertex.getName());
       }
     } finally {
-      writeLock.unlock();;
+      writeLock.unlock();
     }
   }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/MergeManager.java
@@ -322,7 +322,7 @@ public class MergeManager implements FetchedInputAllocatorOrderedGrouped {
     if (this.memToMemMerger != null) {
       memToMemMerger.setParentThread(shuffleSchedulerThread);
     }
-    this.inMemoryMerger.setParentThread(shuffleSchedulerThread);;
+    this.inMemoryMerger.setParentThread(shuffleSchedulerThread);
     this.onDiskMerger.setParentThread(shuffleSchedulerThread);
   }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/TezMerger.java
@@ -699,7 +699,7 @@ public class TezMerger {
       int s1 = key1.getPosition();
       int l1 = key1.getLength();
       int s2 = key2.getPosition();
-      int l2 = key2.getLength();;
+      int l2 = key2.getLength();
 
       return comparator.compare(key1.getData(), s1, l1, key2.getData(), s2, l2) < 0;
     }

--- a/tez-tests/src/test/java/org/apache/tez/test/TestInput.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestInput.java
@@ -393,7 +393,7 @@ public class TestInput extends AbstractLogicalInput {
 
   @Override
   public List<Event> close() throws Exception {
-    getContext().getCounters().findCounter(COUNTER_NAME, COUNTER_NAME).increment(1);;
+    getContext().getCounters().findCounter(COUNTER_NAME, COUNTER_NAME).increment(1);
     return null;
   }
 

--- a/tez-tests/src/test/java/org/apache/tez/test/TestOutput.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestOutput.java
@@ -80,7 +80,7 @@ public class TestOutput extends AbstractLogicalOutput {
   @Override
   public List<Event> close() throws Exception {
     LOG.info("Sending data movement event with value: " + output);
-    getContext().getCounters().findCounter(COUNTER_NAME, COUNTER_NAME).increment(1);;
+    getContext().getCounters().findCounter(COUNTER_NAME, COUNTER_NAME).increment(1);
     ByteBuffer result = ByteBuffer.allocate(4).putInt(output);
     result.flip();
     List<Event> events = Lists.newArrayListWithCapacity(getNumPhysicalOutputs());


### PR DESCRIPTION
JIRA: [TEZ-4454: remove extra commas.](https://issues.apache.org/jira/browse/TEZ-4454)

While reading the code, I found that there are extra commas in the code, I searched the whole project and removed the extra commas.