### PR TITLE
TEZ-4525: Remove broken links from site

### DIFF
--- a/docs/src/site/markdown/talks.md
+++ b/docs/src/site/markdown/talks.md
@@ -23,10 +23,3 @@ Talks
     Hitesh Shah at [Hadoop Summit 2014, San Jose, CA, USA](http://hadoopsummit.org/san-jose/)
     -   [Slides](https://www.slideshare.net/Hadoop_Summit/w-1205phall1saha)
     -   [Video](https://www.youtube.com/watch?v=yf_hBiZy3nk)
-
-User Meetup Recordings
-----------------------
-
--   [Recording](https://hortonworks.webex.com/hortonworks/ldr.php?AT=pb&amp;SP=MC&amp;rID=125516477&amp;rKey=d147a3c924b64496)
-    from [Meetup on July 31st, 2013](https://www.meetup.com/Apache-Tez-User-Group/events/130852782/)
-    at [Hortonworks Inc](https://hortonworks.com)


### PR DESCRIPTION
The links under Presentations and Talks on Tez section for User meetup recrodings is broken.

Link for recording: https://hortonworks.webex.com/hortonworks/ldr.php?AT=pb&SP=MC&rID=125516477&rKey=d147a3c924b64496

as well as meetup group link: http://www.meetup.com/Apache-Tez-User-Group/events/130852782/ doesn't exist anymore.