### PR TITLE
TEZ-4557: Revert TEZ-4303, NoClassDefFoundError because of missing httpclient jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,10 +377,6 @@
             <groupId>io.netty</groupId>
             <artifactId>*</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -391,10 +387,6 @@
           <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
Please refer to [TEZ-4557](https://issues.apache.org/jira/browse/TEZ-4557), for error stacktrace.