### PR TITLE
TEZ-4540: Reading proto data more than 2GB from multiple splits fails

### DIFF
--- a/tez-plugins/tez-protobuf-history-plugin/src/main/java/org/apache/tez/dag/history/logging/proto/ProtoMessageWritable.java
+++ b/tez-plugins/tez-protobuf-history-plugin/src/main/java/org/apache/tez/dag/history/logging/proto/ProtoMessageWritable.java
@@ -98,5 +98,6 @@ public class ProtoMessageWritable<T extends MessageLite> implements Writable {
     }
     din.in = in;
     message = cin.readMessage(parser, ExtensionRegistry.getEmptyRegistry());
+    cin.resetSizeCounter();
   }
 }

--- a/tez-plugins/tez-protobuf-history-plugin/src/test/java/org/apache/tez/dag/history/logging/proto/TestProtoHistoryLoggingService.java
+++ b/tez-plugins/tez-protobuf-history-plugin/src/test/java/org/apache/tez/dag/history/logging/proto/TestProtoHistoryLoggingService.java
@@ -166,7 +166,8 @@ public class TestProtoHistoryLoggingService {
     }
   }
 
-  private static int getTotalBytesRead(ProtoMessageReader<HistoryEventProto> reader) throws NoSuchFieldException, IllegalAccessException {
+  private static int getTotalBytesRead(ProtoMessageReader<HistoryEventProto> reader) throws NoSuchFieldException,
+      IllegalAccessException {
     // writable is a private field in ProtoMessageReader.java
     Field f = reader.getClass().getDeclaredField("writable");
     f.setAccessible(true);
@@ -178,8 +179,7 @@ public class TestProtoHistoryLoggingService {
     CodedInputStream cin = (CodedInputStream) c.get(writable);
 
     // Goal is to get value of: reader.writable.cin.getTotalBytesRead()
-    int totalBytesRead = cin.getTotalBytesRead();
-    return totalBytesRead;
+    return cin.getTotalBytesRead();
   }
 
   @Test


### PR DESCRIPTION
Refer to this: [HIVE-28026](https://issues.apache.org/jira/browse/HIVE-28026) and https://github.com/apache/hive/pull/5033