### PR TITLE
TEZ-4560. Upgrade bouncycastle to 1.77 due to CVE.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
     <!--dependency versions in alphabetical order-->
     <asynchttpclient.version>2.12.3</asynchttpclient.version>
-    <bouncycastle.version>1.70</bouncycastle.version>
+    <bouncycastle.version>1.77</bouncycastle.version>
     <build-helper-maven-plugin.version>1.8</build-helper-maven-plugin.version>
     <buildnumber-maven-plugin.version>1.1</buildnumber-maven-plugin.version>
     <checkstyle.version>8.35</checkstyle.version>
@@ -784,13 +784,13 @@
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
+        <artifactId>bcprov-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
+        <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
         <scope>test</scope>
       </dependency>

--- a/tez-api/pom.xml
+++ b/tez-api/pom.xml
@@ -116,7 +116,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tez-tests/pom.xml
+++ b/tez-tests/pom.xml
@@ -126,7 +126,7 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
JIRA: TEZ-4560. Upgrade bouncycastle to 1.77 due to CVE.

There are 2 CVE issues in bcprov-jdk15on, CVE-2023-33202 and CVE-2023-33201. We can find more information at the following link:

https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on/1.70

The link to the CVE is as follows: 

[CVE-2023-33202](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-33202)
[CVE-2023-33201](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-33201)

We can upgrade bcprov-jdk15on to bcprov-jdk18on to address the CVE issues.