### PR TITLE
TEZ-4508: Allow the FAIR_PARALLELISM mode to accept multiple source vertices

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/dag/library/vertexmanager/FairShuffleVertexManager.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/dag/library/vertexmanager/FairShuffleVertexManager.java
@@ -144,10 +144,6 @@ public class FairShuffleVertexManager extends ShuffleVertexManagerBase {
       return equals(FairRoutingType.REDUCE_PARALLELISM);
     }
 
-    public boolean fairParallelismEnabled() {
-      return equals(FairRoutingType.FAIR_PARALLELISM);
-    }
-
     public boolean enabled() {
       return !equals(FairRoutingType.NONE);
     }
@@ -190,18 +186,6 @@ public class FairShuffleVertexManager extends ShuffleVertexManagerBase {
 
   public FairShuffleVertexManager(VertexManagerPluginContext context) {
     super(context);
-  }
-
-  @Override
-  protected void onVertexStartedCheck() {
-    super.onVertexStartedCheck();
-    if (bipartiteSources > 1 &&
-        (mgrConfig.getFairRoutingType().fairParallelismEnabled())) {
-      // TODO TEZ-3500
-      throw new TezUncheckedException(
-          "Having more than one destination task process same partition(s) " +
-              "only works with one bipartite source.");
-    }
   }
 
   static long ceil(long a, long b) {


### PR DESCRIPTION
As explained in [TEZ-4508](https://issues.apache.org/jira/browse/TEZ-4508), I expect there are valid use cases where FairShuffleVertexManager with FAIR_PARALLELISM should accept multiple SCATTER_GATHER edges.