### PR TITLE
TEZ-4647: Refactor plugin management from DAGAppMaster

### DIFF
--- a/tez-dag/findbugs-exclude.xml
+++ b/tez-dag/findbugs-exclude.xml
@@ -248,4 +248,29 @@
     <Bug pattern="EI_EXPOSE_REP2"/>
   </Match>
 
+  <!-- TEZ-4647 PluginManager EI_EXPOSE_REP warnings -->
+  <Match>
+    <Class name="org.apache.tez.dag.app.PluginManager"/>
+    <Method name="getTaskSchedulers"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+
+  <Match>
+    <Class name="org.apache.tez.dag.app.PluginManager"/>
+    <Method name="getContainerLaunchers"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+
+  <Match>
+    <Class name="org.apache.tez.dag.app.PluginManager"/>
+    <Method name="getTaskCommunicators"/>
+    <Bug pattern="EI_EXPOSE_REP"/>
+  </Match>
+
+  <Match>
+    <Class name="org.apache.tez.dag.app.PluginManager"/>
+    <Method name="&lt;init&gt;"/>
+    <Bug pattern="EI_EXPOSE_REP2"/>
+  </Match>
+
 </FindBugsFilter>

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/PluginManager.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/PluginManager.java
@@ -189,7 +189,7 @@ public class PluginManager {
   public static void addDescriptor(List<NamedEntityDescriptor> list, BiMap<String, Integer> pluginMap,
                             NamedEntityDescriptor namedEntityDescriptor) {
     list.add(namedEntityDescriptor);
-    pluginMap.put(list.get(list.size() - 1).getEntityName(), list.size() - 1);
+    pluginMap.put(list.getLast().getEntityName(), list.size() - 1);
   }
 
   /**

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/PluginManager.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/PluginManager.java
@@ -1,0 +1,264 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tez.dag.app;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.tez.dag.api.DagTypeConverters;
+import org.apache.tez.dag.api.NamedEntityDescriptor;
+import org.apache.tez.dag.api.TezConstants;
+import org.apache.tez.dag.api.UserPayload;
+import org.apache.tez.dag.api.records.DAGProtos.AMPluginDescriptorProto;
+import org.apache.tez.dag.api.records.DAGProtos.TezNamedEntityDescriptorProto;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Lists;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manager for AM service plugins.
+ *
+ * This component parses the configured plugins for TaskSchedulers,
+ * ContainerLaunchers, and TaskCommunicators from the AM configuration,
+ * maintains their name-to-identifier mappings, and provides the parsed
+ * descriptor lists used to initialize the corresponding managers.
+ */
+public class PluginManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PluginManager.class);
+
+  private final AMPluginDescriptorProto amPluginDescriptorProto;
+
+  // Plugin maps for task schedulers, container launchers, and task communicators
+  private final BiMap<String, Integer> taskSchedulers = HashBiMap.create();
+  private final BiMap<String, Integer> containerLaunchers = HashBiMap.create();
+  private final BiMap<String, Integer> taskCommunicators = HashBiMap.create();
+
+  /**
+   * Wrapper for parsed plugin descriptors.
+   *
+   * The descriptor lists exposed by this class are unmodifiable snapshots
+   * created at parse time. Callers must not attempt to modify these
+   * collections; any modification attempts will throw an exception.
+   */
+  public static final class PluginDescriptors {
+    private final List<NamedEntityDescriptor> taskSchedulerDescriptors;
+    private final List<NamedEntityDescriptor> containerLauncherDescriptors;
+    private final List<NamedEntityDescriptor> taskCommunicatorDescriptors;
+
+    public PluginDescriptors(List<NamedEntityDescriptor> taskSchedulerDescriptors,
+                             List<NamedEntityDescriptor> containerLauncherDescriptors,
+                             List<NamedEntityDescriptor> taskCommunicatorDescriptors) {
+      this.taskSchedulerDescriptors = Collections.unmodifiableList(taskSchedulerDescriptors);
+      this.containerLauncherDescriptors = Collections.unmodifiableList(containerLauncherDescriptors);
+      this.taskCommunicatorDescriptors = Collections.unmodifiableList(taskCommunicatorDescriptors);
+    }
+
+    public List<NamedEntityDescriptor> getTaskSchedulerDescriptors() {
+      return taskSchedulerDescriptors;
+    }
+
+    public List<NamedEntityDescriptor> getContainerLauncherDescriptors() {
+      return containerLauncherDescriptors;
+    }
+
+    public List<NamedEntityDescriptor> getTaskCommunicatorDescriptors() {
+      return taskCommunicatorDescriptors;
+    }
+  }
+
+  public PluginManager() {
+    this(null);
+  }
+
+  public PluginManager(AMPluginDescriptorProto amPluginDescriptorProto) {
+    this.amPluginDescriptorProto = amPluginDescriptorProto;
+  }
+
+  /**
+   * Parse all plugins for task schedulers, container launchers, and task communicators.
+   */
+  public PluginDescriptors parseAllPlugins(boolean isLocal, UserPayload defaultPayload) {
+
+    List<NamedEntityDescriptor> taskSchedulerDescriptors = Lists.newLinkedList();
+    List<NamedEntityDescriptor> containerLauncherDescriptors = Lists.newLinkedList();
+    List<NamedEntityDescriptor> taskCommDescriptors = Lists.newLinkedList();
+
+    boolean tezYarnEnabled;
+    boolean uberEnabled;
+    if (!isLocal) {
+      if (amPluginDescriptorProto == null) {
+        tezYarnEnabled = true;
+        uberEnabled = false;
+      } else {
+        tezYarnEnabled = amPluginDescriptorProto.getContainersEnabled();
+        uberEnabled = amPluginDescriptorProto.getUberEnabled();
+      }
+    } else {
+      tezYarnEnabled = false;
+      uberEnabled = true;
+    }
+
+    // parse task scheduler plugins
+    parsePlugin(taskSchedulerDescriptors, taskSchedulers,
+        (amPluginDescriptorProto == null || amPluginDescriptorProto.getTaskSchedulersCount() == 0 ?
+            null :
+            amPluginDescriptorProto.getTaskSchedulersList()),
+        tezYarnEnabled, uberEnabled, defaultPayload);
+
+    // post-process task scheduler plugin descriptors
+    processSchedulerDescriptors(taskSchedulerDescriptors, isLocal, defaultPayload, taskSchedulers);
+
+    // parse container launcher plugins
+    parsePlugin(containerLauncherDescriptors, containerLaunchers,
+        (amPluginDescriptorProto == null ||
+            amPluginDescriptorProto.getContainerLaunchersCount() == 0 ? null :
+            amPluginDescriptorProto.getContainerLaunchersList()),
+        tezYarnEnabled, uberEnabled, defaultPayload);
+
+    // parse task communicator plugins
+    parsePlugin(taskCommDescriptors, taskCommunicators,
+        (amPluginDescriptorProto == null ||
+            amPluginDescriptorProto.getTaskCommunicatorsCount() == 0 ? null :
+            amPluginDescriptorProto.getTaskCommunicatorsList()),
+        tezYarnEnabled, uberEnabled, defaultPayload);
+
+    // Log plugin component information
+    LOG.info(buildPluginComponentLog(taskSchedulerDescriptors, taskSchedulers, "TaskSchedulers"));
+    LOG.info(buildPluginComponentLog(containerLauncherDescriptors, containerLaunchers, "ContainerLaunchers"));
+    LOG.info(buildPluginComponentLog(taskCommDescriptors, taskCommunicators, "TaskCommunicators"));
+
+    return new PluginDescriptors(taskSchedulerDescriptors, containerLauncherDescriptors, taskCommDescriptors);
+  }
+
+  /**
+   * Parse a specific plugin type.
+   */
+  @VisibleForTesting
+  public static void parsePlugin(List<NamedEntityDescriptor> resultList,
+      BiMap<String, Integer> pluginMap, List<TezNamedEntityDescriptorProto> namedEntityDescriptorProtos,
+      boolean tezYarnEnabled, boolean uberEnabled, UserPayload defaultPayload) {
+
+    if (tezYarnEnabled) {
+      // Default classnames will be populated by individual components
+      NamedEntityDescriptor descriptor = new NamedEntityDescriptor(
+          TezConstants.getTezYarnServicePluginName(), null).setUserPayload(defaultPayload);
+      addDescriptor(resultList, pluginMap, descriptor);
+    }
+
+    if (uberEnabled) {
+      // Default classnames will be populated by individual components
+      NamedEntityDescriptor descriptor = new NamedEntityDescriptor(
+          TezConstants.getTezUberServicePluginName(), null).setUserPayload(defaultPayload);
+      addDescriptor(resultList, pluginMap, descriptor);
+    }
+
+    if (namedEntityDescriptorProtos != null) {
+      for (TezNamedEntityDescriptorProto namedEntityDescriptorProto : namedEntityDescriptorProtos) {
+        NamedEntityDescriptor descriptor = DagTypeConverters
+            .convertNamedDescriptorFromProto(namedEntityDescriptorProto);
+        addDescriptor(resultList, pluginMap, descriptor);
+      }
+    }
+  }
+
+  /**
+   * Add a descriptor to the list and map.
+   */
+  public static void addDescriptor(List<NamedEntityDescriptor> list, BiMap<String, Integer> pluginMap,
+                            NamedEntityDescriptor namedEntityDescriptor) {
+    list.add(namedEntityDescriptor);
+    pluginMap.put(list.get(list.size() - 1).getEntityName(), list.size() - 1);
+  }
+
+  /**
+   * Process scheduler descriptors with framework-specific logic.
+   */
+  public void processSchedulerDescriptors(List<NamedEntityDescriptor> descriptors, boolean isLocal,
+                                          UserPayload defaultPayload,
+                                          BiMap<String, Integer> schedulerPluginMap) {
+    if (isLocal) {
+      boolean foundUberServiceName = false;
+      for (NamedEntityDescriptor<?> descriptor : descriptors) {
+        if (descriptor.getEntityName().equals(TezConstants.getTezUberServicePluginName())) {
+          foundUberServiceName = true;
+          break;
+        }
+      }
+      Preconditions.checkState(foundUberServiceName);
+    } else {
+      boolean foundYarn = false;
+      for (NamedEntityDescriptor descriptor : descriptors) {
+        if (descriptor.getEntityName().equals(TezConstants.getTezYarnServicePluginName())) {
+          foundYarn = true;
+          break;
+        }
+      }
+      if (!foundYarn) {
+        NamedEntityDescriptor<?> yarnDescriptor =
+            new NamedEntityDescriptor(TezConstants.getTezYarnServicePluginName(), null)
+                .setUserPayload(defaultPayload);
+        addDescriptor(descriptors, schedulerPluginMap, yarnDescriptor);
+      }
+    }
+  }
+
+  /**
+   * Get the task schedulers map.
+   */
+  public BiMap<String, Integer> getTaskSchedulers() {
+    return taskSchedulers;
+  }
+
+  /**
+   * Get the container launchers map.
+   */
+  public BiMap<String, Integer> getContainerLaunchers() {
+    return containerLaunchers;
+  }
+
+  /**
+   * Get the task communicators map.
+   */
+  public BiMap<String, Integer> getTaskCommunicators() {
+    return taskCommunicators;
+  }
+
+  /**
+   * Build a log message for plugin component information.
+   */
+  private String buildPluginComponentLog(List<NamedEntityDescriptor> namedEntityDescriptors, BiMap<String, Integer> map,
+                                       String component) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("AM Level configured ").append(component).append(": ");
+    for (int i = 0; i < namedEntityDescriptors.size(); i++) {
+      sb.append("[").append(i).append(":").append(map.inverse().get(i))
+          .append(":").append(namedEntityDescriptors.get(i).getClassName()).append("]");
+      if (i != namedEntityDescriptors.size() - 1) {
+        sb.append(",");
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexImpl2.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexImpl2.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.tez.common.TezUtils;
 import org.apache.tez.dag.api.DagTypeConverters;
-import org.apache.tez.dag.api.NamedEntityDescriptor;
 import org.apache.tez.dag.api.TaskLocationHint;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.TezConstants;
@@ -52,7 +51,7 @@ import org.apache.tez.dag.api.records.DAGProtos.TezNamedEntityDescriptorProto;
 import org.apache.tez.dag.api.records.DAGProtos.VertexPlan;
 import org.apache.tez.dag.app.AppContext;
 import org.apache.tez.dag.app.ContainerContext;
-import org.apache.tez.dag.app.DAGAppMaster;
+import org.apache.tez.dag.app.PluginManager;
 import org.apache.tez.dag.app.TaskCommunicatorManagerInterface;
 import org.apache.tez.dag.app.TaskHeartbeatHandler;
 import org.apache.tez.dag.app.dag.DAG;
@@ -381,13 +380,9 @@ public class TestVertexImpl2 {
         } catch (IOException e) {
           throw new TezUncheckedException(e);
         }
-        DAGAppMaster.parsePlugin(Lists.<NamedEntityDescriptor>newLinkedList(), taskSchedulers, null,
-            true, false, defaultPayload);
-        DAGAppMaster
-            .parsePlugin(Lists.<NamedEntityDescriptor>newLinkedList(), containerLaunchers, null,
-                true, false, defaultPayload);
-        DAGAppMaster.parsePlugin(Lists.<NamedEntityDescriptor>newLinkedList(), taskComms, null,
-            true, false, defaultPayload);
+        PluginManager.parsePlugin(Lists.newLinkedList(), taskSchedulers, null, true, false, defaultPayload);
+        PluginManager.parsePlugin(Lists.newLinkedList(), containerLaunchers, null, true, false, defaultPayload);
+        PluginManager.parsePlugin(Lists.newLinkedList(), taskComms, null, true, false, defaultPayload);
       } else { // Add N plugins, no YARN defaults
         List<TezNamedEntityDescriptorProto> schedulerList = new LinkedList<>();
         List<TezNamedEntityDescriptorProto> launcherList = new LinkedList<>();
@@ -407,13 +402,9 @@ public class TestVertexImpl2 {
                       DAGProtos.TezEntityDescriptorProto.newBuilder()
                           .setClassName(append(TASK_COMM_NAME_BASE, i))).build());
         }
-        DAGAppMaster.parsePlugin(Lists.<NamedEntityDescriptor>newLinkedList(), taskSchedulers,
-            schedulerList, false, false, null);
-        DAGAppMaster.parsePlugin(Lists.<NamedEntityDescriptor>newLinkedList(), containerLaunchers,
-            launcherList, false, false, null);
-        DAGAppMaster
-            .parsePlugin(Lists.<NamedEntityDescriptor>newLinkedList(), taskComms, taskCommList,
-                false, false, null);
+        PluginManager.parsePlugin(Lists.newLinkedList(), taskSchedulers, schedulerList, false, false, null);
+        PluginManager.parsePlugin(Lists.newLinkedList(), containerLaunchers, launcherList, false, false, null);
+        PluginManager.parsePlugin(Lists.newLinkedList(), taskComms, taskCommList, false, false, null);
       }
 
       this.appContext = createDefaultMockAppContext();
@@ -557,4 +548,5 @@ public class TestVertexImpl2 {
     doReturn(mockDag).when(appContext).getCurrentDAG();
     return appContext;
   }
+
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskSchedulerManager.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskSchedulerManager.java
@@ -80,8 +80,8 @@ import org.apache.tez.dag.app.AppContext;
 import org.apache.tez.dag.app.ClusterInfo;
 import org.apache.tez.dag.app.ContainerContext;
 import org.apache.tez.dag.app.ContainerHeartbeatHandler;
-import org.apache.tez.dag.app.DAGAppMaster;
 import org.apache.tez.dag.app.DAGAppMasterState;
+import org.apache.tez.dag.app.PluginManager;
 import org.apache.tez.dag.app.ServicePluginLifecycleAbstractService;
 import org.apache.tez.dag.app.TaskCommunicatorManagerInterface;
 import org.apache.tez.dag.app.dag.DAG;
@@ -865,14 +865,16 @@ public class TestTaskSchedulerManager {
     UserPayload defaultPayload = TezUtils.createUserPayloadFromConf(tezConf);
 
     // Parse plugins
-    List<NamedEntityDescriptor> tsDescriptors = Lists.newLinkedList();
+    PluginManager pluginManager = new PluginManager();
+    PluginManager.PluginDescriptors pluginDescriptors = pluginManager.parseAllPlugins(false, defaultPayload);
+    List<NamedEntityDescriptor> tsDescriptors = pluginDescriptors.getTaskSchedulerDescriptors();
     BiMap<String, Integer> tsMap = HashBiMap.create();
-    DAGAppMaster.parseAllPlugins(tsDescriptors, tsMap, Lists.newLinkedList(), HashBiMap.create(), Lists.newLinkedList(),
-        HashBiMap.create(), null, false, defaultPayload);
 
     // Only TezYarn found.
     Assert.assertEquals(1, tsDescriptors.size());
     Assert.assertEquals(TezConstants.getTezYarnServicePluginName(), tsDescriptors.get(0).getEntityName());
+    Assert.assertEquals(1, pluginManager.getTaskSchedulers().size());
+    Assert.assertTrue(pluginManager.getTaskSchedulers().containsKey(TezConstants.getTezYarnServicePluginName()));
 
     // Construct eventHandler
     TestTaskSchedulerHelpers.CapturingEventHandler eventHandler = new TestTaskSchedulerHelpers.CapturingEventHandler();


### PR DESCRIPTION
From Jira:

The proposal is to create a PluginManager to offload much of the plugin management code from the already overloaded DAGAppMaster class (including its static methods).
This issue was discovered while working on TEZ-4007, which only exacerbated the situation with the addition of AMExtensions (not AMExtensions themselves, but rather the original code in DAGAppMaster). Let’s clean this up first before proceeding with TEZ-4007.

Testing done with affected unit tests
`
mvn install -Dtest=TestTaskSchedulerManager,TestVertexImpl2,TestDAGAppMaster -pl ./tez-dag
`