### PR TITLE
TEZ-4643: Enforce speculation configuration to prevent execution on normal tasks.

### DIFF
--- a/tez-dag/src/main/java/org/apache/tez/dag/app/dag/speculation/legacy/LegacySpeculator.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/dag/speculation/legacy/LegacySpeculator.java
@@ -369,8 +369,9 @@ public class LegacySpeculator extends AbstractService {
           return TOO_NEW;
         }
 
+        long taskRuntime = now - taskAttemptStartTime;
         if (shouldUseTimeout) {
-          if ((now - taskAttemptStartTime) > taskTimeout) {
+          if (taskRuntime > taskTimeout) {
             // If the task has timed out, then we want to schedule a speculation
             // immediately. However we cannot return immediately since we may
             // already have a speculation running.
@@ -380,6 +381,10 @@ public class LegacySpeculator extends AbstractService {
             return ON_SCHEDULE;
           }
         } else {
+          if (taskRuntime < acceptableRuntime) {
+            return ON_SCHEDULE;
+          }
+
           long estimatedRunTime = estimator
               .estimatedRuntime(runningTaskAttemptID);
 


### PR DESCRIPTION
A configuration meant to distinguish between slow and normal task attempts is not working correctly. This causes the speculation mechanism to target normal tasks as well, wasting considerable resources. This fix ensures the configuration is enforced, limiting speculative execution to only outlier or slow tasks.

`tez.am.legacy.speculative.slowtask.threshold`