### PR TITLE
TEZ-4456: Upgraded is-my-json-valid version to 2.20.3 to fix the vulnerability

### DIFF
--- a/tez-ui/src/main/webapp/package.json
+++ b/tez-ui/src/main/webapp/package.json
@@ -70,6 +70,7 @@
     "**/jsprim/json-schema": "0.4.0",
     "jsonpointer": "4.1.0",
     "cryptiles": "4.1.2",
-    "lodash.merge": "4.6.2"
+    "lodash.merge": "4.6.2",
+    "is-my-json-valid": "2.20.3"
   }
 }

--- a/tez-ui/src/main/webapp/yarn.lock
+++ b/tez-ui/src/main/webapp/yarn.lock
@@ -2672,12 +2672,17 @@ is-integer@^1.0.4:
   dependencies:
     is-finite "^1.0.0"
 
-is-my-json-valid@^2.12.4:
-  version "2.16.0"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
+is-my-ip-valid@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.1.tgz#f7220d1146257c98672e6fba097a9f3f2d348442"
+
+is-my-json-valid@2.20.3, is-my-json-valid@^2.12.4:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.20.3.tgz#7e72dfd435b7341bc4ba4caa44ccd5703a8f8e19"
   dependencies:
     generate-function "^2.0.0"
     generate-object-property "^1.1.0"
+    is-my-ip-valid "^1.0.0"
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 


### PR DESCRIPTION
TEZ-4456: Upgraded is-my-json-valid version to 2.20.3 to fix the vulnerability. This is a critical vulnerability to fix. The parent JIRA can be tracked under : https://issues.apache.org/jira/browse/TEZ-4419
