### PR TITLE
TEZ-4533: Source release distribution must not contain TestIFile_concatenated_compressed.bin

### DIFF
--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestIFile.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestIFile.java
@@ -18,6 +18,7 @@
 
 package org.apache.tez.runtime.library.common.sort.impl;
 
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -400,7 +401,7 @@ public class TestIFile {
 
     URL url = getClass().getClassLoader()
         .getResource("TestIFile_concatenated_compressed.bin");
-    assertNotEquals("IFileinput file must exist", null, url);
+    Assume.assumeThat("IFileinput file must exist", url, notNullValue());
     Path p = new Path(url.toURI());
     FSDataInputStream inStream = localFs.open(p);
 


### PR DESCRIPTION
TestIFile_concatenated_compressed.bin file must not be present in the source distribution. To avoid test failures when building from source just skip the test if the file is missing.

Since the creation of the src.tar.gz archive is manual the respective instructions have to be update to exclude explicitly this file:
https://cwiki.apache.org/confluence/display/TEZ/Making+a+TEZ+Release#MakingaTEZRelease-CreateaReleasetarballfortheSource