### PR TITLE
TEZ-4495: mvnsite fails for some modules - No public or protected classes found to document

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
     <dependency-check-maven.version>1.3.6</dependency-check-maven.version>
     <restrict-imports.enforcer.version>2.0.0</restrict-imports.enforcer.version>
     <test.build.data>${project.build.directory}/tmp</test.build.data>
+    <maven.javadoc.skip>true</maven.javadoc.skip> <!-- enabled only in relevant modules separately -->
   </properties>
   <scm>
     <connection>${scm.url}</connection>

--- a/tez-api/pom.xml
+++ b/tez-api/pom.xml
@@ -24,6 +24,10 @@
   </parent>
   <artifactId>tez-api</artifactId>
 
+  <properties>
+    <maven.javadoc.skip>false</maven.javadoc.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/tez-mapreduce/pom.xml
+++ b/tez-mapreduce/pom.xml
@@ -24,6 +24,10 @@
   </parent>
   <artifactId>tez-mapreduce</artifactId>
 
+  <properties>
+    <maven.javadoc.skip>false</maven.javadoc.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.tez</groupId>

--- a/tez-runtime-library/pom.xml
+++ b/tez-runtime-library/pom.xml
@@ -24,6 +24,10 @@
   </parent>
   <artifactId>tez-runtime-library</artifactId>
 
+  <properties>
+    <maven.javadoc.skip>false</maven.javadoc.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.roaringbitmap</groupId>


### PR DESCRIPTION
As described in jira, mvn site command fails for some modules. Instead of taking care of javadoc compliance of some non-production modules, it would make sense disable the plugin for all of the modules for which javadocs are not published,