### PR TITLE
TEZ-4593. Disable releases for apache.snapshots.https repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,9 @@
       <id>${distMgmtSnapshotsId}</id>
       <name>${distMgmtSnapshotsName}</name>
       <url>${distMgmtSnapshotsUrl}</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
     </repository>
   </repositories>
 
@@ -144,6 +147,9 @@
       <name>${distMgmtSnapshotsName}</name>
       <url>${distMgmtSnapshotsUrl}</url>
       <layout>default</layout>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
     </pluginRepository>
   </pluginRepositories>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

[Build](https://github.com/apache/tez/actions/runs/12312373636/job/34364280062#step:4:11762) tries to download release artifacts from snapshots repo:

```
Downloading from apache.snapshots.https: https://repository.apache.org/content/repositories/snapshots/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.pom
Downloading from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.pom
Downloaded from central: https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.pom (2.7 kB at 392 kB/s)
```

This change disables releases for `apache.snapshots.https`.

https://issues.apache.org/jira/browse/TEZ-4593

## How was this patch tested?

```
$ mvn -N --batch-mode eu.maveniverse.maven.plugins:toolbox:list-repositories
...
[INFO] --- toolbox:0.6.0:list-repositories (default-cli) @ tez ---
[INFO] Remote repositories used by project org.apache.tez:tez:pom:0.10.5-SNAPSHOT.
[INFO]  * central (https://repo.maven.apache.org/maven2/, default, releases)
[INFO]    First introduced on root
[INFO]  * apache.snapshots.https (https://repository.apache.org/content/repositories/snapshots, default, snapshots)
[INFO]    First introduced on root
[INFO]  * apache.snapshots (https://repository.apache.org/snapshots, default, snapshots)
[INFO]    First introduced on root
```

Local build.