### PR TITLE
TEZ-4609: JDK-17: Fix ByteBuffer mark incompatibility in PipelinedSorter.

### DIFF
--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/sort/impl/PipelinedSorter.java
@@ -945,8 +945,7 @@ public class PipelinedSorter extends ExternalSorter {
         // try to allocate less meta space, because we have sample data
         metasize = METASIZE*(capacity/(perItem+METASIZE));
       }
-      ByteBuffer reserved = source.duplicate();
-      reserved.mark();
+      ByteBuffer reserved = (ByteBuffer) source.duplicate().mark();
       LOG.info(outputContext.getInputOutputVertexNames() + ": " + "reserved.remaining()=" +
           reserved.remaining() + ", reserved.metasize=" + metasize);
       reserved.position(metasize);


### PR DESCRIPTION
The ByteBuffer.mark() method returns ByteBuffer itself in Java 8, but starting with JDK 9+, it returns a more specific subclass (like HeapByteBuffer or DirectByteBuffer), which is incompatible with method signatures expecting ByteBuffer.

When running the same code in JDK 17, this mismatch triggers a NoSuchMethodError due to binary incompatibility.