### PR TITLE
TEZ-4554: Counter for used nodes within a DAG

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/common/counters/DAGCounter.java
+++ b/tez-api/src/main/java/org/apache/tez/common/counters/DAGCounter.java
@@ -91,15 +91,9 @@ public enum DAGCounter {
 
   /*
    * Number of nodes to which task attempts were assigned in this DAG.
-   * Nodes are distinguished by the Yarn NodeId.
+   * Nodes are distinguished by the Yarn NodeId.getHost().
    */
   NODE_USED_COUNT,
-
-  /*
-   * Number of node hosts to which task attempts were assigned in this DAG.
-   * Nodes are distinguished by Yarn NodeId.getHost()
-   */
-  NODE_HOSTS_USED_COUNT,
 
   /*
    * Total number of nodes visible to the task scheduler (regardless of

--- a/tez-api/src/main/java/org/apache/tez/common/counters/DAGCounter.java
+++ b/tez-api/src/main/java/org/apache/tez/common/counters/DAGCounter.java
@@ -87,5 +87,24 @@ public enum DAGCounter {
    * Number of container reuses during a DAG. This is incremented every time
    * the containerReused callback is called in the TaskSchedulerContext.
    */
-  TOTAL_CONTAINER_REUSE_COUNT
+  TOTAL_CONTAINER_REUSE_COUNT,
+
+  /*
+   * Number of nodes to which task attempts were assigned in this DAG.
+   * Nodes are distinguished by the Yarn NodeId.
+   */
+  NODE_USED_COUNT,
+
+  /*
+   * Number of node hosts to which task attempts were assigned in this DAG.
+   * Nodes are distinguished by Yarn NodeId.getHost()
+   */
+  NODE_HOSTS_USED_COUNT,
+
+  /*
+   * Total number of nodes visible to the task scheduler (regardless of
+   * task assignments). This is typically exposed by a resource manager
+   * client.
+   */
+  NODE_TOTAL_COUNT
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/DAG.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/DAG.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.yarn.api.records.ContainerId;
+import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.tez.common.counters.DAGCounter;
@@ -106,7 +106,7 @@ public interface DAG extends DagInfo {
 
   void incrementDagCounter(DAGCounter counter, int incrValue);
   void setDagCounter(DAGCounter counter, int setValue);
-  void addUsedContainer(ContainerId containerId);
+  void addUsedContainer(Container container);
 
   /**
    * Called by the DAGAppMaster when the DAG is started normally or in the event of recovery.

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/DAGImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/DAGImpl.java
@@ -61,8 +61,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.LocalResource;
+import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.state.InvalidStateTransitonException;
 import org.apache.hadoop.yarn.state.MultipleArcTransition;
@@ -250,6 +252,11 @@ public class DAGImpl implements org.apache.tez.dag.app.dag.DAG,
 
   private final MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
   private final Set<ContainerId> containersUsedByCurrentDAG = new HashSet<>();
+  @VisibleForTesting
+  final Set<NodeId> nodesUsedByCurrentDAG = new HashSet<>();
+  @VisibleForTesting
+  final Set<String> nodeHostsUsedByCurrentDAG = new HashSet<>();
+
 
   protected static final
     StateMachineFactory<DAGImpl, DAGState, DAGEventType, DAGEvent>
@@ -2563,7 +2570,7 @@ public class DAGImpl implements org.apache.tez.dag.app.dag.DAG,
   @Override
   public void onFinish() {
     stopVertexServices();
-    handleUsedContainersOnDagFinish();
+    updateCounters();
   }
 
   private void startVertexServices() {
@@ -2579,11 +2586,16 @@ public class DAGImpl implements org.apache.tez.dag.app.dag.DAG,
   }
 
   @Override
-  public void addUsedContainer(ContainerId containerId) {
-    containersUsedByCurrentDAG.add(containerId);
+  public void addUsedContainer(Container container) {
+    containersUsedByCurrentDAG.add(container.getId());
+    nodesUsedByCurrentDAG.add(container.getNodeId());
+    nodeHostsUsedByCurrentDAG.add(container.getNodeId().getHost());
   }
 
-  private void handleUsedContainersOnDagFinish() {
+  private void updateCounters() {
     setDagCounter(DAGCounter.TOTAL_CONTAINERS_USED, containersUsedByCurrentDAG.size());
+    setDagCounter(DAGCounter.NODE_USED_COUNT, nodesUsedByCurrentDAG.size());
+    setDagCounter(DAGCounter.NODE_HOSTS_USED_COUNT, nodeHostsUsedByCurrentDAG.size());
+    setDagCounter(DAGCounter.NODE_TOTAL_COUNT, appContext.getTaskScheduler().getNumClusterNodes());
   }
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/DAGImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/DAGImpl.java
@@ -64,7 +64,6 @@ import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.LocalResource;
-import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.state.InvalidStateTransitonException;
 import org.apache.hadoop.yarn.state.MultipleArcTransition;
@@ -253,10 +252,7 @@ public class DAGImpl implements org.apache.tez.dag.app.dag.DAG,
   private final MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
   private final Set<ContainerId> containersUsedByCurrentDAG = new HashSet<>();
   @VisibleForTesting
-  final Set<NodeId> nodesUsedByCurrentDAG = new HashSet<>();
-  @VisibleForTesting
-  final Set<String> nodeHostsUsedByCurrentDAG = new HashSet<>();
-
+  final Set<String> nodesUsedByCurrentDAG = new HashSet<>();
 
   protected static final
     StateMachineFactory<DAGImpl, DAGState, DAGEventType, DAGEvent>
@@ -2588,14 +2584,12 @@ public class DAGImpl implements org.apache.tez.dag.app.dag.DAG,
   @Override
   public void addUsedContainer(Container container) {
     containersUsedByCurrentDAG.add(container.getId());
-    nodesUsedByCurrentDAG.add(container.getNodeId());
-    nodeHostsUsedByCurrentDAG.add(container.getNodeId().getHost());
+    nodesUsedByCurrentDAG.add(container.getNodeId().getHost());
   }
 
   private void updateCounters() {
     setDagCounter(DAGCounter.TOTAL_CONTAINERS_USED, containersUsedByCurrentDAG.size());
     setDagCounter(DAGCounter.NODE_USED_COUNT, nodesUsedByCurrentDAG.size());
-    setDagCounter(DAGCounter.NODE_HOSTS_USED_COUNT, nodeHostsUsedByCurrentDAG.size());
-    setDagCounter(DAGCounter.NODE_TOTAL_COUNT, appContext.getTaskScheduler().getNumClusterNodes());
+    setDagCounter(DAGCounter.NODE_TOTAL_COUNT, appContext.getTaskScheduler().getNumClusterNodes(true));
   }
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/rm/TaskSchedulerManager.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/rm/TaskSchedulerManager.java
@@ -746,7 +746,7 @@ public class TaskSchedulerManager extends AbstractService implements
       sendEvent(new AMNodeEventContainerAllocated(container
           .getNodeId(), schedulerId, container.getId()));
     }
-    appContext.getCurrentDAG().addUsedContainer(containerId);
+    appContext.getCurrentDAG().addUsedContainer(container);
 
     TaskAttempt taskAttempt = event.getTaskAttempt();
     // TODO - perhaps check if the task still needs this container

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGImpl.java
@@ -19,6 +19,7 @@
 package org.apache.tez.dag.app.dag.impl;
 
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -2399,35 +2400,24 @@ public class TestDAGImpl {
     spy.addUsedContainer(containerOnDifferentHost);
     spy.addUsedContainer(containerOnSameHostWithDifferentPort);
 
-    when(taskSchedulerManager.getNumClusterNodes()).thenReturn(10);
+    when(taskSchedulerManager.getNumClusterNodes(anyBoolean())).thenReturn(10);
 
     spy.onFinish();
     // 4 calls to addUsedContainer
     verify(spy, times(4)).addUsedContainer(any(Container.class));
-    // 3 nodes were used: localhost:0, otherhost:0, localhost:1
-    // localhost:0 and localhost:1 might be on the same physical host, but as long as
-    // yarn considers them different nodes, we consider them different too
-    Assert.assertEquals(3,
-        spy.getAllCounters().getGroup(DAGCounter.class.getName()).findCounter(DAGCounter.NODE_USED_COUNT.name())
-            .getValue());
-
-    Assert.assertTrue(spy.nodesUsedByCurrentDAG.contains(NodeId.fromString("localhost:0")));
-    Assert.assertTrue(spy.nodesUsedByCurrentDAG.contains(NodeId.fromString("otherhost:0")));
-    Assert.assertTrue(spy.nodesUsedByCurrentDAG.contains(NodeId.fromString("localhost:1")));
 
     // 2 distinct node hosts were seen: localhost, otherhost
     Assert.assertEquals(2,
-        spy.getAllCounters().getGroup(DAGCounter.class.getName())
-            .findCounter(DAGCounter.NODE_HOSTS_USED_COUNT.name())
+        spy.getAllCounters().getGroup(DAGCounter.class.getName()).findCounter(DAGCounter.NODE_USED_COUNT.name())
             .getValue());
+
+    Assert.assertTrue(spy.nodesUsedByCurrentDAG.contains("localhost"));
+    Assert.assertTrue(spy.nodesUsedByCurrentDAG.contains("otherhost"));
 
     Assert.assertEquals(10,
         spy.getAllCounters().getGroup(DAGCounter.class.getName())
             .findCounter(DAGCounter.NODE_TOTAL_COUNT.name())
             .getValue());
-
-    Assert.assertTrue(spy.nodeHostsUsedByCurrentDAG.contains("localhost"));
-    Assert.assertTrue(spy.nodeHostsUsedByCurrentDAG.contains("otherhost"));
   }
 
   private DAGImpl getDagSpy() {

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskSchedulerManager.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskSchedulerManager.java
@@ -234,7 +234,7 @@ public class TestTaskSchedulerManager {
     assertEquals(priority, assignEvent.getPriority());
     assertEquals(mockAttemptId, assignEvent.getTaskAttemptId());
 
-    verify(mockAppContext.getCurrentDAG()).addUsedContainer(any(ContainerId.class)); // called on taskAllocated
+    verify(mockAppContext.getCurrentDAG()).addUsedContainer(any(Container.class)); // called on taskAllocated
   }
 
   @Test(timeout = 5000)


### PR DESCRIPTION
tested on a small tez container mode cluster

with 2 healthy and running yarn nodemanagers:
```
INFO  : org.apache.tez.common.counters.DAGCounter:
...
INFO  :    NODE_USED_COUNT: 2
INFO  :    NODE_TOTAL_COUNT: 2
```

after stopping 1 nodemanager:
```
INFO  : org.apache.tez.common.counters.DAGCounter:
...
INFO  :    NODE_USED_COUNT: 1
INFO  :    NODE_TOTAL_COUNT: 2
```

after decommissioning 1 nodemanager:
```
INFO  : org.apache.tez.common.counters.DAGCounter:
...
INFO  :    NODE_USED_COUNT: 1
INFO  :    NODE_TOTAL_COUNT: 1
```


also tested with LLAP on Cloudera CDW (3 LLAP daemons)
```
INFO  :    NODE_USED_COUNT: 3
INFO  :    NODE_TOTAL_COUNT: 3
```
