### PR TITLE
TEZ-4695: Consolidate surefire plugin config to remove redundant surefire blocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -959,11 +959,11 @@
             <reuseForks>false</reuseForks>
             <forkedProcessTimeoutInSeconds>900</forkedProcessTimeoutInSeconds>
             <testFailureIgnore>true</testFailureIgnore>
-            <argLine>-Xmx1024m -XX:+HeapDumpOnOutOfMemoryError</argLine>
-            <argLine>${test.jvm.args}</argLine>
+            <argLine>-Xmx1024m -XX:+HeapDumpOnOutOfMemoryError ${test.jvm.args}</argLine>
             <environmentVariables>
               <JAVA_HOME>${java.home}</JAVA_HOME>
               <MALLOC_ARENA_MAX>4</MALLOC_ARENA_MAX>
+              <LOG_DIRS>${test.log.dir}</LOG_DIRS>
             </environmentVariables>
             <systemPropertyVariables>
               <test.build.data>${test.build.data}</test.build.data>

--- a/pom.xml
+++ b/pom.xml
@@ -105,14 +105,8 @@
     <snappy-java.version>1.1.10.4</snappy-java.version>
     <spotless-maven-plugin.version>3.1.0</spotless-maven-plugin.version>
     <test.build.data>${project.build.directory}/tmp</test.build.data>
+    <test.log.dir>${project.build.directory}/logs</test.log.dir>
     <wro4j-maven-plugin.version>1.7.9</wro4j-maven-plugin.version>
-    <test.jvm.args>
-      --add-opens=java.base/java.lang=ALL-UNNAMED
-      --add-opens=java.base/java.util=ALL-UNNAMED
-      --add-opens java.base/java.io=ALL-UNNAMED
-      -Dnet.bytebuddy.experimental=true
-    </test.jvm.args>
-
     <maven.javadoc.skip>true</maven.javadoc.skip> <!-- enabled only in relevant modules separately -->
   </properties>
   <scm>
@@ -959,11 +953,18 @@
             <reuseForks>false</reuseForks>
             <forkedProcessTimeoutInSeconds>900</forkedProcessTimeoutInSeconds>
             <testFailureIgnore>true</testFailureIgnore>
-            <argLine>-Xmx1024m -XX:+HeapDumpOnOutOfMemoryError ${test.jvm.args}</argLine>
+            <argLine>
+              -XX:+HeapDumpOnOutOfMemoryError
+              --add-opens=java.base/java.lang=ALL-UNNAMED
+              --add-opens=java.base/java.util=ALL-UNNAMED
+              --add-opens=java.base/java.io=ALL-UNNAMED
+              -Dnet.bytebuddy.experimental=true
+            </argLine>
             <environmentVariables>
               <JAVA_HOME>${java.home}</JAVA_HOME>
-              <MALLOC_ARENA_MAX>4</MALLOC_ARENA_MAX>
               <LOG_DIRS>${test.log.dir}</LOG_DIRS>
+              <MALLOC_ARENA_MAX>4</MALLOC_ARENA_MAX>
+              <TEZ_AM_EXTERNAL_ID>test-external-id</TEZ_AM_EXTERNAL_ID>
             </environmentVariables>
             <systemPropertyVariables>
               <test.build.data>${test.build.data}</test.build.data>

--- a/tez-dag/pom.xml
+++ b/tez-dag/pom.xml
@@ -209,9 +209,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>${test.jvm.args}</argLine>
-          <environmentVariables>
-            <LOG_DIRS>${test.log.dir}</LOG_DIRS>
+          <environmentVariables combine.children="append">
             <TEZ_AM_EXTERNAL_ID>test-external-id</TEZ_AM_EXTERNAL_ID>
           </environmentVariables>
         </configuration>

--- a/tez-dag/pom.xml
+++ b/tez-dag/pom.xml
@@ -31,7 +31,6 @@
     org.apache.tez.dag.app.rm.container.AMContainerImpl</tez.dag.state.classes>
     <tez.graphviz.title>Tez</tez.graphviz.title>
     <tez.graphviz.output.file>Tez.gv</tez.graphviz.output.file>
-    <test.log.dir>${project.build.directory}/logs</test.log.dir>
   </properties>
   <artifactId>tez-dag</artifactId>
 
@@ -204,15 +203,6 @@
             </goals>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <environmentVariables combine.children="append">
-            <TEZ_AM_EXTERNAL_ID>test-external-id</TEZ_AM_EXTERNAL_ID>
-          </environmentVariables>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>com.github.os72</groupId>

--- a/tez-ext-service-tests/pom.xml
+++ b/tez-ext-service-tests/pom.xml
@@ -158,16 +158,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>${test.jvm.args}</argLine>
-          <environmentVariables>
-            <LOG_DIRS>${test.log.dir}</LOG_DIRS>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
       </plugin>

--- a/tez-ext-service-tests/pom.xml
+++ b/tez-ext-service-tests/pom.xml
@@ -25,10 +25,6 @@
 
   <artifactId>tez-ext-service-tests</artifactId>
 
-  <properties>
-    <test.log.dir>${project.build.directory}/logs</test.log.dir>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>io.netty</groupId>

--- a/tez-tests/pom.xml
+++ b/tez-tests/pom.xml
@@ -24,10 +24,6 @@
   </parent>
   <artifactId>tez-tests</artifactId>
 
-  <properties>
-    <test.log.dir>${project.build.directory}/logs</test.log.dir>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.tez</groupId>

--- a/tez-tests/pom.xml
+++ b/tez-tests/pom.xml
@@ -158,16 +158,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>${test.jvm.args}</argLine>
-          <environmentVariables>
-            <LOG_DIRS>${test.log.dir}</LOG_DIRS>
-          </environmentVariables>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
The surefire changes are to pass the argline defines in parent pom to child pom and the environment variables defined in parent pom, child pom should inherit them. This will reduce explicit surefire plugin block in child module pom