### PR TITLE
TEZ-4552. Upgrade protobuf to 3.24.4 due to CVE.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <mockito-core.version>4.3.1</mockito-core.version>
     <netty.version>4.1.100.Final</netty.version>
     <pig.version>0.13.0</pig.version>
-    <protobuf.version>3.23.4</protobuf.version>
+    <protobuf.version>3.24.4</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <protoc.path>${env.PROTOC_PATH}</protoc.path>
     <restrict-imports.enforcer.version>2.0.0</restrict-imports.enforcer.version>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <mockito-core.version>4.3.1</mockito-core.version>
     <netty.version>4.1.100.Final</netty.version>
     <pig.version>0.13.0</pig.version>
-    <protobuf.version>3.21.1</protobuf.version>
+    <protobuf.version>3.23.4</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <protoc.path>${env.PROTOC_PATH}</protoc.path>
     <restrict-imports.enforcer.version>2.0.0</restrict-imports.enforcer.version>


### PR DESCRIPTION
JIRA: [TEZ-4552. Upgrade protobuf to 3.24.4 due to CVE.](https://issues.apache.org/jira/browse/TEZ-4552)

I found that there are 3 CVE issues that we need to deal with. These CVE issues are related to protobuf. Our protobuf uses 3.21.1, which is an old version. This PR will try to upgrade the protobuf version to solve the CVE issue.

- [CVE-2022-3171](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3171)
- [CVE-2022-3509](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3509)
- [CVE-2022-3510](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-3510)