### PR TITLE
TEZ-4551. Upgrade commons-io to 2.16.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <commons-cli.version>1.2</commons-cli.version>
     <commons-codec.version>1.15</commons-codec.version>
     <commons-collections4.version>4.4</commons-collections4.version>
-    <commons-io.version>2.8.0</commons-io.version>
+    <commons-io.version>2.16.0</commons-io.version>
     <commons-lang.version>2.6</commons-lang.version>
     <clover.license>${user.home}/clover.license</clover.license>
     <dependency-check-maven.version>1.3.6</dependency-check-maven.version>


### PR DESCRIPTION
JIRA: [TEZ-4551](https://issues.apache.org/jira/browse/TEZ-4551). Upgrade commons-io to 2.16.0.

We are currently using commons-io version 2.8.0, which is an older version (Sep 09, 2020). Commons-io has been upgraded to 2.16.0 (Mar 28, 2024). We can try to upgrade the version to 2.16.0.