### PR TITLE
TEZ-4484 : [CVE-2022-24999] Upgrade qs from 6.2.3 to 6.2.4 to fix the vulnerability.

### DIFF
--- a/tez-ui/src/main/webapp/package.json
+++ b/tez-ui/src/main/webapp/package.json
@@ -71,6 +71,7 @@
     "jsonpointer": "4.1.0",
     "cryptiles": "4.1.2",
     "lodash.merge": "4.6.2",
-    "is-my-json-valid": "2.20.3"
+    "is-my-json-valid": "2.20.3",
+    "qs": "6.2.4"
   }
 }

--- a/tez-ui/src/main/webapp/yarn.lock
+++ b/tez-ui/src/main/webapp/yarn.lock
@@ -3826,21 +3826,9 @@ q@^1.1.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
 
-qs@5.2.0, qs@~5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-5.2.0.tgz#a9f31142af468cb72b25b30136ba2456834916be"
-
-qs@6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-
-qs@~5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-5.1.0.tgz#4d932e5c7ea411cca76a312d39a606200fd50cd9"
-
-qs@~6.2.0:
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.3.tgz#1cfcb25c10a9b2b483053ff39f5dfc9233908cfe"
+qs@5.2.0, qs@6.2.4, qs@6.4.0, qs@~5.1.0, qs@~5.2.0, qs@~6.2.0:
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.4.tgz#d90821bb8537cecc140e6c34f54ec76e54b39b22"
 
 quick-temp@0.1.3, quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3:
   version "0.1.3"


### PR DESCRIPTION
JIRA link : https://issues.apache.org/jira/browse/TEZ-4484. This address critical vulnerability CVE-2022-24999