### PR TITLE
TEZ-4455: Add LoggingHandler in ShuffleHandler pipeline for better debuggability

### DIFF
--- a/tez-plugins/tez-aux-services/src/main/java/org/apache/tez/auxservices/ShuffleHandler.java
+++ b/tez-plugins/tez-aux-services/src/main/java/org/apache/tez/auxservices/ShuffleHandler.java
@@ -33,6 +33,8 @@ import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
 import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import io.netty.handler.logging.LogLevel;
+import io.netty.handler.logging.LoggingHandler;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -602,6 +604,9 @@ public class ShuffleHandler extends AuxiliaryService {
         ChannelPipeline pipeline = ch.pipeline();
         if (sslFactory != null) {
           pipeline.addLast("ssl", new SslHandler(sslFactory.createSSLEngine()));
+        }
+        if (LOG.isDebugEnabled()) {
+          pipeline.addLast("loggingHandler", new LoggingHandler(LogLevel.DEBUG));
         }
         pipeline.addLast("decoder", new HttpRequestDecoder());
         pipeline.addLast("aggregator", new HttpObjectAggregator(1 << 16));


### PR DESCRIPTION
**What changes were proposed in this pull request?**
Adding LoggingHandler in ShuffleHandler pipeline for better debuggability.

**Why are the changes needed?**
For corner case debugging, it will be helpful to understand when netty processed OPEN/BOUND/CLOSE/RECEIVED/CONNECTED events along with payload details.
Adding "LoggingHandler" in ChannelPipeline mode to help in debugging.

**Does this PR introduce any user-facing change?**
No.

**How was this patch tested?**
Pre-commit testing.