### PR TITLE
TEZ-4543: Throw a special exception to DagClient when there is no current DAG

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/common/RPCUtil.java
+++ b/tez-api/src/main/java/org/apache/tez/common/RPCUtil.java
@@ -24,6 +24,7 @@ import java.lang.reflect.InvocationTargetException;
 
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.tez.dag.api.DAGNotRunningException;
+import org.apache.tez.dag.api.NoCurrentDAGException;
 import org.apache.tez.dag.api.SessionNotRunning;
 import org.apache.tez.dag.api.TezException;
 
@@ -112,6 +113,9 @@ public final class RPCUtil {
         } else if (DAGNotRunningException.class.isAssignableFrom(realClass)) {
             throw instantiateTezException(
                 realClass.asSubclass(DAGNotRunningException.class), re);
+        } else if (NoCurrentDAGException.class.isAssignableFrom(realClass)) {
+          throw instantiateTezException(
+              realClass.asSubclass(NoCurrentDAGException.class), re);
         } else if (TezException.class.isAssignableFrom(realClass)) {
           throw instantiateTezException(
               realClass.asSubclass(TezException.class), re);

--- a/tez-api/src/main/java/org/apache/tez/dag/api/NoCurrentDAGException.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/NoCurrentDAGException.java
@@ -21,15 +21,19 @@ package org.apache.tez.dag.api;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 
 /**
- *  Thrown by the AM when the DAG for which the status was queried
- *  is not running anymore: client can decide further action in this case.
+ *  Fatal exception: thrown by the AM if there is no DAG running when
+ *  when a DAG's status is queried. This is different from {@link org.apache.tez.dag.api.DAGNotRunningException}
+ *  in a sense that this exception is fatal, in which scenario the client might consider the DAG failed, because
+ *  it tries to ask a status from an AM which is not currently running a DAG. This scenario is possible in case
+ *  an AM is restarted and the DagClient fails to realize it's asking the status of a possibly lost DAG.
  */
 @Private
-public class DAGNotRunningException extends TezException {
+public class NoCurrentDAGException extends TezException {
   private static final long serialVersionUID = 6337442733802964448L;
-  public DAGNotRunningException(Throwable cause) { super(cause); }
-  public DAGNotRunningException(String message) { super(message); }
-  public DAGNotRunningException(String message, Throwable cause) {
-    super(message, cause);
+
+  public static final String MESSAGE_PREFIX = "No running DAG at present";
+
+  public NoCurrentDAGException(String dagId) {
+    super(MESSAGE_PREFIX + ": " + dagId);
   }
 }

--- a/tez-api/src/main/java/org/apache/tez/dag/api/NoCurrentDAGException.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/NoCurrentDAGException.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.classification.InterfaceAudience.Private;
 
 /**
  *  Fatal exception: thrown by the AM if there is no DAG running when
- *  when a DAG's status is queried. This is different from {@link org.apache.tez.dag.api.DAGNotRunningException}
+ *  a DAG's status is queried. This is different from {@link org.apache.tez.dag.api.DAGNotRunningException}
  *  in a sense that this exception is fatal, in which scenario the client might consider the DAG failed, because
  *  it tries to ask a status from an AM which is not currently running a DAG. This scenario is possible in case
  *  an AM is restarted and the DagClient fails to realize it's asking the status of a possibly lost DAG.

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientImpl.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientImpl.java
@@ -410,7 +410,8 @@ public class DAGClientImpl extends DAGClient {
       LOG.info("DAG is no longer running - application not found by YARN", e);
       dagCompleted = true;
     } catch (NoCurrentDAGException e) {
-      return dagLost(e);
+      LOG.info("Got NoCurrentDAGException from AM, returning a failed DAG", e);
+      return dagLost();
     } catch (TezException e) {
       // can be either due to a n/w issue or due to AM completed.
       LOG.info("Cannot retrieve DAG Status due to TezException: {}", e.getMessage());
@@ -426,7 +427,7 @@ public class DAGClientImpl extends DAGClient {
     return dagStatus;
   }
 
-  private DAGStatus dagLost(Exception e) {
+  private DAGStatus dagLost() {
     DAGProtos.DAGStatusProto.Builder builder = DAGProtos.DAGStatusProto.newBuilder();
     DAGStatus dagStatus = new DAGStatus(builder, DagStatusSource.AM);
     builder.setState(DAGProtos.DAGStatusStateProto.DAG_FAILED);

--- a/tez-dag/src/main/java/org/apache/tez/dag/api/client/DAGClientHandler.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/api/client/DAGClientHandler.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.tez.client.TezAppMasterStatus;
 import org.apache.tez.dag.api.DAGNotRunningException;
+import org.apache.tez.dag.api.NoCurrentDAGException;
 import org.apache.tez.dag.api.TezException;
 import org.apache.tez.dag.api.records.DAGProtos.DAGPlan;
 import org.apache.tez.dag.app.DAGAppMaster;
@@ -94,7 +95,7 @@ public class DAGClientHandler {
 
     DAG currentDAG = getCurrentDAG();
     if (currentDAG == null) {
-      throw new TezException("No running dag at present");
+      throw new NoCurrentDAGException(dagIdStr);
     }
 
     final String currentDAGIdStr = currentDAG.getID().toString();


### PR DESCRIPTION
This is an AM + client-side change to make DagClient realize much faster when its asking for the status of a DAG which is not present.