### PR TITLE
TEZ-4586: Upgrade jersey to 1.19.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.3.6</hadoop.version>
     <jdk.tools.version>1.8</jdk.tools.version>
-    <jersey.version>1.19</jersey.version>
+    <jersey.version>1.19.4</jersey.version>
     <jettison.version>1.5.4</jettison.version>
     <jsr305.version>3.0.0</jsr305.version>
     <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade jersey to 1.19.4

### Why are the changes needed?
[TEZ-4586](https://issues.apache.org/jira/browse/TEZ-4586)
Hadoop and Hive have already upgraded jersey version to 1.19.4, so tez should upgrade jersey version to 1.19.4 too.

### Does this PR introduce _any_ user-facing change?
None, that I am aware of.

### How was this patch tested?
CI