### PR TITLE
TEZ-4523: Findbugs build is broken tez-tfile-parser.

### DIFF
--- a/tez-tools/tez-tfile-parser/findbugs-exclude.xml
+++ b/tez-tools/tez-tfile-parser/findbugs-exclude.xml
@@ -1,0 +1,16 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<FindBugsFilter>
+
+</FindBugsFilter>

--- a/tez-tools/tez-tfile-parser/src/main/java/org/apache/tez/tools/TFileRecordReader.java
+++ b/tez-tools/tez-tfile-parser/src/main/java/org/apache/tez/tools/TFileRecordReader.java
@@ -37,6 +37,7 @@ import java.io.BufferedReader;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Simple record reader which reads the TFile and emits it as key, value pair.
@@ -84,7 +85,7 @@ public class TFileRecordReader extends RecordReader<Text, Text> {
     //splitpath contains the machine name. Create the key as splitPath + realKey
     String keyStr = new StringBuilder()
         .append(splitPath.getName()).append(":")
-        .append(new String(keyBytesWritable.getBytes()))
+        .append(new String(keyBytesWritable.getBytes(), StandardCharsets.UTF_8))
         .toString();
 
     /**
@@ -92,7 +93,7 @@ public class TFileRecordReader extends RecordReader<Text, Text> {
      * better to handle such scenarios.
      */
     currentValueReader = new BufferedReader(
-        new InputStreamReader(entry.getValueStream()));
+        new InputStreamReader(entry.getValueStream(), StandardCharsets.UTF_8));
     key.set(keyStr);
     String line = currentValueReader.readLine();
     value.set((line == null) ? "" : line);


### PR DESCRIPTION
Findbugs build by adding the exclude file.

Fixed 2 findbugs warning highlighted post fix
![image](https://github.com/apache/tez/assets/25608848/e19df54d-b907-43e7-bdf1-087934a268ed)
