### PR TITLE
TEZ-4110: Make Tez fail fast when DFS quota is exceeded.

### DIFF
--- a/tez-runtime-internals/src/main/java/org/apache/tez/runtime/task/TezTaskRunner2.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/runtime/task/TezTaskRunner2.java
@@ -91,7 +91,7 @@ public class TezTaskRunner2 {
   // TaskRunnerCallable, a failure to heartbeat, or a signalFatalError on the context.
   private volatile Throwable firstException;
   private volatile EventMetaData exceptionSourceInfo;
-  private volatile TaskFailureType firstTaskFailureType;
+  volatile TaskFailureType firstTaskFailureType;
   private final AtomicBoolean errorReporterToAm = new AtomicBoolean(false);
 
   private volatile boolean oobSignalErrorInProgress = false;

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestTaskExecution2.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestTaskExecution2.java
@@ -658,7 +658,7 @@ public class TestTaskExecution2 {
   }
 
   @Test
-  public void testClusterStoragaeCapacityFatalError() throws IOException {
+  public void testClusterStorageCapacityFatalError() throws IOException {
     // Try having a ClusterStorageCapacityExceededException, which is nested within several exceptions.
     TezTaskRunner2ForTest taskRunner = createTaskRunnerForTest();
     TaskRunner2CallableResult executionResult = new TaskRunner2CallableResult(new Exception(


### PR DESCRIPTION
Tested on Hive.
**Without Patch**
```
----------------------------------------------------------------------------------------------
        VERTICES      MODE        STATUS  TOTAL  COMPLETED  RUNNING  PENDING  FAILED  KILLED  
----------------------------------------------------------------------------------------------
Map 1            container       RUNNING      1          0        0        1       4       0  
Reducer 2        container        INITED      1          0        0        1       0       0  
----------------------------------------------------------------------------------------------
VERTICES: 00/02  [>>--------------------------] 0%    ELAPSED TIME: 16.68 s    
----------------------------------------------------------------------------------------------
```

**With Patch**
```
----------------------------------------------------------------------------------------------
        VERTICES      MODE        STATUS  TOTAL  COMPLETED  RUNNING  PENDING  FAILED  KILLED  
----------------------------------------------------------------------------------------------
Map 1            container       RUNNING      1          0        0        1       1       0  
Reducer 2        container        INITED      1          0        0        1       0       0  
----------------------------------------------------------------------------------------------
VERTICES: 00/02  [>>--------------------------] 0%    ELAPSED TIME: 5.52 s     
----------------------------------------------------------------------------------------------
```