### PR TITLE
TEZ-4474: Added config to fail the DAG status when recovery data is missing

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/dag/api/TezConfiguration.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/TezConfiguration.java
@@ -1828,6 +1828,18 @@ public class TezConfiguration extends Configuration {
       TEZ_PREFIX + "dag.recovery.enabled";
   public static final boolean DAG_RECOVERY_ENABLED_DEFAULT = true;
 
+
+  /**
+   * Boolean value. When set, this enables AM to fail when DAG recovery is enabled and
+   * restarted app master did not find anything to recover
+   * Expert level setting.
+   */
+  @ConfigurationScope(Scope.AM)
+  @ConfigurationProperty(type="boolean")
+  public static final String TEZ_AM_FAILURE_ON_MISSING_RECOVERY_DATA =
+          TEZ_AM_PREFIX + "failure.on.missing.recovery.data";
+  public static final boolean TEZ_AM_FAILURE_ON_MISSING_RECOVERY_DATA_DEFAULT = false;
+
   /**
    * Int value. Size in bytes for the IO buffer size while processing the recovery file.
    * Expert level setting.


### PR DESCRIPTION
When Tez DAG recovery is failed because of some reason in the second retry of any Tez AM, then in corner case scenario, Tez Job sets DAG state to IDLE

Once the DAG state is set to IDLE, then after checkAndHandleSessionTimeout(), Tez AM will try to shutdown the DAG, and since recovery was failed so there will not be any running DAGs

If there are no RUNNING DAGs and state of DAG is IDLE, then by default AM sets the status to SUCCEEDED

This can result in issues in dependent systems like Hive which will move ahead with other tasks in pipeline assuming the DAG was success, this can result in moving empty data in Hive

As part of this PR, we are proposing to introduce a patch in TEZ, which introduces a config, which when set, then in case of recovery missing in attempts > 1, it fails the DAG

Raised JIRA for the same: https://issues.apache.org/jira/browse/TEZ-4474