### PR TITLE
TEZ-4530: Distribution years in NOTICE files are incorrect

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-api/src/main/javadoc/resources/META-INF/NOTICE.txt
+++ b/tez-api/src/main/javadoc/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-api/src/main/resources/META-INF/NOTICE.txt
+++ b/tez-api/src/main/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-api/src/test/resources/META-INF/NOTICE.txt
+++ b/tez-api/src/test/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-common/src/main/javadoc/resources/META-INF/NOTICE.txt
+++ b/tez-common/src/main/javadoc/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-common/src/main/resources/META-INF/NOTICE.txt
+++ b/tez-common/src/main/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-common/src/test/resources/META-INF/NOTICE.txt
+++ b/tez-common/src/test/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-dag/src/main/javadoc/resources/META-INF/NOTICE.txt
+++ b/tez-dag/src/main/javadoc/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-dag/src/main/resources/META-INF/NOTICE.txt
+++ b/tez-dag/src/main/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-dag/src/test/resources/META-INF/NOTICE.txt
+++ b/tez-dag/src/test/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-dist/dist-files/full/NOTICE
+++ b/tez-dist/dist-files/full/NOTICE
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2015 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-dist/dist-files/minimal/NOTICE
+++ b/tez-dist/dist-files/minimal/NOTICE
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2015 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-dist/src/main/javadoc/resources/META-INF/NOTICE.txt
+++ b/tez-dist/src/main/javadoc/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-examples/src/main/javadoc/resources/META-INF/NOTICE.txt
+++ b/tez-examples/src/main/javadoc/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-examples/src/main/resources/META-INF/NOTICE.txt
+++ b/tez-examples/src/main/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-examples/src/test/resources/META-INF/NOTICE.txt
+++ b/tez-examples/src/test/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-mapreduce/src/main/javadoc/resources/META-INF/NOTICE.txt
+++ b/tez-mapreduce/src/main/javadoc/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-mapreduce/src/main/resources/META-INF/NOTICE.txt
+++ b/tez-mapreduce/src/main/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-mapreduce/src/test/resources/META-INF/NOTICE.txt
+++ b/tez-mapreduce/src/test/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-plugins/tez-yarn-timeline-cache-plugin/src/main/javadoc/resources/META-INF/NOTICE.txt
+++ b/tez-plugins/tez-yarn-timeline-cache-plugin/src/main/javadoc/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-plugins/tez-yarn-timeline-cache-plugin/src/main/resources/META-INF/NOTICE.txt
+++ b/tez-plugins/tez-yarn-timeline-cache-plugin/src/main/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-plugins/tez-yarn-timeline-history-with-fs/src/main/javadoc/resources/META-INF/NOTICE.txt
+++ b/tez-plugins/tez-yarn-timeline-history-with-fs/src/main/javadoc/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-plugins/tez-yarn-timeline-history-with-fs/src/main/resources/META-INF/NOTICE.txt
+++ b/tez-plugins/tez-yarn-timeline-history-with-fs/src/main/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-plugins/tez-yarn-timeline-history/src/main/javadoc/resources/META-INF/NOTICE.txt
+++ b/tez-plugins/tez-yarn-timeline-history/src/main/javadoc/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-plugins/tez-yarn-timeline-history/src/main/resources/META-INF/NOTICE.txt
+++ b/tez-plugins/tez-yarn-timeline-history/src/main/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-plugins/tez-yarn-timeline-history/src/test/resources/META-INF/NOTICE.txt
+++ b/tez-plugins/tez-yarn-timeline-history/src/test/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-runtime-internals/src/main/javadoc/resources/META-INF/NOTICE.txt
+++ b/tez-runtime-internals/src/main/javadoc/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-runtime-internals/src/main/resources/META-INF/NOTICE.txt
+++ b/tez-runtime-internals/src/main/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-runtime-internals/src/test/resources/META-INF/NOTICE.txt
+++ b/tez-runtime-internals/src/test/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-runtime-library/src/main/javadoc/resources/META-INF/NOTICE.txt
+++ b/tez-runtime-library/src/main/javadoc/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-runtime-library/src/main/resources/META-INF/NOTICE.txt
+++ b/tez-runtime-library/src/main/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-runtime-library/src/test/resources/META-INF/NOTICE.txt
+++ b/tez-runtime-library/src/test/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-tests/src/main/javadoc/resources/META-INF/NOTICE.txt
+++ b/tez-tests/src/main/javadoc/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-tests/src/main/resources/META-INF/NOTICE.txt
+++ b/tez-tests/src/main/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-tests/src/test/resources/META-INF/NOTICE.txt
+++ b/tez-tests/src/test/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/tez-ui/src/main/resources/META-INF/NOTICE.txt
+++ b/tez-ui/src/main/resources/META-INF/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Tez
-Copyright (c) 2016 The Apache Software Foundation
+Copyright 2014-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
According to the ASF policy the NOTICE file must reflect the distribution years of the product.

Update the files using the following command:
```
find . -name "*NOTICE*" -exec sed -i 's/Copyright.*/Copyright 2014-2024 The Apache Software Foundation/' {} \;
```