### PR TITLE
TEZ-4469:Upgrade jettison to 1.5.3 to fix CVE-2022-40150

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -739,7 +739,7 @@
       <dependency>
         <groupId>org.codehaus.jettison</groupId>
         <artifactId>jettison</artifactId>
-        <version>1.5.1</version>
+        <version>1.5.3</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/tez-dag/src/main/java/org/apache/tez/dag/history/utils/DAGUtils.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/history/utils/DAGUtils.java
@@ -111,7 +111,7 @@ public final class DAGUtils {
     return dagJson;
   }
   
-  public static JSONObject convertDataEventDependencyInfoToJSON(List<DataEventDependencyInfo> info) {
+  public static JSONObject convertDataEventDependencyInfoToJSON(List<DataEventDependencyInfo> info) throws JSONException{
     return new JSONObject(convertDataEventDependecyInfoToATS(info));
   }
   
@@ -436,7 +436,7 @@ public final class DAGUtils {
   }
 
   public static JSONObject convertServicePluginToJSON(
-      ServicePluginInfo servicePluginInfo) {
+      ServicePluginInfo servicePluginInfo) throws JSONException{
     JSONObject jsonObject = new JSONObject(convertServicePluginToATSMap(servicePluginInfo));
     return jsonObject;
   }


### PR DESCRIPTION
Upgrading Jettison version to 1.5.3 to fix CVEs