### PR TITLE
DE-203 Downgrade version of guava to be consistent with hadoop3.3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
     <distMgmtStagingUrl>https://repository.apache.org/service/local/staging/deploy/maven2</distMgmtStagingUrl>
 
     <clover.license>${user.home}/clover.license</clover.license>
-    <guava.version>31.1-jre</guava.version>
-    <hadoop.version>3.3.1</hadoop.version>
+    <guava.version>27.0-jre</guava.version>
+    <hadoop.version>3.3.5</hadoop.version>
     <netty.version>4.1.72.Final</netty.version>
     <pig.version>0.13.0</pig.version>
     <jersey.version>1.19</jersey.version>


### PR DESCRIPTION
Downgrade version of guava from 31.1-jre to 27.0-jre, to be consistent with hadoop3.3.5