### PR TITLE
TEZ-4520: Enable Parallel Compilation for TEZ

### DIFF
--- a/tez-dist/pom.xml
+++ b/tez-dist/pom.xml
@@ -49,6 +49,12 @@
       <version>${project.version}</version>
       <type>test-jar</type>
     </dependency>
+    <dependency>
+        <groupId>org.apache.tez</groupId>
+        <artifactId>tez-job-analyzer</artifactId>
+        <version>${project.version}</version>
+        <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <properties>


### PR DESCRIPTION
Tez was unable to utilize Maven's multi-threaded compilation due to dependency issues, resulting in slow compilation. However, this problem was resolved through module dependency resolution. After implementing parallel compilation with Maven, the compilation speed increased several times over.

![image](https://github.com/apache/tez/assets/18082602/e77c02d9-9f70-446f-806e-3245118cfb99)
