### PR TITLE
TEZ-4585: Fix counters for speculation.

### DIFF
--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/TaskImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/TaskImpl.java
@@ -1036,7 +1036,6 @@ public class TaskImpl implements Task, EventHandler<TaskEvent> {
     @Override
     public void transition(TaskImpl task, TaskEvent event) {
       LOG.info("Scheduling a redundant attempt for task " + task.taskId);
-      task.counters.findCounter(TaskCounter.NUM_SPECULATIONS).increment(1);
       TaskAttempt earliestUnfinishedAttempt = null;
       for (TaskAttempt ta : task.attempts.values()) {
         // find the oldest running attempt
@@ -1063,6 +1062,7 @@ public class TaskImpl implements Task, EventHandler<TaskEvent> {
             task.getTaskID(), task.commitAttempt);
         return;
       }
+      task.counters.findCounter(TaskCounter.NUM_SPECULATIONS).increment(1);
       task.addAndScheduleAttempt(earliestUnfinishedAttempt.getTaskAttemptID());
     }
   }


### PR DESCRIPTION
When some conditions skip speculative execution, NUM_SPECULATIONS should not be counted.