### PR TITLE
TEZ-4599: Bump netty to 4.1.116.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
     <metrics-core.version>3.1.0</metrics-core.version>
     <mockito-core.version>4.3.1</mockito-core.version>
-    <netty.version>4.1.100.Final</netty.version>
+    <netty.version>4.1.116.Final</netty.version>
     <pig.version>0.13.0</pig.version>
     <protobuf.version>3.25.5</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>


### PR DESCRIPTION
JIra - [TEZ-4599](https://issues.apache.org/jira/browse/TEZ-4599)

After Upgarding netty to 4.1.116.Final, netty libraries package image looks like the below
![Tez_netty_jars_ss](https://github.com/user-attachments/assets/83206517-81e8-4f09-8f4e-00ce60c57aff)
