### PR TITLE
TEZ-4517: Upgrade commons-collection4 to 4.4.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <codehaus.mojo.version>1.3.2</codehaus.mojo.version>
     <commons-cli.version>1.2</commons-cli.version>
     <commons-codec.version>1.13</commons-codec.version>
-    <commons-collections4.version>4.1</commons-collections4.version>
+    <commons-collections4.version>4.4</commons-collections4.version>
     <commons-io.version>2.8.0</commons-io.version>
     <commons-lang.version>2.6</commons-lang.version>
     <clover.license>${user.home}/clover.license</clover.license>


### PR DESCRIPTION
[Details for Why?](https://devhub.checkmarx.com/cve-details/Cx78f40514-81ff/?utm_source=jetbrains&utm_medium=referral&utm_campaign=idea)