### PR TITLE
TEZ-4485:  Upgrade jettison to 1.5.4 due to CVE-2023-1436

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -739,7 +739,7 @@
       <dependency>
         <groupId>org.codehaus.jettison</groupId>
         <artifactId>jettison</artifactId>
-        <version>1.5.3</version>
+        <version>1.5.4</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
[TEZ-4485](https://issues.apache.org/jira/browse/TEZ-4485)