### PR TITLE
TEZ-4605: Enbale hadoop CallerContext in TezChild and DAGAppMaster

### DIFF
--- a/tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java
@@ -2390,9 +2390,11 @@ public class DAGAppMaster extends AbstractService {
       ContainerId containerId = ConverterUtils.toContainerId(containerIdStr);
       ApplicationAttemptId applicationAttemptId =
           containerId.getApplicationAttemptId();
+      org.apache.hadoop.ipc.CallerContext callerContext = org.apache.hadoop.ipc.CallerContext.getCurrent();
       org.apache.hadoop.ipc.CallerContext.setCurrent(new org.apache.hadoop.ipc.CallerContext
-              .Builder("tez_appmaster_" + containerId.getApplicationAttemptId()
-      ).build());
+              .Builder("tez_appmaster_" + containerId.getApplicationAttemptId())
+              .append(containerIdStr)
+              .build());
       long appSubmitTime = Long.parseLong(appSubmitTimeStr);
 
       String jobUserName = System

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java
@@ -2390,11 +2390,9 @@ public class DAGAppMaster extends AbstractService {
       ContainerId containerId = ConverterUtils.toContainerId(containerIdStr);
       ApplicationAttemptId applicationAttemptId =
           containerId.getApplicationAttemptId();
-      org.apache.hadoop.ipc.CallerContext callerContext = org.apache.hadoop.ipc.CallerContext.getCurrent();
       org.apache.hadoop.ipc.CallerContext.setCurrent(new org.apache.hadoop.ipc.CallerContext
-              .Builder("tez_appmaster_" + containerId.getApplicationAttemptId())
-              .append(containerIdStr)
-              .build());
+              .Builder("tez_appmaster_" + containerId.getApplicationAttemptId()
+      ).build());
       long appSubmitTime = Long.parseLong(appSubmitTimeStr);
 
       String jobUserName = System

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java
@@ -2393,7 +2393,7 @@ public class DAGAppMaster extends AbstractService {
       org.apache.hadoop.ipc.CallerContext callerContext = org.apache.hadoop.ipc.CallerContext.getCurrent();
       org.apache.hadoop.ipc.CallerContext.setCurrent(new org.apache.hadoop.ipc.CallerContext
               .Builder("tez_appmaster_" + containerId.getApplicationAttemptId())
-              .append(callerContext.getContext())
+              .append(containerIdStr)
               .build());
       long appSubmitTime = Long.parseLong(appSubmitTimeStr);
 

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java
@@ -2390,7 +2390,9 @@ public class DAGAppMaster extends AbstractService {
       ContainerId containerId = ConverterUtils.toContainerId(containerIdStr);
       ApplicationAttemptId applicationAttemptId =
           containerId.getApplicationAttemptId();
-
+      org.apache.hadoop.ipc.CallerContext.setCurrent(new org.apache.hadoop.ipc.CallerContext
+              .Builder("tez_appmaster_" + containerId.getApplicationAttemptId()
+      ).build());
       long appSubmitTime = Long.parseLong(appSubmitTimeStr);
 
       String jobUserName = System

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java
@@ -2393,7 +2393,7 @@ public class DAGAppMaster extends AbstractService {
       org.apache.hadoop.ipc.CallerContext callerContext = org.apache.hadoop.ipc.CallerContext.getCurrent();
       org.apache.hadoop.ipc.CallerContext.setCurrent(new org.apache.hadoop.ipc.CallerContext
               .Builder("tez_appmaster_" + containerId.getApplicationAttemptId())
-              .append(containerIdStr)
+              .append(callerContext.getContext())
               .build());
       long appSubmitTime = Long.parseLong(appSubmitTimeStr);
 

--- a/tez-runtime-internals/src/main/java/org/apache/tez/runtime/task/TezChild.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/runtime/task/TezChild.java
@@ -41,6 +41,7 @@ import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ipc.CallerContext;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.SecurityUtil;

--- a/tez-runtime-internals/src/main/java/org/apache/tez/runtime/task/TezChild.java
+++ b/tez-runtime-internals/src/main/java/org/apache/tez/runtime/task/TezChild.java
@@ -533,6 +533,7 @@ public class TezChild {
     final int attemptNumber = Integer.parseInt(args[4]);
     final String[] localDirs = TezCommonUtils.getTrimmedStrings(System.getenv(Environment.LOCAL_DIRS
         .name()));
+    CallerContext.setCurrent(new CallerContext.Builder("tez_"+tokenIdentifier).build());
     LOG.info("TezChild starting with PID=" + pid + ", containerIdentifier=" + containerIdentifier);
     if (LOG.isDebugEnabled()) {
       LOG.debug("Info from cmd line: AM-host: " + host + " AM-port: " + port


### PR DESCRIPTION
As described in [TEZ-4605](https://issues.apache.org/jira/browse/TEZ-4605)

### What did I change
I modified `tez-dag/src/main/java/org/apache/tez/dag/app/DAGAppMaster.java` and `tez-runtime-internals/src/main/java/org/apache/tez/runtime/task/TezChild.java`

### Why did I change
I want to enable org.apache.hadoop.ipc.CallerContext when running TEZ on yarn, so that we can trace how the application interacted with hdfs files.

### How did I test
I modified the code and build the whole project, then I test on my own hadoop cluster, we can see the callcontext information in hdfs-audit.log.

here is a screenshot of it:
<img width="1483" alt="image" src="https://github.com/user-attachments/assets/1b288e23-022c-4a7e-a83a-d4c5456ae5eb" />
