### PR TITLE
TEZ-4575: Upgrade Apache parent pom version from 23 to 33

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,5 +38,5 @@ jobs:
       - run: echo "$java-version"
       - run: echo "$JAVA_HOME"
       - run: echo "${{ matrix.java-version }}"
-      - run: java --version
+      - run: java -version
       - run: mvn clean install -DskipTests -Dmaven.javadoc.skip=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,4 +35,8 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java-version }}
+      - run: echo "$java-version"
+      - run: echo "$JAVA_HOME"
+      - run: echo "${{ matrix.java-version }}"
+      - run: java --version
       - run: mvn clean install -DskipTests -Dmaven.javadoc.skip=true

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>23</version>
+    <version>33</version>
   </parent>
   <groupId>org.apache.tez</groupId>
   <artifactId>tez</artifactId>

--- a/tez-dag/pom.xml
+++ b/tez-dag/pom.xml
@@ -190,10 +190,10 @@
             <id>generate-sources</id>
             <phase>generate-sources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <delete dir="${test.log.dir}" />
                 <mkdir dir="${test.log.dir}" />
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/tez-ext-service-tests/pom.xml
+++ b/tez-ext-service-tests/pom.xml
@@ -140,10 +140,10 @@
             <id>generate-sources</id>
             <phase>generate-sources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <delete dir="${test.log.dir}" />
                 <mkdir dir="${test.log.dir}" />
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/tez-tests/pom.xml
+++ b/tez-tests/pom.xml
@@ -145,10 +145,10 @@
             <id>generate-sources</id>
             <phase>generate-sources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <delete dir="${test.log.dir}" />
                 <mkdir dir="${test.log.dir}" />
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>


### PR DESCRIPTION
Upgrade the Apache parent pom to the 33 version (latest) to take advantage of recent enhancements and use the more recent version and properties for the various plugins.

The [maven-antrun-plugin](https://maven.apache.org/plugins/maven-antrun-plugin/index.html) from version 3.0.0 onwards requires the replacement of the `tasks` parameter with `target`.