### PR TITLE
TEZ-4492 : Approach 1 : Update Bower Registry to a different mirror

### DIFF
--- a/tez-ui/src/main/webapp/.bowerrc
+++ b/tez-ui/src/main/webapp/.bowerrc
@@ -1,5 +1,6 @@
 {
   "directory": "bower_components",
+  "registry": "https://bower.herokuapp.com",
   "analytics": false,
   "resolvers": [
     "bower-shrinkwrap-resolver-ext"


### PR DESCRIPTION
This approach updates `Bowerrc` to use `bower.herokuapp` mirror to avoid Bower Registry `CERT_EXPIRE `issue