### PR TITLE
TEZ-4462: update common-codec to 1.13 to fix vulnerability SNYK-JAVA-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.11</version>
+        <version>1.13</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
This PR proposes to upgrade commons-codec to 1.13.

The commons-codec:commons-codec version contains a vunerability detected by Snyk:

[commons-codec:commons-codec](https://commons.apache.org/proper/commons-codec) is a package that contains simple encoder and decoders for various formats such as Base64 and Hexadecimal.

Affected versions of this package are vulnerable to Information Exposure.
https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518