### PR TITLE
TEZ-4584: TezUtilsInternal.readUserSpecifiedTezConfiguration throws com.google.protobuf.CodedInputStream exception

### DIFF
--- a/tez-common/src/main/java/org/apache/tez/common/TezUtilsInternal.java
+++ b/tez-common/src/main/java/org/apache/tez/common/TezUtilsInternal.java
@@ -38,6 +38,7 @@ import java.util.zip.Deflater;
 import java.util.zip.Inflater;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.TextFormat;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
@@ -77,7 +78,9 @@ public final class TezUtilsInternal {
       IOException {
     File confPBFile = new File(baseDir, TezConstants.TEZ_PB_BINARY_CONF_NAME);
     try (FileInputStream fis = new FileInputStream(confPBFile)) {
-      return ConfigurationProto.parseFrom(fis);
+      CodedInputStream in = CodedInputStream.newInstance(fis);
+      in.setSizeLimit(Integer.MAX_VALUE);
+      return ConfigurationProto.parseFrom(in);
     }
   }
 


### PR DESCRIPTION
```
com.google.protobuf.InvalidProtocolBufferException: Protocol message was too large.  May be malicious.  Use CodedInputStream.setSizeLimit() to increase the size limit.
    at com.google.protobuf.InvalidProtocolBufferException.sizeLimitExceeded(InvalidProtocolBufferException.java:110)
    at com.google.protobuf.CodedInputStream.refillBuffer(CodedInputStream.java:755)
    at com.google.protobuf.CodedInputStream.isAtEnd(CodedInputStream.java:701)
    at com.google.protobuf.CodedInputStream.readTag(CodedInputStream.java:99)
    at org.apache.tez.dag.api.records.DAGProtos$ConfigurationProto.<init>(DAGProtos.java:19303)
    at org.apache.tez.dag.api.records.DAGProtos$ConfigurationProto.<init>(DAGProtos.java:19267)
    at org.apache.tez.dag.api.records.DAGProtos$ConfigurationProto$1.parsePartialFrom(DAGProtos.java:19369)
    at org.apache.tez.dag.api.records.DAGProtos$ConfigurationProto$1.parsePartialFrom(DAGProtos.java:19364)
    at com.google.protobuf.AbstractParser.parsePartialFrom(AbstractParser.java:200)
    at com.google.protobuf.AbstractParser.parseFrom(AbstractParser.java:217)
    at com.google.protobuf.AbstractParser.parseFrom(AbstractParser.java:223)
    at com.google.protobuf.AbstractParser.parseFrom(AbstractParser.java:49)
    at org.apache.tez.dag.api.records.DAGProtos$ConfigurationProto.parseFrom(DAGProtos.java:19561)
    at org.apache.tez.common.TezUtilsInternal.readUserSpecifiedTezConfiguration(TezUtilsInternal.java:77)
    at org.apache.tez.dag.app.DAGAppMaster.main(DAGAppMaster.java:2351) 
```
It is same as https://issues.apache.org/jira/browse/TEZ-4142. Fix this issue by calling CodedInputStream.setSizeLimit.