### PR TITLE
TEZ-4578: Upgrade roaringbit version to 1.2.1 to fix CVE's

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <protoc.path>${env.PROTOC_PATH}</protoc.path>
     <restrict-imports.enforcer.version>2.0.0</restrict-imports.enforcer.version>
-    <roaringbitmap.version>0.7.45</roaringbitmap.version>
+    <roaringbitmap.version>1.2.1</roaringbitmap.version>
     <scm.url>scm:git:https://gitbox.apache.org/repos/asf/tez.git</scm.url>
     <servlet-api.version>3.1.0</servlet-api.version>
     <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
There are CVE's in roaringbit 0.7.45:
https://mvnrepository.com/artifact/org.roaringbitmap/RoaringBitmap/0.7.45

As there is a plan in hive as well to upgrade roaringbit to 1.2.x hence better to keep them in sync.