### PR TITLE
TEZ-4559: Fix Retry logic in case of Recovery

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientImpl.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/DAGClientImpl.java
@@ -410,8 +410,14 @@ public class DAGClientImpl extends DAGClient {
       LOG.info("DAG is no longer running - application not found by YARN", e);
       dagCompleted = true;
     } catch (NoCurrentDAGException e) {
-      LOG.info("Got NoCurrentDAGException from AM, returning a failed DAG", e);
-      return dagLost();
+      if (conf.getBoolean(TezConfiguration.DAG_RECOVERY_ENABLED,
+          TezConfiguration.DAG_RECOVERY_ENABLED_DEFAULT)) {
+        LOG.info("Got NoCurrentDAGException from AM, going on as recovery is enabled", e);
+      } else {
+        // if recovery is disabled, we're not expecting the DAG to be finished any time in the future
+        LOG.info("Got NoCurrentDAGException from AM, returning a failed DAG as recovery is disabled", e);
+        return dagLost();
+      }
     } catch (TezException e) {
       // can be either due to a n/w issue or due to AM completed.
       LOG.info("Cannot retrieve DAG Status due to TezException: {}", e.getMessage());

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClient.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClient.java
@@ -715,6 +715,7 @@ public class TestDAGClient {
   @Test
   public void testDagClientReturnsFailedDAGOnNoCurrentDAGException() throws Exception {
     TezConfiguration tezConf = new TezConfiguration();
+    tezConf.setBoolean(TezConfiguration.DAG_RECOVERY_ENABLED, false);
 
     try (DAGClientImplForTest dagClientImpl = new DAGClientImplForTest(mockAppId, dagIdStr, tezConf, null)) {
 


### PR DESCRIPTION
Some unit tests were broken by [TEZ-4543](https://issues.apache.org/jira/browse/TEZ-4543), where we simply returned a failed DAG if the requested DAG status cannot be found. This completely breaks recovery scenarios where the dagClient might keep asking for the failed DAGs status (while the AM restarts after a failure).

Considering recovery works, the client should simply consider if recovery is enabled and behave accordingly. This patch reverts the behavior in case of recovery to pre-TEZ-4543, but if there is no recovery, TEZ-4543 is a fair assumption and still makes the client able to return much faster in case of the specialized exception implying that the DAG is already lost.

Unit tests have been run manually with this patch: TestDAGRecovery, TestAMRecovery, TestRecovery