### PR TITLE
TEZ-4589: Counter for the overall duration of succeeded/failed/killed task attempts

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/common/counters/DAGCounter.java
+++ b/tez-api/src/main/java/org/apache/tez/common/counters/DAGCounter.java
@@ -30,6 +30,28 @@ public enum DAGCounter {
   NUM_KILLED_TASKS,
   NUM_SUCCEEDED_TASKS,
   TOTAL_LAUNCHED_TASKS,
+
+  /* The durations of task attempts are categorized based on their final states. The duration of successful tasks
+  can serve as a reference when analyzing the durations of failed or killed tasks. This is because solely examining
+  failed or killed task durations may be misleading, as these durations are measured from the submission time,
+  which does not always correspond to the actual start time of the task attempt on executor nodes
+  (e.g., in scenarios involving Hive LLAP).
+  These counters align with the duration metrics used for WALL_CLOCK_MILLIS.
+  As such, the following relationship applies:
+  WALL_CLOCK_MILLIS = DURATION_FAILED_TASKS_MILLIS + DURATION_KILLED_TASKS_MILLIS + DURATION_SUCCEEDED_TASKS_MILLIS
+  */
+
+  // Total amount of time spent on running FAILED task attempts. This can be blamed for performance degradation, as a
+  // DAG can still finish successfully in the presence of failed attempts.
+  DURATION_FAILED_TASKS_MILLIS,
+
+  // Total amount of time spent on running KILLED task attempts.
+  DURATION_KILLED_TASKS_MILLIS,
+
+  // Total amount of time spent on running SUCCEEDED task attempts, which can be a reference together with the same for
+  // FAILED and KILLED attempts.
+  DURATION_SUCCEEDED_TASKS_MILLIS,
+
   OTHER_LOCAL_TASKS,
   DATA_LOCAL_TASKS,
   RACK_LOCAL_TASKS,

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/event/DAGEventCounterUpdate.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/event/DAGEventCounterUpdate.java
@@ -57,6 +57,7 @@ public class DAGEventCounterUpdate extends DAGEvent {
       return incrValue;
     }
 
+    @Override
     public String toString(){
       return String.format("DAGEventCounterUpdate.CounterIncrementalUpdate(key=%s, incrValue=%d)", key, incrValue);
     }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/event/DAGEventCounterUpdate.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/event/DAGEventCounterUpdate.java
@@ -29,7 +29,7 @@ public class DAGEventCounterUpdate extends DAGEvent {
   
   public DAGEventCounterUpdate(TezDAGID dagId) {
     super(dagId, DAGEventType.DAG_COUNTER_UPDATE);
-    counterUpdates = new ArrayList<DAGEventCounterUpdate.CounterIncrementalUpdate>();
+    counterUpdates = new ArrayList<>();
   }
 
   public void addCounterUpdate(Enum<?> key, long incrValue) {
@@ -55,6 +55,10 @@ public class DAGEventCounterUpdate extends DAGEvent {
 
     public long getIncrementValue() {
       return incrValue;
+    }
+
+    public String toString(){
+      return String.format("DAGEventCounterUpdate.CounterIncrementalUpdate(key=%s, incrValue=%d)", key, incrValue);
     }
   }
 }

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/TaskAttemptImpl.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/impl/TaskAttemptImpl.java
@@ -967,22 +967,25 @@ public class TaskAttemptImpl implements TaskAttempt,
     return dagCounterEvent;
   }
 
-  private static DAGEventCounterUpdate createDAGCounterUpdateEventTAFinished(
+  @VisibleForTesting
+  static DAGEventCounterUpdate createDAGCounterUpdateEventTAFinished(
       TaskAttemptImpl taskAttempt, TaskAttemptState taState) {
     DAGEventCounterUpdate jce =
         new DAGEventCounterUpdate(taskAttempt.getDAGID());
 
+    long amSideWallClockTimeMs = TimeUnit.NANOSECONDS.toMillis(taskAttempt.getDurationNs());
+    jce.addCounterUpdate(DAGCounter.WALL_CLOCK_MILLIS, amSideWallClockTimeMs);
+
     if (taState == TaskAttemptState.FAILED) {
       jce.addCounterUpdate(DAGCounter.NUM_FAILED_TASKS, 1);
+      jce.addCounterUpdate(DAGCounter.DURATION_FAILED_TASKS_MILLIS, amSideWallClockTimeMs);
     } else if (taState == TaskAttemptState.KILLED) {
       jce.addCounterUpdate(DAGCounter.NUM_KILLED_TASKS, 1);
+      jce.addCounterUpdate(DAGCounter.DURATION_KILLED_TASKS_MILLIS, amSideWallClockTimeMs);
     } else if (taState == TaskAttemptState.SUCCEEDED ) {
       jce.addCounterUpdate(DAGCounter.NUM_SUCCEEDED_TASKS, 1);
+      jce.addCounterUpdate(DAGCounter.DURATION_SUCCEEDED_TASKS_MILLIS, amSideWallClockTimeMs);
     }
-
-    long amSideWallClockTimeMs = TimeUnit.NANOSECONDS.toMillis(
-        taskAttempt.getDurationNs());
-    jce.addCounterUpdate(DAGCounter.WALL_CLOCK_MILLIS, amSideWallClockTimeMs);
 
     return jce;
   }


### PR DESCRIPTION
tested on cluster with different scenarios, hive LLAP

1. 2 queries running in parallel, leading to task kills, also I killed random nodes during the test
```
INFO  : Run DAG                               149.16s

INFO  :    NUM_FAILED_TASKS: 18
INFO  :    NUM_KILLED_TASKS: 11078
INFO  :    NUM_SUCCEEDED_TASKS: 774
INFO  :    TOTAL_LAUNCHED_TASKS: 11870
INFO  :    DURATION_FAILED_TASKS_MILLIS: 125559
INFO  :    DURATION_KILLED_TASKS_MILLIS: 2474797
INFO  :    DURATION_SUCCEEDED_TASKS_MILLIS: 15740900

ratio of failed to succeeded durations: 0.0080 = 0.80%
ratio of killed to succeeded durations: 0.1575 = 15.75%
```
low killed/succeeded ratio implies the hive LLAP behavior (task preempted quite fast, 11078 task kills didn't contributed that much)


2. single query, but more aggressive node killing
```
INFO  : Run DAG                               392.71s

INFO  :    NUM_FAILED_TASKS: 210
INFO  :    NUM_KILLED_TASKS: 334
INFO  :    NUM_SUCCEEDED_TASKS: 880
INFO  :    TOTAL_LAUNCHED_TASKS: 1318
INFO  :    DURATION_FAILED_TASKS_MILLIS: 14433036
INFO  :    DURATION_KILLED_TASKS_MILLIS: 12815980
INFO  :    DURATION_SUCCEEDED_TASKS_MILLIS: 31076258

ratio of failed to succeeded durations: 0.4643 = 46.43%
ratio of killed to succeeded durations: 0.4117 = 41.17%
```
btw, this time, task kills were in the early started Reducer5 tasks, as many Map 4 source tasks have failed (so reducer considered unhealthy most probably):
```
----------------------------------------------------------------------------------------------
        VERTICES      MODE        STATUS  TOTAL  COMPLETED  RUNNING  PENDING  FAILED  KILLED
----------------------------------------------------------------------------------------------
Map 2 ..........      llap     SUCCEEDED      1          1        0        0       0       0
Map 1 ..........      llap     SUCCEEDED      1          1        0        0       0       0
Map 3 ..........      llap     SUCCEEDED      5          5        0        0       1       0
Map 4 ..........      llap     SUCCEEDED    675        675        0        0     209       0
Reducer 5 ......      llap     SUCCEEDED     92         92        0        0       0     334 
----------------------------------------------------------------------------------------------
VERTICES: 05/05  [==========================>>] 100%  ELAPSED TIME: 394.27 s
----------------------------------------------------------------------------------------------
```


3. normal query, no contention, no node failures

```
INFO  :    NUM_SUCCEEDED_TASKS: 774
INFO  :    TOTAL_LAUNCHED_TASKS: 774
INFO  :    DURATION_SUCCEEDED_TASKS_MILLIS: 15253902
```