### PR TITLE
TEZ-4587: Synchronize Tez site with the current markup

### DIFF
--- a/docs/src/site/markdown/releases/apache-tez-0-10-2.md
+++ b/docs/src/site/markdown/releases/apache-tez-0-10-2.md
@@ -1,0 +1,30 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<head><title>Apache TEZ&reg; 0.10.2</title></head>
+
+Apache TEZ&reg; 0.10.2
+----------------------
+
+- [Download Release Artifacts](http://www.apache.org/dyn/closer.lua/tez/0.10.2/)
+- [Release Notes](0.10.2/release-notes.txt)
+- Documentation
+    - [API Javadocs](0.10.2/tez-api-javadocs/index.html) : Documentation for the Tez APIs
+    - [Runtime Library Javadocs](0.10.2/tez-runtime-library-javadocs/index.html) : Documentation for built-in implementations of useful Inputs, Outputs, Processors etc. written based on the Tez APIs
+    - [Tez Mapreduce Javadocs](0.10.2/tez-mapreduce-javadocs/index.html) : Documentation for built-in implementations of Mapreduce compatible Inputs, Outputs, Processors etc. written based on the Tez APIs
+    - [Tez Configuration](0.10.2/tez-api-javadocs/configs/TezConfiguration.html) : Documentation for configurations of Tez. These configurations are typically specified in tez-site.xml.
+    - [Tez Runtime Configuration](0.10.2/tez-runtime-library-javadocs/configs/TezRuntimeConfiguration.html) : Documentation for runtime configurations of Tez. These configurations are typically specified by job submitters.

--- a/docs/src/site/markdown/releases/apache-tez-0-10-3.md
+++ b/docs/src/site/markdown/releases/apache-tez-0-10-3.md
@@ -1,0 +1,30 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<head><title>Apache TEZ&reg; 0.10.3</title></head>
+
+Apache TEZ&reg; 0.10.3
+----------------------
+
+- [Download Release Artifacts](http://www.apache.org/dyn/closer.lua/tez/0.10.3/)
+- [Release Notes](0.10.3/release-notes.txt)
+- Documentation
+    - [API Javadocs](0.10.3/tez-api-javadocs/index.html) : Documentation for the Tez APIs
+    - [Runtime Library Javadocs](0.10.3/tez-runtime-library-javadocs/index.html) : Documentation for built-in implementations of useful Inputs, Outputs, Processors etc. written based on the Tez APIs
+    - [Tez Mapreduce Javadocs](0.10.3/tez-mapreduce-javadocs/index.html) : Documentation for built-in implementations of Mapreduce compatible Inputs, Outputs, Processors etc. written based on the Tez APIs
+    - [Tez Configuration](0.10.3/tez-api-javadocs/configs/TezConfiguration.html) : Documentation for configurations of Tez. These configurations are typically specified in tez-site.xml.
+    - [Tez Runtime Configuration](0.10.3/tez-runtime-library-javadocs/configs/TezRuntimeConfiguration.html) : Documentation for runtime configurations of Tez. These configurations are typically specified by job submitters.

--- a/docs/src/site/markdown/releases/apache-tez-0-10-4.md
+++ b/docs/src/site/markdown/releases/apache-tez-0-10-4.md
@@ -1,0 +1,30 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+
+<head><title>Apache TEZ&reg; 0.10.4</title></head>
+
+Apache TEZ&reg; 0.10.4
+----------------------
+
+- [Download Release Artifacts](http://www.apache.org/dyn/closer.lua/tez/0.10.4/)
+- [Release Notes](0.10.4/release-notes.txt)
+- Documentation
+    - [API Javadocs](0.10.4/tez-api-javadocs/index.html) : Documentation for the Tez APIs
+    - [Runtime Library Javadocs](0.10.4/tez-runtime-library-javadocs/index.html) : Documentation for built-in implementations of useful Inputs, Outputs, Processors etc. written based on the Tez APIs
+    - [Tez Mapreduce Javadocs](0.10.4/tez-mapreduce-javadocs/index.html) : Documentation for built-in implementations of Mapreduce compatible Inputs, Outputs, Processors etc. written based on the Tez APIs
+    - [Tez Configuration](0.10.4/tez-api-javadocs/configs/TezConfiguration.html) : Documentation for configurations of Tez. These configurations are typically specified in tez-site.xml.
+    - [Tez Runtime Configuration](0.10.4/tez-runtime-library-javadocs/configs/TezRuntimeConfiguration.html) : Documentation for runtime configurations of Tez. These configurations are typically specified by job submitters.

--- a/docs/src/site/markdown/releases/index.md
+++ b/docs/src/site/markdown/releases/index.md
@@ -19,6 +19,9 @@
 
 Releases
 ------------
+-   [Apache TEZ&reg; 0.10.4](./apache-tez-0-10-4.html) (Sep 15, 2024)
+-   [Apache TEZ&reg; 0.10.3](./apache-tez-0-10-3.html) (Jan 31, 2024)
+-   [Apache TEZ&reg; 0.10.2](./apache-tez-0-10-2.html) (Jul 30, 2022)
 -   [Apache TEZ&reg; 0.10.1](./apache-tez-0-10-1.html) (Jul 01, 2021)
 -   [Apache TEZ&reg; 0.10.0](./apache-tez-0-10-0.html) (Oct 15, 2020)
 -   [Apache TEZ&reg; 0.9.2](./apache-tez-0-9-2.html) (Mar 29, 2019)

--- a/docs/src/site/site.xml
+++ b/docs/src/site/site.xml
@@ -22,7 +22,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.3.0</version>
+    <version>1.9</version>
   </skin>
   <custom>
     <fluidoSkin>
@@ -56,24 +56,7 @@
 
   <body>
     <head>
-       <!-- Start of Google analytics 
-       <script type="text/javascript">
-         var _gaq = _gaq || [];
-         _gaq.push(['_setAccount', '']);
-         _gaq.push(['_trackPageview']);
-
-         (function() {
-            var ga = document.createElement('script'); 
-            ga.type = 'text/javascript'; ga.async = true;
-            ga.src = ('https:' == document.location.protocol ? 
-                      'https://ssl' : 'http://www') + 
-                     '.google-analytics.com/ga.js';
-            var s = document.getElementsByTagName('script')[0]; 
-            s.parentNode.insertBefore(ga, s);
-          })();
-       </script>
-       End of Google analytics -->
-       <style>
+      <![CDATA[<style>
            .well.sidebar-nav {
              background-color: #fff;
            }
@@ -90,7 +73,7 @@
            .nav-list .active a:hover {
              background-color: #a0a0a0;
            }
-       </style>
+      </style>]]>
     </head>
 
     <breadcrumbs>
@@ -121,16 +104,10 @@
     </menu>
 
     <menu name="Download Apache TEZ&#174; Releases">
-      <item name="0.4.1-incubating" href="https://archive.apache.org/dist/incubator/tez/tez-0.4.1-incubating/"/>
-      <item name="0.5.4" href="./releases/apache-tez-0-5-4.html"/>
-      <item name="0.6.2" href="./releases/apache-tez-0-6-2.html"/>
-      <item name="0.7.1" href="./releases/apache-tez-0-7-1.html"/>
       <item name="0.8.5" href="./releases/apache-tez-0-8-5.html"/>
-      <item name="0.9.0" href="./releases/apache-tez-0-9-0.html"/>
-      <item name="0.9.1" href="./releases/apache-tez-0-9-1.html"/>
       <item name="0.9.2" href="./releases/apache-tez-0-9-2.html"/>
-      <item name="0.10.0" href="./releases/apache-tez-0-10-0.html"/>
-      <item name="0.10.1" href="./releases/apache-tez-0-10-1.html"/>
+      <item name="0.10.3" href="./releases/apache-tez-0-10-3.html"/>
+      <item name="0.10.4" href="./releases/apache-tez-0-10-4.html"/>
       <item name="All Releases" href="./releases/index.html"/>
     </menu>
 
@@ -149,6 +126,7 @@
     </menu>
 
     <footer>
+      <![CDATA[
       <div class="row span12">
         Apache Tez, Apache, the Apache feather logo, and the Apache Tez project logos are trademarks of The Apache Software Foundation.
         All other marks mentioned may be trademarks or registered trademarks of their respective owners.
@@ -157,6 +135,7 @@
       <div class="row span12">
         <a href="privacy-policy.html">Privacy Policy</a>
       </div>
+      ]]>
     </footer>
 
   </body>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
     <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-    <maven-site-plugin.version>2.4</maven-site-plugin.version>
+    <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
     <metrics-core.version>3.1.0</metrics-core.version>
     <mockito-core.version>4.3.1</mockito-core.version>
     <netty.version>4.1.100.Final</netty.version>


### PR DESCRIPTION
work done:
- upgraded maven site plugin
- upgraded fluido skin to be compatible with the site plugin
- created missing release pages markdown
- removed deprecated releases from the menu (still available in the all releases page)

testing:
- ran:
```
cd docs
mvn clean site
```
opened the webpage: docs/target/index.html