### PR TITLE
TEZ-4564: TezClient to expose Tez AM host:port

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/client/FrameworkClient.java
+++ b/tez-api/src/main/java/org/apache/tez/client/FrameworkClient.java
@@ -94,6 +94,9 @@ public abstract class FrameworkClient {
 
   public abstract ApplicationReport getApplicationReport(ApplicationId appId) throws YarnException, IOException;
 
+  public abstract String getAmHost();
+  public abstract int getAmPort();
+
   public abstract boolean isRunning() throws IOException;
 
   public TezAppMasterStatus getAMStatus(Configuration conf, ApplicationId appId,

--- a/tez-api/src/main/java/org/apache/tez/client/TezClient.java
+++ b/tez-api/src/main/java/org/apache/tez/client/TezClient.java
@@ -1286,4 +1286,12 @@ public class TezClient {
               + appIdStr, n);
     }
   }
+
+  public String getAmHost() {
+    return frameworkClient.getAmHost();
+  }
+
+  public int getAmPort() {
+    return frameworkClient.getAmPort();
+  }
 }

--- a/tez-api/src/main/java/org/apache/tez/client/TezClient.java
+++ b/tez-api/src/main/java/org/apache/tez/client/TezClient.java
@@ -1288,10 +1288,10 @@ public class TezClient {
   }
 
   public String getAmHost() {
-    return frameworkClient.getAmHost();
+    return frameworkClient == null ? null : frameworkClient.getAmHost();
   }
 
   public int getAmPort() {
-    return frameworkClient.getAmPort();
+    return frameworkClient == null ? -1 : frameworkClient.getAmPort();
   }
 }

--- a/tez-api/src/main/java/org/apache/tez/client/TezYarnClient.java
+++ b/tez-api/src/main/java/org/apache/tez/client/TezYarnClient.java
@@ -40,6 +40,9 @@ public class TezYarnClient extends FrameworkClient {
 
   private volatile boolean isRunning;
 
+  private String amHost;
+  private int amPort;
+
   protected TezYarnClient(YarnClient yarnClient) {
     this.yarnClient = yarnClient;
   }
@@ -100,11 +103,23 @@ public class TezYarnClient extends FrameworkClient {
       throw new ApplicationNotFoundException("YARN reports no state for application "
           + appId);
     }
+    this.amHost = report.getHost();
+    this.amPort = report.getRpcPort();
     return report;
   }
 
   @Override
   public boolean isRunning() throws IOException {
     return isRunning;
+  }
+
+  @Override
+  public String getAmHost() {
+    return amHost;
+  }
+
+  @Override
+  public int getAmPort() {
+    return amPort;
   }
 }

--- a/tez-api/src/test/java/org/apache/tez/client/TestTezClient.java
+++ b/tez-api/src/test/java/org/apache/tez/client/TestTezClient.java
@@ -161,6 +161,16 @@ public class TestTezClient {
       }
       return super.getProxy(conf, sessionAppId, ugi);
     }
+
+    @Override
+    public String getAmHost() {
+      return "testhost";
+    }
+
+    @Override
+    public int getAmPort() {
+      return 1234;
+    }
   }
 
   TezClientForTest configureAndCreateTezClient() throws YarnException, IOException, ServiceException {
@@ -1004,5 +1014,14 @@ public class TestTezClient {
 
     //Test that Exception is not thrown by createFinalConfProtoForApp
     TezClientUtils.createFinalConfProtoForApp(conf, null);
+  }
+
+  @Test
+  public void testGetAmHostAndPort() throws Exception {
+    final TezClientForTest client = configureAndCreateTezClient(new TezConfiguration());
+
+    // TezClient exposes AM host and port from the FrameworkClient (now it's a TezYarnClientForTest)
+    assertEquals("testhost", client.getAmHost());
+    assertEquals(1234, client.getAmPort());
   }
 }

--- a/tez-dag/src/main/java/org/apache/tez/client/LocalClient.java
+++ b/tez-dag/src/main/java/org/apache/tez/client/LocalClient.java
@@ -88,6 +88,8 @@ public class LocalClient extends FrameworkClient {
   private TezApiVersionInfo versionInfo = new TezApiVersionInfo();
   private volatile Throwable amFailException = null;
   private boolean isLocalWithoutNetwork;
+  private String amHost;
+  private int amPort;
 
   private static final String localModeDAGSchedulerClassName =
       "org.apache.tez.dag.app.dag.impl.DAGSchedulerNaturalOrderControlled";
@@ -203,6 +205,9 @@ public class LocalClient extends FrameworkClient {
     report.setOriginalTrackingUrl("N/A");
     report.setProgress(dagAppMaster.getProgress());
     report.setAMRMToken(null);
+
+    this.amHost = dagAppMaster.getAppNMHost();
+    this.amPort = dagAppMaster.getRpcPort();
 
     return report;
   }
@@ -474,5 +479,15 @@ public class LocalClient extends FrameworkClient {
       return true;
     }
     return super.shutdownSession(configuration, sessionAppId, ugi);
+  }
+
+  @Override
+  public String getAmHost() {
+    return amHost;
+  }
+
+  @Override
+  public int getAmPort() {
+    return amPort;
   }
 }


### PR DESCRIPTION
This PR exposes Tez AM host and port from TezClient (and the underlying FrameworkClient).