### PR TITLE
Improve test reliability by resolving nondeterministic of HashMap 

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/dag/api/DAG.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/DAG.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -577,7 +578,7 @@ public class DAG {
 
     // check for valid vertices, duplicate vertex names,
     // and prepare for cycle detection
-    Map<String, AnnotatedVertex> vertexMap = new HashMap<String, AnnotatedVertex>();
+    Map<String, AnnotatedVertex> vertexMap = new LinkedHashMap<String, AnnotatedVertex>();
     Map<Vertex, Set<String>> inboundVertexMap = new HashMap<Vertex, Set<String>>();
     Map<Vertex, Set<String>> outboundVertexMap = new HashMap<Vertex, Set<String>>();
     for (Vertex v : vertices.values()) {
@@ -909,7 +910,7 @@ public class DAG {
             TezConfiguration.TEZ_TASK_RESOURCE_CPU_VCORES,
             TezConfiguration.TEZ_TASK_RESOURCE_CPU_VCORES_DEFAULT));
       }
-      Map<String, LocalResource> vertexLRs = Maps.newHashMap();
+      Map<String, LocalResource> vertexLRs = Maps.newLinkedHashMap();
       vertexLRs.putAll(vertex.getTaskLocalFiles());
       List<DataSourceDescriptor> dataSources = vertex.getDataSources();
       for (DataSourceDescriptor dataSource : dataSources) {
@@ -1007,7 +1008,7 @@ public class DAG {
         taskConfigBuilder.addAllLocalResource(DagTypeConverters.convertToDAGPlan(vertexLRs));
       }
 
-      Map<String, String> taskEnv = Maps.newHashMap(vertex.getTaskEnvironment());
+      Map<String, String> taskEnv = Maps.newLinkedHashMap(vertex.getTaskEnvironment());
       TezYARNUtils.setupDefaultEnv(taskEnv, tezConf,
           TezConfiguration.TEZ_TASK_LAUNCH_ENV,
           TezConfiguration.TEZ_TASK_LAUNCH_ENV_DEFAULT,

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexImpl.java
@@ -53,6 +53,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -2701,7 +2702,7 @@ public class TestVertexImpl {
       VertexPlan vertexPlan = dagPlan.getVertex(i);
       Vertex vertex = vertices.get(vertexPlan.getName());
       Map<Vertex, Edge> inVertices =
-          new HashMap<Vertex, Edge>();
+          new LinkedHashMap<>();
 
       Map<Vertex, Edge> outVertices =
           new HashMap<Vertex, Edge>();


### PR DESCRIPTION
# Problem 

I detected the unstable For the test :

[INFO] org.apache.tez.dag.api.TestDAG#testRecreateDAG
[INFO] org.apache.tez.dag.api.TestDAGPlan#userVertexOrderingIsMaintained

(they both use createDAG function and will be affected by the order of the vertex map)

[INFO] org.apache.tez.dag.app.dag.impl.TestVertexImpl#testVertexInit

All these tests assume the order of the Map (but java provided one with ordered specification called LinkedHashMap). which was not true.

# Solution

we used the order-specified one