### PR TITLE
TEZ-4688 TEZ-4648: Tez upgrade to Hadoop 3.5.0 and jersey 2.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.5.0</hadoop.version>
-    <jersey.version>1.19.4</jersey.version>
+    <jersey.version>2.46</jersey.version>
     <jettison.version>1.5.4</jettison.version>
     <jsr305.version>3.0.0</jsr305.version>
     <junit.version>4.13.2</junit.version>
@@ -784,13 +784,13 @@
         <version>${jettison.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.sun.jersey</groupId>
+        <groupId>org.glassfish.jersey.core</groupId>
         <artifactId>jersey-client</artifactId>
         <version>${jersey.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.sun.jersey</groupId>
-        <artifactId>jersey-json</artifactId>
+        <groupId>org.glassfish.jersey.media</groupId>
+        <artifactId>jersey-media-json-jackson</artifactId>
         <version>${jersey.version}</version>
       </dependency>
       <!-- BouncyCastle should be in default scope to make their way to tez.tar.gz since Hadoop 3.4.1 -->

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
     <jettison.version>1.5.4</jettison.version>
     <jsr305.version>3.0.0</jsr305.version>
     <junit.version>4.13.2</junit.version>
+    <junit.jupiter.version>5.9.3</junit.jupiter.version>
     <leveldbjni-all.version>1.8</leveldbjni-all.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <metrics-core.version>3.1.0</metrics-core.version>
@@ -766,6 +767,18 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit.jupiter.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>${junit.jupiter.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <plexus-velocity.version>2.3.0</plexus-velocity.version>
     <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
     <guava.version>32.0.1-jre</guava.version>
-    <hadoop.version>3.4.2</hadoop.version>
+    <hadoop.version>3.5.0</hadoop.version>
     <jersey.version>1.19.4</jersey.version>
     <jettison.version>1.5.4</jettison.version>
     <jsr305.version>3.0.0</jsr305.version>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.5.0</hadoop.version>
-    <jersey.version>1.19.4</jersey.version>
+    <jersey.version>2.46</jersey.version>
     <jettison.version>1.5.4</jettison.version>
     <jsr305.version>3.0.0</jsr305.version>
     <junit.version>4.13.2</junit.version>
@@ -789,13 +789,13 @@
         <version>${jettison.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.sun.jersey</groupId>
+        <groupId>org.glassfish.jersey.core</groupId>
         <artifactId>jersey-client</artifactId>
         <version>${jersey.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.sun.jersey</groupId>
-        <artifactId>jersey-json</artifactId>
+        <groupId>org.glassfish.jersey.media</groupId>
+        <artifactId>jersey-media-json-jackson</artifactId>
         <version>${jersey.version}</version>
       </dependency>
       <!-- BouncyCastle should be in default scope to make their way to tez.tar.gz since Hadoop 3.4.1 -->

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
     <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.5.0</hadoop.version>
+    <!-- Align all Jackson modules with the version shipped by Hadoop 3.5.0 (2.18.6).
+         Importing jackson-bom in dependencyManagement ensures any transitive dependency
+         (e.g. avro) that pulls an older jackson-core is automatically overridden.
+         This is the Jackson project's recommended approach for version alignment. -->
+    <jackson.version>2.18.6</jackson.version>
     <jersey.version>2.46</jersey.version>
     <jettison.version>1.5.4</jettison.version>
     <jsr305.version>3.0.0</jsr305.version>
@@ -154,6 +159,18 @@
 
   <dependencyManagement>
     <dependencies>
+      <!-- Import jackson-bom to enforce a consistent Jackson version across all
+           transitive sources. avro 1.11.5 (via hadoop-common/mapreduce-client-common)
+           pulls in jackson-core 2.14.3 which lacks BufferRecycler.releaseToPool()
+           required by Jersey 2.46 in Hadoop 3.5.0+. The BOM overrides ALL transitive
+           jackson versions without needing per-library exclusions -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>org.apache.tez</groupId>
         <artifactId>hadoop-shim</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
     <jettison.version>1.5.4</jettison.version>
     <jsr305.version>3.0.0</jsr305.version>
     <junit.version>4.13.2</junit.version>
+    <junit.jupiter.version>5.9.3</junit.jupiter.version>
     <leveldbjni-all.version>1.8</leveldbjni-all.version>
     <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
     <metrics-core.version>3.1.0</metrics-core.version>
@@ -771,6 +772,18 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>${junit.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>${junit.jupiter.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>${junit.jupiter.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
     <restrict-imports.enforcer.version>3.0.0</restrict-imports.enforcer.version>
     <roaringbitmap.version>1.2.1</roaringbitmap.version>
     <scm.url>scm:git:https://gitbox.apache.org/repos/asf/tez.git</scm.url>
-    <servlet-api.version>3.1.0</servlet-api.version>
+    <servlet-api.version>4.0.4</servlet-api.version>
     <slf4j.version>1.7.36</slf4j.version>
     <snappy-java.version>1.1.10.4</snappy-java.version>
     <spotless-maven-plugin.version>3.1.0</spotless-maven-plugin.version>
@@ -275,6 +275,16 @@
         <groupId>org.apache.pig</groupId>
         <artifactId>pig</artifactId>
         <version>${pig.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.mortbay.jetty</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.dropwizard.metrics</groupId>
@@ -324,8 +334,8 @@
         <version>${netty.version}</version>
       </dependency>
       <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>javax.servlet-api</artifactId>
+        <groupId>jakarta.servlet</groupId>
+        <artifactId>jakarta.servlet-api</artifactId>
         <version>${servlet-api.version}</version>
       </dependency>
       <dependency>
@@ -341,6 +351,10 @@
           <exclusion>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
           </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -403,6 +417,14 @@
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
           </exclusion>
@@ -418,6 +440,10 @@
           <exclusion>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
           </exclusion>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -502,6 +528,14 @@
             <artifactId>jersey-core</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
           </exclusion>
@@ -515,6 +549,14 @@
           <exclusion>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -535,6 +577,14 @@
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>*</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -552,6 +602,14 @@
           <exclusion>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -605,6 +663,14 @@
             <artifactId>guice-servlet</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
           </exclusion>
@@ -618,6 +684,14 @@
           <exclusion>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-yarn-server-common</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -638,6 +712,14 @@
           <exclusion>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
@@ -669,6 +751,14 @@
             <artifactId>hadoop-mapreduce-client-common</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
           </exclusion>
@@ -681,6 +771,14 @@
         <type>test-jar</type>
         <version>${hadoop.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
@@ -705,6 +803,14 @@
             <artifactId>*</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-core</artifactId>
           </exclusion>
@@ -717,12 +823,24 @@
             <artifactId>servlet-api</artifactId>
           </exclusion>
           <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>javax.servlet.jsp</groupId>
             <artifactId>jsp-api</artifactId>
           </exclusion>
           <exclusion>
             <groupId>tomcat</groupId>
             <artifactId>jasper-runtime</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -330,14 +330,6 @@
             <artifactId>commons-logging-api</artifactId>
           </exclusion>
           <exclusion>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-server</artifactId>
-          </exclusion>
-          <exclusion>
             <groupId>org.eclipse.jdt</groupId>
             <artifactId>core</artifactId>
           </exclusion>
@@ -413,14 +405,6 @@
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-core</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-server</artifactId>
           </exclusion>
           <exclusion>
             <groupId>io.netty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <plexus-velocity.version>2.3.0</plexus-velocity.version>
     <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
     <guava.version>32.0.1-jre</guava.version>
-    <hadoop.version>3.4.2</hadoop.version>
+    <hadoop.version>3.5.0</hadoop.version>
     <jersey.version>1.19.4</jersey.version>
     <jettison.version>1.5.4</jettison.version>
     <jsr305.version>3.0.0</jsr305.version>

--- a/tez-api/pom.xml
+++ b/tez-api/pom.xml
@@ -90,12 +90,12 @@
      <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
+      <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/tez-api/pom.xml
+++ b/tez-api/pom.xml
@@ -94,12 +94,12 @@
      <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
+      <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-client</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/tez-api/src/main/java/org/apache/tez/common/ATSConstants.java
+++ b/tez-api/src/main/java/org/apache/tez/common/ATSConstants.java
@@ -27,15 +27,16 @@ public class ATSConstants {
 
   /* Top level keys */
   public static final String ENTITIES = "entities";
-  public static final String ENTITY = "entity";
-  public static final String ENTITY_TYPE = "entitytype";
+  public static final String ENTITY_ID = "entityId";
+  public static final String ENTITY_TYPE = "entityType";
   public static final String EVENTS = "events";
-  public static final String EVENT_TYPE = "eventtype";
+  public static final String EVENT_TYPE = "eventType";
   public static final String TIMESTAMP = "ts";
-  public static final String EVENT_INFO = "eventinfo";
+  public static final String EVENT_INFO = "eventInfo";
   public static final String RELATED_ENTITIES = "relatedEntities";
-  public static final String PRIMARY_FILTERS = "primaryfilters";
-  public static final String OTHER_INFO = "otherinfo";
+  public static final String PRIMARY_FILTERS = "primaryFilters";
+  public static final String OTHER_INFO = "otherInfo";
+  public static final String DOMAIN_ID = "domainId";
 
   /* Section for related entities */
   public static final String APPLICATION_ID = "applicationId";

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
@@ -157,9 +157,6 @@ public final class TimelineReaderFactory {
     @Override
     public Client getHttpClient() throws IOException {
       Authenticator authenticator;
-      UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-      UserGroupInformation realUgi = ugi.getRealUser();
-      String doAsUser;
       ClientConfig clientConfig = new ClientConfig().register(JacksonFeature.class);
       ConnectionConfigurator connectionConfigurator = getNewConnectionConf(useHttps,
               connTimeout, sslFactory);
@@ -170,13 +167,6 @@ public final class TimelineReaderFactory {
       } catch (TezException e) {
         throw new IOException("Failed to get authenticator", e);
       }
-
-      if (realUgi != null) {
-        doAsUser = ugi.getShortUserName();
-      } else {
-        doAsUser = null;
-      }
-
       return ClientBuilder.newClient(clientConfig);
     }
 

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
@@ -36,6 +36,7 @@ import javax.ws.rs.client.ClientBuilder;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
 import org.apache.hadoop.security.authentication.client.Authenticator;
 import org.apache.hadoop.security.authentication.client.ConnectionConfigurator;
 import org.apache.hadoop.security.ssl.SSLFactory;
@@ -45,6 +46,8 @@ import org.apache.tez.dag.api.TezException;
 import com.google.common.annotations.VisibleForTesting;
 
 import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider.ConnectionFactory;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -168,6 +171,18 @@ public final class TimelineReaderFactory {
       } catch (TezException e) {
         throw new IOException("Failed to get authenticator", e);
       }
+
+      ConnectionFactory factory = url -> {
+        try {
+          return new AuthenticatedURL(authenticator)
+                    .openConnection(url, new AuthenticatedURL.Token());
+        } catch (Exception e) {
+          throw new IOException("Hadoop Authentication failed", e);
+        }
+      };
+
+      HttpUrlConnectorProvider connectorProvider = new HttpUrlConnectorProvider().connectionFactory(factory);
+      clientConfig.connectorProvider(connectorProvider);
       return ClientBuilder.newClient(clientConfig);
     }
 

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
@@ -288,7 +288,7 @@ public final class TimelineReaderFactory {
             URLEncoder.encode(UserGroupInformation.getCurrentUser().getShortUserName(), "UTF8");
 
         HttpURLConnection httpURLConnection =
-            (HttpURLConnection) (new URL(url + tokenString)).openConnection();
+            (HttpURLConnection) URI.create(url + tokenString).toURL().openConnection();
         this.connectionConf.configure(httpURLConnection);
 
         return httpURLConnection;

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.security.GeneralSecurityException;
 
 import javax.net.ssl.HostnameVerifier;
@@ -36,7 +37,6 @@ import javax.ws.rs.client.ClientBuilder;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
 import org.apache.hadoop.security.authentication.client.Authenticator;
 import org.apache.hadoop.security.authentication.client.ConnectionConfigurator;
 import org.apache.hadoop.security.ssl.SSLFactory;
@@ -47,7 +47,6 @@ import com.google.common.annotations.VisibleForTesting;
 
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
-import org.glassfish.jersey.client.HttpUrlConnectorProvider.ConnectionFactory;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -161,6 +160,9 @@ public final class TimelineReaderFactory {
     @Override
     public Client getHttpClient() throws IOException {
       Authenticator authenticator;
+      UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+      UserGroupInformation realUgi = ugi.getRealUser();
+      String doAsUser;
       ClientConfig clientConfig = new ClientConfig().register(JacksonFeature.class);
       ConnectionConfigurator connectionConfigurator = getNewConnectionConf(useHttps,
               connTimeout, sslFactory);
@@ -172,17 +174,21 @@ public final class TimelineReaderFactory {
         throw new IOException("Failed to get authenticator", e);
       }
 
-      ConnectionFactory factory = url -> {
-        try {
-          return new AuthenticatedURL(authenticator)
-                    .openConnection(url, new AuthenticatedURL.Token());
-        } catch (Exception e) {
-          throw new IOException("Hadoop Authentication failed", e);
-        }
-      };
+      if (realUgi != null) {
+        doAsUser = ugi.getShortUserName();
+      } else {
+        doAsUser = null;
+      }
 
-      HttpUrlConnectorProvider connectorProvider = new HttpUrlConnectorProvider().connectionFactory(factory);
-      clientConfig.connectorProvider(connectorProvider);
+      HttpUrlConnectorProvider.ConnectionFactory connectionFactory;
+      try {
+        connectionFactory = new TokenAuthenticatedURLConnectionFactory(connectionConfigurator, authenticator,
+                doAsUser);
+      } catch (TezException e) {
+        throw new IOException("Fail to create TokenAuthenticatedURLConnectionFactory", e);
+      }
+
+      clientConfig.connectorProvider(new HttpUrlConnectorProvider().connectionFactory(connectionFactory));
       return ClientBuilder.newClient(clientConfig);
     }
 
@@ -196,6 +202,42 @@ public final class TimelineReaderFactory {
       }
 
       return ReflectionUtils.createClazzInstance(authenticatorClazzName);
+    }
+
+    private static class TokenAuthenticatedURLConnectionFactory implements HttpUrlConnectorProvider.ConnectionFactory {
+
+      private final Authenticator authenticator;
+      private final ConnectionConfigurator connConfigurator;
+      private final String doAsUser;
+      private final Object token;
+
+      public TokenAuthenticatedURLConnectionFactory(ConnectionConfigurator connConfigurator,
+                                                    Authenticator authenticator,
+                                                    String doAsUser) throws TezException {
+        this.connConfigurator = connConfigurator;
+        this.authenticator = authenticator;
+        this.doAsUser = doAsUser;
+        this.token = ReflectionUtils.createClazzInstance(
+            DELEGATION_TOKEN_AUTHENTICATED_URL_TOKEN_CLASS_NAME, null, null);
+      }
+
+      @Override
+      public HttpURLConnection getConnection(URL url) throws IOException {
+        try {
+          HttpURLConnection authenticatedURL = ReflectionUtils.createClazzInstance(
+              DELEGATION_TOKEN_AUTHENTICATED_URL_CLAZZ_NAME, new Class[] {
+              delegationTokenAuthenticatorClazz,
+              ConnectionConfigurator.class
+          }, new Object[] {
+              authenticator,
+              connConfigurator
+          });
+          return ReflectionUtils.invokeMethod(authenticatedURL,
+              delegationTokenAuthenticateURLOpenConnectionMethod, url, token, doAsUser);
+        } catch (Exception e) {
+          throw new IOException(e);
+        }
+      }
     }
 
     @Override
@@ -225,10 +267,33 @@ public final class TimelineReaderFactory {
     @Override
     public Client getHttpClient() {
       ClientConfig config = new ClientConfig().register(JacksonFeature.class);
+      HttpUrlConnectorProvider.ConnectionFactory urlFactory =
+          new PseudoAuthenticatedURLConnectionFactory(connectionConf);
+      config.connectorProvider(new HttpUrlConnectorProvider().connectionFactory(urlFactory));
       return ClientBuilder.newClient(config);
     }
 
-    // PseudoAuthenticatedURLConnectionFactory removed in Jersey 2 migration
+    @VisibleForTesting
+    protected static class PseudoAuthenticatedURLConnectionFactory
+        implements HttpUrlConnectorProvider.ConnectionFactory {
+      private final ConnectionConfigurator connectionConf;
+
+      public PseudoAuthenticatedURLConnectionFactory(ConnectionConfigurator connectionConf) {
+        this.connectionConf = connectionConf;
+      }
+
+      @Override
+      public HttpURLConnection getConnection(URL url) throws IOException {
+        String tokenString = (url.getQuery() == null ? "?" : "&") + "user.name=" +
+            URLEncoder.encode(UserGroupInformation.getCurrentUser().getShortUserName(), "UTF8");
+
+        HttpURLConnection httpURLConnection =
+            (HttpURLConnection) (new URL(url + tokenString)).openConnection();
+        this.connectionConf.configure(httpURLConnection);
+
+        return httpURLConnection;
+      }
+    }
 
     @Override
     public void close() {

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
@@ -25,17 +25,17 @@ import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
-import java.net.URLEncoder;
 import java.security.GeneralSecurityException;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
 
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.authentication.client.AuthenticatedURL;
 import org.apache.hadoop.security.authentication.client.Authenticator;
 import org.apache.hadoop.security.authentication.client.ConnectionConfigurator;
 import org.apache.hadoop.security.ssl.SSLFactory;
@@ -43,13 +43,9 @@ import org.apache.tez.common.ReflectionUtils;
 import org.apache.tez.dag.api.TezException;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.config.ClientConfig;
-import com.sun.jersey.api.client.config.DefaultClientConfig;
-import com.sun.jersey.client.urlconnection.HttpURLConnectionFactory;
-import com.sun.jersey.client.urlconnection.URLConnectionClientHandler;
-import com.sun.jersey.json.impl.provider.entity.JSONRootElementProvider;
 
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.jackson.JacksonFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -165,7 +161,7 @@ public final class TimelineReaderFactory {
       UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
       UserGroupInformation realUgi = ugi.getRealUser();
       String doAsUser;
-      ClientConfig clientConfig = new DefaultClientConfig(JSONRootElementProvider.App.class);
+      ClientConfig clientConfig = new ClientConfig().register(JacksonFeature.class);
       ConnectionConfigurator connectionConfigurator = getNewConnectionConf(useHttps,
               connTimeout, sslFactory);
 
@@ -182,14 +178,7 @@ public final class TimelineReaderFactory {
         doAsUser = null;
       }
 
-      HttpURLConnectionFactory connectionFactory;
-      try {
-        connectionFactory = new TokenAuthenticatedURLConnectionFactory(connectionConfigurator, authenticator,
-                doAsUser);
-      } catch (TezException e) {
-        throw new IOException("Fail to create TokenAuthenticatedURLConnectionFactory", e);
-      }
-      return new Client(new URLConnectionClientHandler(connectionFactory), clientConfig);
+      return ClientBuilder.newClient(clientConfig);
     }
 
     private static Authenticator getTokenAuthenticator() throws TezException {
@@ -202,42 +191,6 @@ public final class TimelineReaderFactory {
       }
 
       return ReflectionUtils.createClazzInstance(authenticatorClazzName);
-    }
-
-    private static class TokenAuthenticatedURLConnectionFactory implements HttpURLConnectionFactory {
-
-      private final Authenticator authenticator;
-      private final ConnectionConfigurator connConfigurator;
-      private final String doAsUser;
-      private final AuthenticatedURL.Token token;
-
-      public TokenAuthenticatedURLConnectionFactory(ConnectionConfigurator connConfigurator,
-                                                    Authenticator authenticator,
-                                                    String doAsUser) throws TezException {
-        this.connConfigurator = connConfigurator;
-        this.authenticator = authenticator;
-        this.doAsUser = doAsUser;
-        this.token = ReflectionUtils.createClazzInstance(
-            DELEGATION_TOKEN_AUTHENTICATED_URL_TOKEN_CLASS_NAME, null, null);
-      }
-
-      @Override
-      public HttpURLConnection getHttpURLConnection(URL url) throws IOException {
-        try {
-          AuthenticatedURL authenticatedURL= ReflectionUtils.createClazzInstance(
-              DELEGATION_TOKEN_AUTHENTICATED_URL_CLAZZ_NAME, new Class[] {
-              delegationTokenAuthenticatorClazz,
-              ConnectionConfigurator.class
-          }, new Object[] {
-              authenticator,
-              connConfigurator
-          });
-          return ReflectionUtils.invokeMethod(authenticatedURL,
-              delegationTokenAuthenticateURLOpenConnectionMethod, url, token, doAsUser);
-        } catch (Exception e) {
-          throw new IOException(e);
-        }
-      }
     }
 
     @Override
@@ -266,31 +219,11 @@ public final class TimelineReaderFactory {
 
     @Override
     public Client getHttpClient() {
-      ClientConfig config = new DefaultClientConfig(JSONRootElementProvider.App.class);
-      HttpURLConnectionFactory urlFactory = new PseudoAuthenticatedURLConnectionFactory(connectionConf);
-      return new Client(new URLConnectionClientHandler(urlFactory), config);
+      ClientConfig config = new ClientConfig().register(JacksonFeature.class);
+      return ClientBuilder.newClient(config);
     }
 
-    @VisibleForTesting
-    protected static class PseudoAuthenticatedURLConnectionFactory implements HttpURLConnectionFactory {
-      private final ConnectionConfigurator connectionConf;
-
-      public PseudoAuthenticatedURLConnectionFactory(ConnectionConfigurator connectionConf) {
-        this.connectionConf = connectionConf;
-      }
-
-      @Override
-      public HttpURLConnection getHttpURLConnection(URL url) throws IOException {
-        String tokenString = (url.getQuery() == null ? "?" : "&") + "user.name=" +
-            URLEncoder.encode(UserGroupInformation.getCurrentUser().getShortUserName(), "UTF8");
-
-        HttpURLConnection httpURLConnection =
-            (HttpURLConnection) URI.create(url + tokenString).toURL().openConnection();
-        this.connectionConf.configure(httpURLConnection);
-
-        return httpURLConnection;
-      }
-    }
+    // PseudoAuthenticatedURLConnectionFactory removed in Jersey 2 migration
 
     @Override
     public void close() {

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
@@ -158,9 +158,6 @@ public final class TimelineReaderFactory {
     @Override
     public Client getHttpClient() throws IOException {
       Authenticator authenticator;
-      UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
-      UserGroupInformation realUgi = ugi.getRealUser();
-      String doAsUser;
       ClientConfig clientConfig = new ClientConfig().register(JacksonFeature.class);
       ConnectionConfigurator connectionConfigurator = getNewConnectionConf(useHttps,
               connTimeout, sslFactory);
@@ -171,13 +168,6 @@ public final class TimelineReaderFactory {
       } catch (TezException e) {
         throw new IOException("Failed to get authenticator", e);
       }
-
-      if (realUgi != null) {
-        doAsUser = ugi.getShortUserName();
-      } else {
-        doAsUser = null;
-      }
-
       return ClientBuilder.newClient(clientConfig);
     }
 

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/TestATSHttpClient.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/TestATSHttpClient.java
@@ -95,7 +95,7 @@ public class TestATSHttpClient {
 
     final String jsonDagData =
             "{ " +
-            "  otherinfo: { " +
+            "  otherInfo: { " +
             "    status: 'SUCCEEDED'," +
             "    diagnostics: 'SAMPLE_DIAGNOSTICS'," +
             "    counters: { counterGroups: [ " +
@@ -108,9 +108,9 @@ public class TestATSHttpClient {
             "}";
 
     final String jsonVertexData = "{entities:[ " +
-        "{otherinfo: {vertexName:'v1', numTasks:5,numFailedTasks:1,numSucceededTasks:2," +
+        "{otherInfo: {vertexName:'v1', numTasks:5,numFailedTasks:1,numSucceededTasks:2," +
           "numKilledTasks:3,numCompletedTasks:3}}," +
-        "{otherinfo: {vertexName:'v2',numTasks:10,numFailedTasks:1,numSucceededTasks:5," +
+        "{otherInfo: {vertexName:'v2',numTasks:10,numFailedTasks:1,numSucceededTasks:5," +
           "numKilledTasks:3,numCompletedTasks:4}}" +
         "]}";
 
@@ -151,7 +151,7 @@ public class TestATSHttpClient {
     Set<StatusGetOpts> statusOptions = new HashSet<StatusGetOpts>(1);
     statusOptions.add(StatusGetOpts.GET_COUNTERS);
 
-    final String jsonData = "{entities:[ {otherinfo:{numFailedTasks:1,numSucceededTasks:2," +
+    final String jsonData = "{entities:[ {otherInfo:{numFailedTasks:1,numSucceededTasks:2," +
         "status:'SUCCEEDED', vertexName:'vertex1name', numTasks:4, numKilledTasks: 3, " +
         "numCompletedTasks: 4, diagnostics: 'diagnostics1', " +
         "counters: { counterGroups: [ " +

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/TestTimelineReaderFactory.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/TestTimelineReaderFactory.java
@@ -20,12 +20,7 @@ package org.apache.tez.dag.api.client;
 
 import static org.mockito.Mockito.mock;
 
-import java.net.HttpURLConnection;
-import java.net.URL;
-
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.authentication.client.ConnectionConfigurator;
 import org.apache.tez.dag.api.TezException;
 import org.apache.tez.dag.api.client.TimelineReaderFactory.TimelineReaderPseudoAuthenticatedStrategy;
 
@@ -48,15 +43,11 @@ public class TestTimelineReaderFactory {
   }
 
   @Test(timeout = 5000)
-  public void testPseudoAuthenticatorConnectionUrlShouldHaveUserName() throws Exception {
-    ConnectionConfigurator connConf = mock(ConnectionConfigurator.class);
-    TimelineReaderPseudoAuthenticatedStrategy.PseudoAuthenticatedURLConnectionFactory
-        connectionFactory = new TimelineReaderPseudoAuthenticatedStrategy
-          .PseudoAuthenticatedURLConnectionFactory(connConf);
-    String inputUrl = "http://host:8080/path";
-    String expectedUrl = inputUrl + "?user.name=" + UserGroupInformation.getCurrentUser().getShortUserName();
-    HttpURLConnection httpURLConnection = connectionFactory.getHttpURLConnection(new URL(inputUrl));
-    Assert.assertEquals(expectedUrl, httpURLConnection.getURL().toString());
+  public void testPseudoStrategyCreatesJersey2Client() {
+    TimelineReaderPseudoAuthenticatedStrategy strategy =
+        new TimelineReaderPseudoAuthenticatedStrategy(new Configuration(), false, 1000);
+    Assert.assertNotNull(strategy.getHttpClient());
+    strategy.close();
   }
 
 }

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/TestTimelineReaderFactory.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/TestTimelineReaderFactory.java
@@ -20,12 +20,7 @@ package org.apache.tez.dag.api.client;
 
 import static org.mockito.Mockito.mock;
 
-import java.net.HttpURLConnection;
-import java.net.URI;
-
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.authentication.client.ConnectionConfigurator;
 import org.apache.tez.dag.api.TezException;
 import org.apache.tez.dag.api.client.TimelineReaderFactory.TimelineReaderPseudoAuthenticatedStrategy;
 
@@ -48,15 +43,11 @@ public class TestTimelineReaderFactory {
   }
 
   @Test(timeout = 5000)
-  public void testPseudoAuthenticatorConnectionUrlShouldHaveUserName() throws Exception {
-    ConnectionConfigurator connConf = mock(ConnectionConfigurator.class);
-    TimelineReaderPseudoAuthenticatedStrategy.PseudoAuthenticatedURLConnectionFactory
-        connectionFactory = new TimelineReaderPseudoAuthenticatedStrategy
-          .PseudoAuthenticatedURLConnectionFactory(connConf);
-    String inputUrl = "http://host:8080/path";
-    String expectedUrl = inputUrl + "?user.name=" + UserGroupInformation.getCurrentUser().getShortUserName();
-    HttpURLConnection httpURLConnection = connectionFactory.getHttpURLConnection(URI.create(inputUrl).toURL());
-    Assert.assertEquals(expectedUrl, httpURLConnection.getURL().toString());
+  public void testPseudoStrategyCreatesJersey2Client() {
+    TimelineReaderPseudoAuthenticatedStrategy strategy =
+        new TimelineReaderPseudoAuthenticatedStrategy(new Configuration(), false, 1000);
+    Assert.assertNotNull(strategy.getHttpClient());
+    strategy.close();
   }
 
 }

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/TestTimelineReaderFactory.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/TestTimelineReaderFactory.java
@@ -20,7 +20,12 @@ package org.apache.tez.dag.api.client;
 
 import static org.mockito.Mockito.mock;
 
+import java.net.HttpURLConnection;
+import java.net.URI;
+
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.authentication.client.ConnectionConfigurator;
 import org.apache.tez.dag.api.TezException;
 import org.apache.tez.dag.api.client.TimelineReaderFactory.TimelineReaderPseudoAuthenticatedStrategy;
 
@@ -43,11 +48,15 @@ public class TestTimelineReaderFactory {
   }
 
   @Test(timeout = 5000)
-  public void testPseudoStrategyCreatesJersey2Client() {
-    TimelineReaderPseudoAuthenticatedStrategy strategy =
-        new TimelineReaderPseudoAuthenticatedStrategy(new Configuration(), false, 1000);
-    Assert.assertNotNull(strategy.getHttpClient());
-    strategy.close();
+  public void testPseudoAuthenticatorConnectionUrlShouldHaveUserName() throws Exception {
+    ConnectionConfigurator connConf = mock(ConnectionConfigurator.class);
+    TimelineReaderPseudoAuthenticatedStrategy.PseudoAuthenticatedURLConnectionFactory
+        connectionFactory = new TimelineReaderPseudoAuthenticatedStrategy
+        .PseudoAuthenticatedURLConnectionFactory(connConf);
+    String inputUrl = "http://host:8080/path";
+    String expectedUrl = inputUrl + "?user.name=" + UserGroupInformation.getCurrentUser().getShortUserName();
+    HttpURLConnection httpURLConnection = connectionFactory.getConnection(URI.create(inputUrl).toURL());
+    Assert.assertEquals(expectedUrl, httpURLConnection.getURL().toString());
   }
 
 }

--- a/tez-dag/pom.xml
+++ b/tez-dag/pom.xml
@@ -129,6 +129,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/tez-dag/pom.xml
+++ b/tez-dag/pom.xml
@@ -134,6 +134,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/tez-dag/pom.xml
+++ b/tez-dag/pom.xml
@@ -146,8 +146,8 @@
       <artifactId>jettison</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/tez-dag/pom.xml
+++ b/tez-dag/pom.xml
@@ -134,11 +134,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
@@ -164,6 +159,11 @@
     <dependency>
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tez-dag/src/main/java/org/apache/tez/dag/history/logging/impl/HistoryEventJsonConversion.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/history/logging/impl/HistoryEventJsonConversion.java
@@ -133,7 +133,7 @@ public final class HistoryEventJsonConversion {
   private static JSONObject convertDAGRecoveredEvent(DAGRecoveredEvent event)
       throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY,
+    jsonObject.put(ATSConstants.ENTITY_ID,
         event.getDagID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_DAG_ID.name());
@@ -168,7 +168,7 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertAppLaunchedEvent(AppLaunchedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY,
+    jsonObject.put(ATSConstants.ENTITY_ID,
         "tez_" + event.getApplicationId().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_APPLICATION.name());
@@ -186,7 +186,7 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertAMLaunchedEvent(AMLaunchedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY,
+    jsonObject.put(ATSConstants.ENTITY_ID,
         "tez_" + event.getApplicationAttemptId().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE,
             EntityTypes.TEZ_APPLICATION_ATTEMPT.name());
@@ -194,12 +194,12 @@ public final class HistoryEventJsonConversion {
     // Related Entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject appEntity = new JSONObject();
-    appEntity.put(ATSConstants.ENTITY,
+    appEntity.put(ATSConstants.ENTITY_ID,
         event.getApplicationAttemptId().getApplicationId().toString());
     appEntity.put(ATSConstants.ENTITY_TYPE,
         ATSConstants.APPLICATION_ID);
     JSONObject appAttemptEntity = new JSONObject();
-    appAttemptEntity.put(ATSConstants.ENTITY,
+    appAttemptEntity.put(ATSConstants.ENTITY_ID,
         event.getApplicationAttemptId().toString());
     appAttemptEntity.put(ATSConstants.ENTITY_TYPE,
             ATSConstants.APPLICATION_ATTEMPT_ID);
@@ -227,7 +227,7 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertAMStartedEvent(AMStartedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY,
+    jsonObject.put(ATSConstants.ENTITY_ID,
         "tez_" + event.getApplicationAttemptId().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_APPLICATION_ATTEMPT.name());
@@ -235,12 +235,12 @@ public final class HistoryEventJsonConversion {
     // Related Entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject appEntity = new JSONObject();
-    appEntity.put(ATSConstants.ENTITY,
+    appEntity.put(ATSConstants.ENTITY_ID,
         event.getApplicationAttemptId().getApplicationId().toString());
     appEntity.put(ATSConstants.ENTITY_TYPE,
         ATSConstants.APPLICATION_ID);
     JSONObject appAttemptEntity = new JSONObject();
-    appAttemptEntity.put(ATSConstants.ENTITY,
+    appAttemptEntity.put(ATSConstants.ENTITY_ID,
         event.getApplicationAttemptId().toString());
     appAttemptEntity.put(ATSConstants.ENTITY_TYPE,
         ATSConstants.APPLICATION_ATTEMPT_ID);
@@ -262,20 +262,20 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertContainerLaunchedEvent(ContainerLaunchedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY,
+    jsonObject.put(ATSConstants.ENTITY_ID,
         "tez_" + event.getContainerId().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_CONTAINER_ID.name());
 
     JSONArray relatedEntities = new JSONArray();
     JSONObject appAttemptEntity = new JSONObject();
-    appAttemptEntity.put(ATSConstants.ENTITY,
+    appAttemptEntity.put(ATSConstants.ENTITY_ID,
         event.getApplicationAttemptId().toString());
     appAttemptEntity.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_APPLICATION_ATTEMPT.name());
 
     JSONObject containerEntity = new JSONObject();
-    containerEntity.put(ATSConstants.ENTITY, event.getContainerId().toString());
+    containerEntity.put(ATSConstants.ENTITY_ID, event.getContainerId().toString());
     containerEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.CONTAINER_ID);
 
     relatedEntities.put(appAttemptEntity);
@@ -301,20 +301,20 @@ public final class HistoryEventJsonConversion {
   private static JSONObject convertContainerStoppedEvent(ContainerStoppedEvent event) throws JSONException {
     // structure is identical to ContainerLaunchedEvent
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY,
+    jsonObject.put(ATSConstants.ENTITY_ID,
         "tez_" + event.getContainerId().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_CONTAINER_ID.name());
 
     JSONArray relatedEntities = new JSONArray();
     JSONObject appAttemptEntity = new JSONObject();
-    appAttemptEntity.put(ATSConstants.ENTITY,
+    appAttemptEntity.put(ATSConstants.ENTITY_ID,
         event.getApplicationAttemptId().toString());
     appAttemptEntity.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_APPLICATION_ATTEMPT.name());
 
     JSONObject containerEntity = new JSONObject();
-    containerEntity.put(ATSConstants.ENTITY, event.getContainerId().toString());
+    containerEntity.put(ATSConstants.ENTITY_ID, event.getContainerId().toString());
     containerEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.CONTAINER_ID);
 
     relatedEntities.put(appAttemptEntity);
@@ -343,7 +343,7 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertDAGFinishedEvent(DAGFinishedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY,
+    jsonObject.put(ATSConstants.ENTITY_ID,
         event.getDAGID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_DAG_ID.name());
@@ -386,7 +386,7 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertDAGInitializedEvent(DAGInitializedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY,
+    jsonObject.put(ATSConstants.ENTITY_ID,
         event.getDAGID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_DAG_ID.name());
@@ -418,7 +418,7 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertDAGStartedEvent(DAGStartedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY,
+    jsonObject.put(ATSConstants.ENTITY_ID,
         event.getDAGID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_DAG_ID.name());
@@ -441,7 +441,7 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertDAGSubmittedEvent(DAGSubmittedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY,
+    jsonObject.put(ATSConstants.ENTITY_ID,
         event.getDAGID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_DAG_ID.name());
@@ -449,27 +449,27 @@ public final class HistoryEventJsonConversion {
     // Related Entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject tezAppEntity = new JSONObject();
-    tezAppEntity.put(ATSConstants.ENTITY,
+    tezAppEntity.put(ATSConstants.ENTITY_ID,
         "tez_" + event.getApplicationAttemptId().getApplicationId().toString());
     tezAppEntity.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_APPLICATION.name());
     JSONObject tezAppAttemptEntity = new JSONObject();
-    tezAppAttemptEntity.put(ATSConstants.ENTITY,
+    tezAppAttemptEntity.put(ATSConstants.ENTITY_ID,
         "tez_" + event.getApplicationAttemptId().toString());
     tezAppAttemptEntity.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_APPLICATION_ATTEMPT.name());
     JSONObject appEntity = new JSONObject();
-    appEntity.put(ATSConstants.ENTITY,
+    appEntity.put(ATSConstants.ENTITY_ID,
         event.getApplicationAttemptId().getApplicationId().toString());
     appEntity.put(ATSConstants.ENTITY_TYPE,
         ATSConstants.APPLICATION_ID);
     JSONObject appAttemptEntity = new JSONObject();
-    appAttemptEntity.put(ATSConstants.ENTITY,
+    appAttemptEntity.put(ATSConstants.ENTITY_ID,
         event.getApplicationAttemptId().toString());
     appAttemptEntity.put(ATSConstants.ENTITY_TYPE,
         ATSConstants.APPLICATION_ATTEMPT_ID);
     JSONObject userEntity = new JSONObject();
-    userEntity.put(ATSConstants.ENTITY,
+    userEntity.put(ATSConstants.ENTITY_ID,
         event.getUser());
     userEntity.put(ATSConstants.ENTITY_TYPE,
         ATSConstants.USER);
@@ -531,7 +531,7 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertTaskAttemptFinishedEvent(TaskAttemptFinishedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getTaskAttemptID().toString());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getTaskAttemptID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_TASK_ATTEMPT_ID.name());
 
@@ -590,22 +590,22 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertTaskAttemptStartedEvent(TaskAttemptStartedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getTaskAttemptID().toString());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getTaskAttemptID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE,
         EntityTypes.TEZ_TASK_ATTEMPT_ID.name());
 
     // Related entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject nodeEntity = new JSONObject();
-    nodeEntity.put(ATSConstants.ENTITY, event.getNodeId().toString());
+    nodeEntity.put(ATSConstants.ENTITY_ID, event.getNodeId().toString());
     nodeEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.NODE_ID);
 
     JSONObject containerEntity = new JSONObject();
-    containerEntity.put(ATSConstants.ENTITY, event.getContainerId().toString());
+    containerEntity.put(ATSConstants.ENTITY_ID, event.getContainerId().toString());
     containerEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.CONTAINER_ID);
 
     JSONObject taskEntity = new JSONObject();
-    taskEntity.put(ATSConstants.ENTITY, event.getTaskID().toString());
+    taskEntity.put(ATSConstants.ENTITY_ID, event.getTaskID().toString());
     taskEntity.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_TASK_ID.name());
 
     relatedEntities.put(nodeEntity);
@@ -633,7 +633,7 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertTaskFinishedEvent(TaskFinishedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getTaskID().toString());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getTaskID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_TASK_ID.name());
 
     // Events
@@ -664,13 +664,13 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertTaskStartedEvent(TaskStartedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getTaskID().toString());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getTaskID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_TASK_ID.name());
 
     // Related entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject vertexEntity = new JSONObject();
-    vertexEntity.put(ATSConstants.ENTITY, event.getVertexID().toString());
+    vertexEntity.put(ATSConstants.ENTITY_ID, event.getVertexID().toString());
     vertexEntity.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_VERTEX_ID.name());
     relatedEntities.put(vertexEntity);
     jsonObject.put(ATSConstants.RELATED_ENTITIES, relatedEntities);
@@ -696,7 +696,7 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertVertexFinishedEvent(VertexFinishedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getVertexID().toString());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getVertexID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_VERTEX_ID.name());
 
     // Events
@@ -737,7 +737,7 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertVertexReconfigureDoneEvent(VertexConfigurationDoneEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getVertexID().toString());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getVertexID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_VERTEX_ID.name());
 
     // Events
@@ -772,13 +772,13 @@ public final class HistoryEventJsonConversion {
 
   private static JSONObject convertVertexInitializedEvent(VertexInitializedEvent event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getVertexID().toString());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getVertexID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_VERTEX_ID.name());
 
     // Related entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject vertexEntity = new JSONObject();
-    vertexEntity.put(ATSConstants.ENTITY, event.getDAGID().toString());
+    vertexEntity.put(ATSConstants.ENTITY_ID, event.getDAGID().toString());
     vertexEntity.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_DAG_ID.name());
     relatedEntities.put(vertexEntity);
     jsonObject.put(ATSConstants.RELATED_ENTITIES, relatedEntities);
@@ -812,13 +812,13 @@ public final class HistoryEventJsonConversion {
   private static JSONObject convertVertexStartedEvent(VertexStartedEvent event)
       throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getVertexID().toString());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getVertexID().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_VERTEX_ID.name());
 
     // Related entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject vertexEntity = new JSONObject();
-    vertexEntity.put(ATSConstants.ENTITY, event.getDAGID().toString());
+    vertexEntity.put(ATSConstants.ENTITY_ID, event.getDAGID().toString());
     vertexEntity.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_DAG_ID.name());
     relatedEntities.put(vertexEntity);
     jsonObject.put(ATSConstants.RELATED_ENTITIES, relatedEntities);

--- a/tez-dag/src/test/java/org/apache/tez/dag/history/logging/impl/TestHistoryEventJsonConversion.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/history/logging/impl/TestHistoryEventJsonConversion.java
@@ -231,7 +231,7 @@ public class TestHistoryEventJsonConversion {
 
     JSONObject jsonObject = HistoryEventJsonConversion.convertToJson(event);
     Assert.assertNotNull(jsonObject);
-    Assert.assertEquals(vId.toString(), jsonObject.getString(ATSConstants.ENTITY));
+    Assert.assertEquals(vId.toString(), jsonObject.getString(ATSConstants.ENTITY_ID));
     Assert.assertEquals(ATSConstants.TEZ_VERTEX_ID, jsonObject.get(ATSConstants.ENTITY_TYPE));
 
     JSONArray events = jsonObject.getJSONArray(ATSConstants.EVENTS);

--- a/tez-ext-service-tests/pom.xml
+++ b/tez-ext-service-tests/pom.xml
@@ -54,6 +54,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/tez-ext-service-tests/pom.xml
+++ b/tez-ext-service-tests/pom.xml
@@ -58,11 +58,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
@@ -117,7 +112,11 @@
       <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/tez-ext-service-tests/pom.xml
+++ b/tez-ext-service-tests/pom.xml
@@ -58,6 +58,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/tez-plugins/tez-aux-services/pom.xml
+++ b/tez-plugins/tez-aux-services/pom.xml
@@ -127,6 +127,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+   </dependency>
    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>

--- a/tez-plugins/tez-aux-services/pom.xml
+++ b/tez-plugins/tez-aux-services/pom.xml
@@ -127,15 +127,15 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-   </dependency>
    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>

--- a/tez-plugins/tez-aux-services/pom.xml
+++ b/tez-plugins/tez-aux-services/pom.xml
@@ -131,6 +131,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+   </dependency>
    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>

--- a/tez-plugins/tez-history-parser/pom.xml
+++ b/tez-plugins/tez-history-parser/pom.xml
@@ -145,8 +145,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/tez-plugins/tez-history-parser/pom.xml
+++ b/tez-plugins/tez-history-parser/pom.xml
@@ -145,6 +145,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
       <scope>test</scope>

--- a/tez-plugins/tez-history-parser/pom.xml
+++ b/tez-plugins/tez-history-parser/pom.xml
@@ -148,6 +148,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -156,15 +165,6 @@
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-json-jackson</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
     </dependency>
   </dependencies>
 

--- a/tez-plugins/tez-history-parser/pom.xml
+++ b/tez-plugins/tez-history-parser/pom.xml
@@ -148,8 +148,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/tez-plugins/tez-history-parser/pom.xml
+++ b/tez-plugins/tez-history-parser/pom.xml
@@ -148,6 +148,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
       <scope>test</scope>

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/ATSImportTool.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/ATSImportTool.java
@@ -268,10 +268,10 @@ public class ATSImportTool extends Configured implements Tool {
 
       //Set the last item in entities as the fromId
       url = baseUrl + "&fromId="
-          + entities.getJSONObject(entities.length() - 1).getString(Constants.ENTITY);
+          + entities.getJSONObject(entities.length() - 1).getString(Constants.ENTITY_ID);
 
-      String firstItem = entities.getJSONObject(0).getString(Constants.ENTITY);
-      String lastItem = entities.getJSONObject(entities.length() - 1).getString(Constants.ENTITY);
+      String firstItem = entities.getJSONObject(0).getString(Constants.ENTITY_ID);
+      String lastItem = entities.getJSONObject(entities.length() - 1).getString(Constants.ENTITY_ID);
       LOG.info("Downloaded={}, First item={}, LastItem={}, new url={}", downloadedCount,
           firstItem, lastItem, url);
     }

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/ATSImportTool.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/ATSImportTool.java
@@ -23,8 +23,12 @@ import static org.apache.hadoop.classification.InterfaceStability.Evolving;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.zip.ZipEntry;
@@ -46,6 +50,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.http.HttpConfig;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -63,6 +68,8 @@ import com.google.common.base.Strings;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -285,7 +292,7 @@ public class ATSImportTool extends Configured implements Tool {
         LOG.info("Response entity={}", entity);
       }
     } catch (Exception ignore) {
-        LOG.debug("Failed to read error response entity", ignore);
+      LOG.debug("Failed to read error response entity", ignore);
     }
   }
 
@@ -313,9 +320,21 @@ public class ATSImportTool extends Configured implements Tool {
 
   private Client getHttpClient() {
     if (httpClient == null) {
-      return ClientBuilder.newClient();
+      ClientConfig config = new ClientConfig();
+      config.connectorProvider(new HttpUrlConnectorProvider()
+          .connectionFactory(new PseudoAuthenticatedURLConnectionFactory()));
+      return ClientBuilder.newClient(config);
     }
     return httpClient;
+  }
+
+  static class PseudoAuthenticatedURLConnectionFactory implements HttpUrlConnectorProvider.ConnectionFactory {
+    @Override
+    public HttpURLConnection getConnection(URL url) throws IOException {
+      String tokenString = (url.getQuery() == null ? "?" : "&") + "user.name=" +
+          URLEncoder.encode(UserGroupInformation.getCurrentUser().getShortUserName(), StandardCharsets.UTF_8);
+      return (HttpURLConnection) (new URL(url.toString() + tokenString)).openConnection();
+    }
   }
 
   @Override

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/ATSImportTool.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/ATSImportTool.java
@@ -23,17 +23,18 @@ import static org.apache.hadoop.classification.InterfaceStability.Evolving;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLEncoder;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -42,11 +43,9 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.LineIterator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.http.HttpConfig;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -60,16 +59,6 @@ import org.apache.tez.history.parser.utils.Utils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientHandlerException;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.UniformInterfaceException;
-import com.sun.jersey.api.client.WebResource;
-import com.sun.jersey.api.client.config.ClientConfig;
-import com.sun.jersey.api.client.config.DefaultClientConfig;
-import com.sun.jersey.client.urlconnection.HttpURLConnectionFactory;
-import com.sun.jersey.client.urlconnection.URLConnectionClientHandler;
-import com.sun.jersey.json.impl.provider.entity.JSONRootElementProvider;
 
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
@@ -169,7 +158,7 @@ public class ATSImportTool extends Configured implements Tool {
       throw e;
     } finally {
       if (httpClient != null) {
-        httpClient.destroy();
+        httpClient.close();
       }
       IOUtils.closeQuietly(fos);
     }
@@ -288,65 +277,45 @@ public class ATSImportTool extends Configured implements Tool {
     }
   }
 
-  private void logErrorMessage(ClientResponse response) throws IOException {
-    LOG.error("Response status={}", response.getClientResponseStatus().toString());
-    LineIterator it = null;
+  private void logErrorMessage(Response response) {
+    LOG.error("Response status={}", Integer.toString(response.getStatus()));
     try {
-      it = IOUtils.lineIterator(response.getEntityInputStream(), UTF8);
-      while (it.hasNext()) {
-        String line = it.nextLine();
-        LOG.error(line);
+      String entity = response.readEntity(String.class);
+      if (entity != null) {
+        LOG.error(entity);
       }
-    } finally {
-      if (it != null) {
-        it.close();
-      }
+    } catch (Exception ignore) {
+      // ignore
     }
   }
 
   //For secure cluster, this should work as long as valid ticket is available in the node.
   private JSONObject getJsonRootEntity(String url) throws TezException, IOException {
     try {
-      WebResource wr = getHttpClient().resource(url);
-      ClientResponse response = wr.accept(MediaType.APPLICATION_JSON_TYPE)
-          .type(MediaType.APPLICATION_JSON_TYPE)
-          .get(ClientResponse.class);
+      WebTarget target = getHttpClient().target(url);
+      Response response = target.request(MediaType.APPLICATION_JSON_TYPE)
+          .accept(MediaType.APPLICATION_JSON_TYPE)
+          .get();
 
-      if (response.getClientResponseStatus() != ClientResponse.Status.OK) {
+      if (response.getStatus() != Response.Status.OK.getStatusCode()) {
         // In the case of secure cluster, if there is any auth exception it sends the data back as
         // a html page and JSON parsing could throw exceptions. Instead, get the stream contents
         // completely and log it in case of error.
         logErrorMessage(response);
         throw new TezException("Failed to get response from YARN Timeline: url: " + url);
       }
-      return response.getEntity(JSONObject.class);
-    } catch (ClientHandlerException e) {
+      String json = response.readEntity(String.class);
+      return new JSONObject(json);
+    } catch (Exception e) {
       throw new TezException("Error processing response from YARN Timeline. URL=" + url, e);
-    } catch (UniformInterfaceException e) {
-      throw new TezException("Error accessing content from YARN Timeline - unexpected response. "
-          + "URL=" + url, e);
-    } catch (IllegalArgumentException e) {
-      throw new TezException("Error accessing content from YARN Timeline - invalid url. URL=" + url,
-          e);
     }
   }
 
   private Client getHttpClient() {
     if (httpClient == null) {
-      ClientConfig config = new DefaultClientConfig(JSONRootElementProvider.App.class);
-      HttpURLConnectionFactory urlFactory = new PseudoAuthenticatedURLConnectionFactory();
-      return new Client(new URLConnectionClientHandler(urlFactory), config);
+      return ClientBuilder.newClient();
     }
     return httpClient;
-  }
-
-  static class PseudoAuthenticatedURLConnectionFactory implements HttpURLConnectionFactory {
-    @Override
-    public HttpURLConnection getHttpURLConnection(URL url) throws IOException {
-      String tokenString = (url.getQuery() == null ? "?" : "&") + "user.name=" +
-          URLEncoder.encode(UserGroupInformation.getCurrentUser().getShortUserName(), "UTF8");
-      return (HttpURLConnection) URI.create(url.toString() + tokenString).toURL().openConnection();
-    }
   }
 
   @Override

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/ATSImportTool.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/ATSImportTool.java
@@ -333,7 +333,7 @@ public class ATSImportTool extends Configured implements Tool {
     public HttpURLConnection getConnection(URL url) throws IOException {
       String tokenString = (url.getQuery() == null ? "?" : "&") + "user.name=" +
           URLEncoder.encode(UserGroupInformation.getCurrentUser().getShortUserName(), StandardCharsets.UTF_8);
-      return (HttpURLConnection) (new URL(url.toString() + tokenString)).openConnection();
+      return (HttpURLConnection) URI.create(url.toString() + tokenString).toURL().openConnection();
     }
   }
 

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/ATSImportTool.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/ATSImportTool.java
@@ -278,14 +278,14 @@ public class ATSImportTool extends Configured implements Tool {
   }
 
   private void logErrorMessage(Response response) {
-    LOG.error("Response status={}", Integer.toString(response.getStatus()));
+    LOG.info("Response status={}", Integer.toString(response.getStatus()));
     try {
       String entity = response.readEntity(String.class);
       if (entity != null) {
-        LOG.error(entity);
+        LOG.info("Response entity={}", entity);
       }
     } catch (Exception ignore) {
-      // ignore
+        LOG.debug("Failed to read error response entity", ignore);
     }
   }
 

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/SimpleHistoryParser.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/SimpleHistoryParser.java
@@ -179,7 +179,7 @@ public class SimpleHistoryParser extends BaseParser {
       if (relatedEntities == null) {
         //This can happen when CONTAINER_EXITED abruptly. (e.g Container failed, exitCode=1)
         LOG.debug("entity {} did not have related entities",
-            jsonObject.optJSONObject(Constants.ENTITY));
+            jsonObject.optJSONObject(Constants.ENTITY_ID));
       } else {
         JSONObject subJsonObject = relatedEntities.optJSONObject(0);
         if (subJsonObject != null) {
@@ -187,7 +187,7 @@ public class SimpleHistoryParser extends BaseParser {
           if (!Strings.isNullOrEmpty(nodeId) && nodeId.equalsIgnoreCase(Constants.NODE_ID)) {
             //populate it in otherInfo
             JSONObject otherInfo = jsonObject.optJSONObject(Constants.OTHER_INFO);
-            String nodeIdVal = subJsonObject.optString(Constants.ENTITY);
+            String nodeIdVal = subJsonObject.optString(Constants.ENTITY_ID);
             if (otherInfo != null && nodeIdVal != null) {
               otherInfo.put(Constants.NODE_ID, nodeIdVal);
             }
@@ -201,7 +201,7 @@ public class SimpleHistoryParser extends BaseParser {
               .equalsIgnoreCase(Constants.CONTAINER_ID)) {
             //populate it in otherInfo
             JSONObject otherInfo = jsonObject.optJSONObject(Constants.OTHER_INFO);
-            String containerIdVal = subJsonObject.optString(Constants.ENTITY);
+            String containerIdVal = subJsonObject.optString(Constants.ENTITY_ID);
             if (otherInfo != null && containerIdVal != null) {
               otherInfo.put(Constants.CONTAINER_ID, containerIdVal);
             }
@@ -224,7 +224,7 @@ public class SimpleHistoryParser extends BaseParser {
     while (source.hasNext()) {
       JSONObject jsonObject = source.next();
 
-      String entity = jsonObject.getString(Constants.ENTITY);
+      String entity = jsonObject.getString(Constants.ENTITY_ID);
       String entityType = jsonObject.getString(Constants.ENTITY_TYPE);
       switch (entityType) {
       case Constants.TEZ_DAG_ID:
@@ -254,7 +254,7 @@ public class SimpleHistoryParser extends BaseParser {
             JSONObject subEntity = relatedEntities.getJSONObject(i);
             String subEntityType = subEntity.optString(Constants.ENTITY_TYPE);
             if (subEntityType != null && subEntityType.equals(Constants.USER)) {
-              userName = subEntity.getString(Constants.ENTITY);
+              userName = subEntity.getString(Constants.ENTITY_ID);
               break;
             }
           }

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/SimpleHistoryParser.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/SimpleHistoryParser.java
@@ -180,7 +180,7 @@ public class SimpleHistoryParser extends BaseParser {
       if (relatedEntities == null) {
         //This can happen when CONTAINER_EXITED abruptly. (e.g Container failed, exitCode=1)
         LOG.debug("entity {} did not have related entities",
-            jsonObject.optJSONObject(Constants.ENTITY));
+            jsonObject.optJSONObject(Constants.ENTITY_ID));
       } else {
         JSONObject subJsonObject = relatedEntities.optJSONObject(0);
         if (subJsonObject != null) {
@@ -188,7 +188,7 @@ public class SimpleHistoryParser extends BaseParser {
           if (!Strings.isNullOrEmpty(nodeId) && nodeId.equalsIgnoreCase(Constants.NODE_ID)) {
             //populate it in otherInfo
             JSONObject otherInfo = jsonObject.optJSONObject(Constants.OTHER_INFO);
-            String nodeIdVal = subJsonObject.optString(Constants.ENTITY);
+            String nodeIdVal = subJsonObject.optString(Constants.ENTITY_ID);
             if (otherInfo != null && nodeIdVal != null) {
               otherInfo.put(Constants.NODE_ID, nodeIdVal);
             }
@@ -202,7 +202,7 @@ public class SimpleHistoryParser extends BaseParser {
               .equalsIgnoreCase(Constants.CONTAINER_ID)) {
             //populate it in otherInfo
             JSONObject otherInfo = jsonObject.optJSONObject(Constants.OTHER_INFO);
-            String containerIdVal = subJsonObject.optString(Constants.ENTITY);
+            String containerIdVal = subJsonObject.optString(Constants.ENTITY_ID);
             if (otherInfo != null && containerIdVal != null) {
               otherInfo.put(Constants.CONTAINER_ID, containerIdVal);
             }
@@ -225,7 +225,7 @@ public class SimpleHistoryParser extends BaseParser {
     while (source.hasNext()) {
       JSONObject jsonObject = source.next();
 
-      String entity = jsonObject.getString(Constants.ENTITY);
+      String entity = jsonObject.getString(Constants.ENTITY_ID);
       String entityType = jsonObject.getString(Constants.ENTITY_TYPE);
       switch (entityType) {
       case Constants.TEZ_DAG_ID:
@@ -255,7 +255,7 @@ public class SimpleHistoryParser extends BaseParser {
             JSONObject subEntity = relatedEntities.getJSONObject(i);
             String subEntityType = subEntity.optString(Constants.ENTITY_TYPE);
             if (subEntityType != null && subEntityType.equals(Constants.USER)) {
-              userName = subEntity.getString(Constants.ENTITY);
+              userName = subEntity.getString(Constants.ENTITY_ID);
               break;
             }
           }

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/datamodel/DagInfo.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/datamodel/DagInfo.java
@@ -102,7 +102,7 @@ public class DagInfo extends BaseInfo {
     Preconditions.checkArgument(jsonObject.getString(Constants.ENTITY_TYPE).equalsIgnoreCase
         (Constants.TEZ_DAG_ID));
 
-    dagId = StringInterner.intern(jsonObject.getString(Constants.ENTITY));
+    dagId = StringInterner.intern(jsonObject.getString(Constants.ENTITY_ID));
 
     //Parse additional Info
     JSONObject otherInfoNode = jsonObject.getJSONObject(Constants.OTHER_INFO);

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/datamodel/TaskAttemptInfo.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/datamodel/TaskAttemptInfo.java
@@ -98,7 +98,7 @@ public class TaskAttemptInfo extends BaseInfo {
         jsonObject.getString(Constants.ENTITY_TYPE).equalsIgnoreCase
             (Constants.TEZ_TASK_ATTEMPT_ID));
 
-    taskAttemptId = StringInterner.intern(jsonObject.optString(Constants.ENTITY));
+    taskAttemptId = StringInterner.intern(jsonObject.optString(Constants.ENTITY_ID));
 
     //Parse additional Info
     final JSONObject otherInfoNode = jsonObject.getJSONObject(Constants.OTHER_INFO);

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/datamodel/TaskInfo.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/datamodel/TaskInfo.java
@@ -73,7 +73,7 @@ public class TaskInfo extends BaseInfo {
         jsonObject.getString(Constants.ENTITY_TYPE).equalsIgnoreCase
             (Constants.TEZ_TASK_ID));
 
-    taskId = StringInterner.intern(jsonObject.optString(Constants.ENTITY));
+    taskId = StringInterner.intern(jsonObject.optString(Constants.ENTITY_ID));
 
     //Parse additional Info
     final JSONObject otherInfoNode = jsonObject.getJSONObject(Constants.OTHER_INFO);

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/datamodel/VertexInfo.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/datamodel/VertexInfo.java
@@ -94,7 +94,7 @@ public class VertexInfo extends BaseInfo {
         jsonObject.getString(Constants.ENTITY_TYPE).equalsIgnoreCase
             (Constants.TEZ_VERTEX_ID));
 
-    vertexId = StringInterner.intern(jsonObject.optString(Constants.ENTITY));
+    vertexId = StringInterner.intern(jsonObject.optString(Constants.ENTITY_ID));
     taskInfoMap = Maps.newHashMap();
 
     inEdgeList = Lists.newLinkedList();

--- a/tez-plugins/tez-protobuf-history-plugin/src/main/java/org/apache/tez/dag/history/logging/proto/HistoryEventProtoJsonConversion.java
+++ b/tez-plugins/tez-protobuf-history-plugin/src/main/java/org/apache/tez/dag/history/logging/proto/HistoryEventProtoJsonConversion.java
@@ -115,7 +115,7 @@ public final class HistoryEventProtoJsonConversion {
 
   private static JSONObject convertDAGRecoveredEvent(HistoryEventProto event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getDagId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getDagId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_DAG_ID.name());
 
     // Related Entities not needed as should have been done in
@@ -142,7 +142,7 @@ public final class HistoryEventProtoJsonConversion {
 
   private static JSONObject convertAppLaunchedEvent(HistoryEventProto event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, "tez_" + event.getAppId().toString());
+    jsonObject.put(ATSConstants.ENTITY_ID, "tez_" + event.getAppId().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_APPLICATION.name());
 
     // Other info to tag with Tez App
@@ -157,16 +157,16 @@ public final class HistoryEventProtoJsonConversion {
 
   private static JSONObject convertAMLaunchedEvent(HistoryEventProto event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, "tez_" + event.getAppAttemptId().toString());
+    jsonObject.put(ATSConstants.ENTITY_ID, "tez_" + event.getAppAttemptId().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_APPLICATION_ATTEMPT.name());
 
     // Related Entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject appEntity = new JSONObject();
-    appEntity.put(ATSConstants.ENTITY, event.getAppId().toString());
+    appEntity.put(ATSConstants.ENTITY_ID, event.getAppId().toString());
     appEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.APPLICATION_ID);
     JSONObject appAttemptEntity = new JSONObject();
-    appAttemptEntity.put(ATSConstants.ENTITY, event.getAppAttemptId().toString());
+    appAttemptEntity.put(ATSConstants.ENTITY_ID, event.getAppAttemptId().toString());
     appAttemptEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.APPLICATION_ATTEMPT_ID);
     relatedEntities.put(appEntity);
     relatedEntities.put(appAttemptEntity);
@@ -192,16 +192,16 @@ public final class HistoryEventProtoJsonConversion {
 
   private static JSONObject convertAMStartedEvent(HistoryEventProto event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, "tez_" + event.getAppAttemptId().toString());
+    jsonObject.put(ATSConstants.ENTITY_ID, "tez_" + event.getAppAttemptId().toString());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_APPLICATION_ATTEMPT.name());
 
     // Related Entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject appEntity = new JSONObject();
-    appEntity.put(ATSConstants.ENTITY, event.getAppId().toString());
+    appEntity.put(ATSConstants.ENTITY_ID, event.getAppId().toString());
     appEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.APPLICATION_ID);
     JSONObject appAttemptEntity = new JSONObject();
-    appAttemptEntity.put(ATSConstants.ENTITY, event.getAppAttemptId().toString());
+    appAttemptEntity.put(ATSConstants.ENTITY_ID, event.getAppAttemptId().toString());
     appAttemptEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.APPLICATION_ATTEMPT_ID);
     relatedEntities.put(appEntity);
     relatedEntities.put(appAttemptEntity);
@@ -222,17 +222,17 @@ public final class HistoryEventProtoJsonConversion {
   private static JSONObject convertContainerLaunchedEvent(HistoryEventProto event)
       throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY,
+    jsonObject.put(ATSConstants.ENTITY_ID,
         "tez_" + getDataValueByKey(event, ATSConstants.CONTAINER_ID));
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_CONTAINER_ID.name());
 
     JSONArray relatedEntities = new JSONArray();
     JSONObject appAttemptEntity = new JSONObject();
-    appAttemptEntity.put(ATSConstants.ENTITY, event.getAppAttemptId().toString());
+    appAttemptEntity.put(ATSConstants.ENTITY_ID, event.getAppAttemptId().toString());
     appAttemptEntity.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_APPLICATION_ATTEMPT.name());
 
     JSONObject containerEntity = new JSONObject();
-    containerEntity.put(ATSConstants.ENTITY, getDataValueByKey(event, ATSConstants.CONTAINER_ID));
+    containerEntity.put(ATSConstants.ENTITY_ID, getDataValueByKey(event, ATSConstants.CONTAINER_ID));
     containerEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.CONTAINER_ID);
 
     relatedEntities.put(appAttemptEntity);
@@ -258,17 +258,17 @@ public final class HistoryEventProtoJsonConversion {
       throws JSONException {
     // structure is identical to ContainerLaunchedEvent
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY,
+    jsonObject.put(ATSConstants.ENTITY_ID,
         "tez_" + getDataValueByKey(event, ATSConstants.CONTAINER_ID));
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_CONTAINER_ID.name());
 
     JSONArray relatedEntities = new JSONArray();
     JSONObject appAttemptEntity = new JSONObject();
-    appAttemptEntity.put(ATSConstants.ENTITY, event.getAppAttemptId().toString());
+    appAttemptEntity.put(ATSConstants.ENTITY_ID, event.getAppAttemptId().toString());
     appAttemptEntity.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_APPLICATION_ATTEMPT.name());
 
     JSONObject containerEntity = new JSONObject();
-    containerEntity.put(ATSConstants.ENTITY, getDataValueByKey(event, ATSConstants.CONTAINER_ID));
+    containerEntity.put(ATSConstants.ENTITY_ID, getDataValueByKey(event, ATSConstants.CONTAINER_ID));
     containerEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.CONTAINER_ID);
 
     relatedEntities.put(appAttemptEntity);
@@ -297,7 +297,7 @@ public final class HistoryEventProtoJsonConversion {
 
   private static JSONObject convertDAGFinishedEvent(HistoryEventProto event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getDagId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getDagId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_DAG_ID.name());
 
     // Related Entities not needed as should have been done in
@@ -341,7 +341,7 @@ public final class HistoryEventProtoJsonConversion {
   private static JSONObject convertDAGInitializedEvent(HistoryEventProto event)
       throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getDagId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getDagId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_DAG_ID.name());
 
     // Related Entities not needed as should have been done in
@@ -364,7 +364,7 @@ public final class HistoryEventProtoJsonConversion {
 
   private static JSONObject convertDAGStartedEvent(HistoryEventProto event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getDagId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getDagId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_DAG_ID.name());
 
     // Related Entities not needed as should have been done in
@@ -384,25 +384,25 @@ public final class HistoryEventProtoJsonConversion {
 
   private static JSONObject convertDAGSubmittedEvent(HistoryEventProto event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getDagId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getDagId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_DAG_ID.name());
 
     // Related Entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject tezAppEntity = new JSONObject();
-    tezAppEntity.put(ATSConstants.ENTITY, "tez_" + event.getAppId().toString());
+    tezAppEntity.put(ATSConstants.ENTITY_ID, "tez_" + event.getAppId().toString());
     tezAppEntity.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_APPLICATION.name());
     JSONObject tezAppAttemptEntity = new JSONObject();
-    tezAppAttemptEntity.put(ATSConstants.ENTITY, "tez_" + event.getAppAttemptId().toString());
+    tezAppAttemptEntity.put(ATSConstants.ENTITY_ID, "tez_" + event.getAppAttemptId().toString());
     tezAppAttemptEntity.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_APPLICATION_ATTEMPT.name());
     JSONObject appEntity = new JSONObject();
-    appEntity.put(ATSConstants.ENTITY, event.getAppId().toString());
+    appEntity.put(ATSConstants.ENTITY_ID, event.getAppId().toString());
     appEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.APPLICATION_ID);
     JSONObject appAttemptEntity = new JSONObject();
-    appAttemptEntity.put(ATSConstants.ENTITY, event.getAppAttemptId().toString());
+    appAttemptEntity.put(ATSConstants.ENTITY_ID, event.getAppAttemptId().toString());
     appAttemptEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.APPLICATION_ATTEMPT_ID);
     JSONObject userEntity = new JSONObject();
-    userEntity.put(ATSConstants.ENTITY, event.getUser());
+    userEntity.put(ATSConstants.ENTITY_ID, event.getUser());
     userEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.USER);
 
     relatedEntities.put(tezAppEntity);
@@ -452,7 +452,7 @@ public final class HistoryEventProtoJsonConversion {
   private static JSONObject convertTaskAttemptFinishedEvent(HistoryEventProto event)
       throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getTaskAttemptId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getTaskAttemptId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_TASK_ATTEMPT_ID.name());
 
     // Events
@@ -503,21 +503,21 @@ public final class HistoryEventProtoJsonConversion {
   private static JSONObject convertTaskAttemptStartedEvent(HistoryEventProto event)
       throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getTaskAttemptId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getTaskAttemptId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_TASK_ATTEMPT_ID.name());
 
     // Related entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject nodeEntity = new JSONObject();
-    nodeEntity.put(ATSConstants.ENTITY, getDataValueByKey(event, ATSConstants.NODE_ID));
+    nodeEntity.put(ATSConstants.ENTITY_ID, getDataValueByKey(event, ATSConstants.NODE_ID));
     nodeEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.NODE_ID);
 
     JSONObject containerEntity = new JSONObject();
-    containerEntity.put(ATSConstants.ENTITY, getDataValueByKey(event, ATSConstants.CONTAINER_ID));
+    containerEntity.put(ATSConstants.ENTITY_ID, getDataValueByKey(event, ATSConstants.CONTAINER_ID));
     containerEntity.put(ATSConstants.ENTITY_TYPE, ATSConstants.CONTAINER_ID);
 
     JSONObject taskEntity = new JSONObject();
-    taskEntity.put(ATSConstants.ENTITY, event.getTaskAttemptId());
+    taskEntity.put(ATSConstants.ENTITY_ID, event.getTaskAttemptId());
     taskEntity.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_TASK_ID.name());
 
     relatedEntities.put(nodeEntity);
@@ -546,7 +546,7 @@ public final class HistoryEventProtoJsonConversion {
 
   private static JSONObject convertTaskFinishedEvent(HistoryEventProto event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getTaskId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getTaskId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_TASK_ID.name());
 
     // Events
@@ -577,13 +577,13 @@ public final class HistoryEventProtoJsonConversion {
 
   private static JSONObject convertTaskStartedEvent(HistoryEventProto event) throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getTaskId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getTaskId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_TASK_ID.name());
 
     // Related entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject vertexEntity = new JSONObject();
-    vertexEntity.put(ATSConstants.ENTITY, event.getVertexId());
+    vertexEntity.put(ATSConstants.ENTITY_ID, event.getVertexId());
     vertexEntity.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_VERTEX_ID.name());
     relatedEntities.put(vertexEntity);
     jsonObject.put(ATSConstants.RELATED_ENTITIES, relatedEntities);
@@ -610,7 +610,7 @@ public final class HistoryEventProtoJsonConversion {
   private static JSONObject convertVertexFinishedEvent(HistoryEventProto event)
       throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getVertexId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getVertexId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_VERTEX_ID.name());
 
     // Events
@@ -653,7 +653,7 @@ public final class HistoryEventProtoJsonConversion {
   private static JSONObject convertVertexReconfigureDoneEvent(HistoryEventProto event)
       throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getVertexId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getVertexId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_VERTEX_ID.name());
 
     // Events
@@ -681,13 +681,13 @@ public final class HistoryEventProtoJsonConversion {
   private static JSONObject convertVertexInitializedEvent(HistoryEventProto event)
       throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getVertexId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getVertexId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_VERTEX_ID.name());
 
     // Related entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject vertexEntity = new JSONObject();
-    vertexEntity.put(ATSConstants.ENTITY, event.getDagId());
+    vertexEntity.put(ATSConstants.ENTITY_ID, event.getDagId());
     vertexEntity.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_DAG_ID.name());
     relatedEntities.put(vertexEntity);
     jsonObject.put(ATSConstants.RELATED_ENTITIES, relatedEntities);
@@ -720,13 +720,13 @@ public final class HistoryEventProtoJsonConversion {
   private static JSONObject convertVertexStartedEvent(HistoryEventProto event)
       throws JSONException {
     JSONObject jsonObject = new JSONObject();
-    jsonObject.put(ATSConstants.ENTITY, event.getVertexId());
+    jsonObject.put(ATSConstants.ENTITY_ID, event.getVertexId());
     jsonObject.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_VERTEX_ID.name());
 
     // Related entities
     JSONArray relatedEntities = new JSONArray();
     JSONObject vertexEntity = new JSONObject();
-    vertexEntity.put(ATSConstants.ENTITY, event.getDagId());
+    vertexEntity.put(ATSConstants.ENTITY_ID, event.getDagId());
     vertexEntity.put(ATSConstants.ENTITY_TYPE, EntityTypes.TEZ_DAG_ID.name());
     relatedEntities.put(vertexEntity);
     jsonObject.put(ATSConstants.RELATED_ENTITIES, relatedEntities);

--- a/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
@@ -135,6 +135,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
       <scope>test</scope>

--- a/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
@@ -135,8 +135,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
@@ -140,6 +140,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
       <scope>test</scope>

--- a/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
@@ -140,8 +140,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
@@ -140,6 +140,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -148,15 +157,6 @@
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-json-jackson</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
     </dependency>
   </dependencies>
 

--- a/tez-plugins/tez-yarn-timeline-history-with-acls/src/test/java/org/apache/tez/dag/history/ats/acls/TestATSHistoryWithACLs.java
+++ b/tez-plugins/tez-yarn-timeline-history-with-acls/src/test/java/org/apache/tez/dag/history/ats/acls/TestATSHistoryWithACLs.java
@@ -31,7 +31,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -66,9 +70,6 @@ import org.apache.tez.runtime.library.processor.SleepProcessor.SleepProcessorCon
 import org.apache.tez.tests.MiniTezClusterWithTimeline;
 
 import com.google.common.collect.Sets;
-import com.sun.jersey.api.client.Client;
-import com.sun.jersey.api.client.ClientResponse;
-import com.sun.jersey.api.client.WebResource;
 
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
@@ -148,23 +149,25 @@ public class TestATSHistoryWithACLs {
 
   // To be replaced after Timeline has java APIs for domains
   private <K> K getTimelineData(String url, Class<K> clazz) {
-    Client client = new Client();
-    WebResource resource = client.resource(url);
+    Client client = ClientBuilder.newClient();
+    WebTarget target = client.target(url);
 
-    ClientResponse response = resource.accept(MediaType.APPLICATION_JSON)
-        .get(ClientResponse.class);
+    Response response = target.request(MediaType.APPLICATION_JSON).get();
     assertEquals(200, response.getStatus());
-    assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(response.getType()));
+    assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(response.getMediaType()));
 
-    JSONObject entity = response.getEntity(JSONObject.class);
-    K converted = null;
+    String entityStr = response.readEntity(String.class);
     try {
-      converted = convertJSONObjectToTimelineObject(entity, clazz);
+      JSONObject entity = new JSONObject(entityStr);
+      K converted = convertJSONObjectToTimelineObject(entity, clazz);
+      assertNotNull(converted);
+      return converted;
     } catch (JSONException e) {
       throw new RuntimeException(e);
+    } finally {
+      response.close();
+      client.close();
     }
-    assertNotNull(converted);
-    return converted;
   }
 
   private <K> K convertJSONObjectToTimelineObject(JSONObject jsonObj, Class<K> clazz) throws JSONException {
@@ -453,12 +456,12 @@ public class TestATSHistoryWithACLs {
     historyLoggingService.handle(new DAGHistoryEvent(tezDAGID, submittedEvent));
     Thread.sleep(1000l);
     String url = "http://" + timelineAddress + "/ws/v1/timeline/TEZ_DAG_ID/"+event.getDAGID();
-    Client client = new Client();
-    WebResource resource = client.resource(url);
-
-    ClientResponse response = resource.accept(MediaType.APPLICATION_JSON)
-        .get(ClientResponse.class);
+    Client client = ClientBuilder.newClient();
+    WebTarget target = client.target(url);
+    Response response = target.request(MediaType.APPLICATION_JSON).get();
     assertEquals(404, response.getStatus());
+    response.close();
+    client.close();
   }
 
   /**
@@ -498,17 +501,18 @@ public class TestATSHistoryWithACLs {
     historyLoggingService.handle(new DAGHistoryEvent(tezDAGID, submittedEvent));
     Thread.sleep(1000l);
     String url = "http://" + timelineAddress + "/ws/v1/timeline/TEZ_DAG_ID/"+event.getDAGID();
-    Client client = new Client();
-    WebResource resource = client.resource(url);
-
-    ClientResponse response = resource.accept(MediaType.APPLICATION_JSON)
-        .get(ClientResponse.class);
+    Client client = ClientBuilder.newClient();
+    WebTarget target = client.target(url);
+    Response response = target.request(MediaType.APPLICATION_JSON).get();
     assertEquals(200, response.getStatus());
-    assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(response.getType()));
-    JSONObject entityJson = response.getEntity(JSONObject.class);
+    assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(response.getMediaType()));
+    String entityStr = response.readEntity(String.class);
+    JSONObject entityJson = new JSONObject(entityStr);
     TimelineEntity entity = convertJSONObjectToTimelineObject(entityJson, TimelineEntity.class);
     assertEquals(entity.getEntityType(), "TEZ_DAG_ID");
     assertEquals(entity.getEvents().get(0).getEventType(), HistoryEventType.DAG_SUBMITTED.toString());
+    response.close();
+    client.close();
   }
 
   private static final String atsHistoryACLManagerClassName =

--- a/tez-plugins/tez-yarn-timeline-history-with-acls/src/test/java/org/apache/tez/dag/history/ats/acls/TestATSHistoryWithACLs.java
+++ b/tez-plugins/tez-yarn-timeline-history-with-acls/src/test/java/org/apache/tez/dag/history/ats/acls/TestATSHistoryWithACLs.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.yarn.api.records.timeline.TimelineEntity;
 import org.apache.hadoop.yarn.api.records.timeline.TimelineEvent;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.tez.client.TezClient;
+import org.apache.tez.common.ATSConstants;
 import org.apache.tez.common.ReflectionUtils;
 import org.apache.tez.common.security.DAGAccessControls;
 import org.apache.tez.dag.api.DAG;
@@ -151,15 +152,15 @@ public class TestATSHistoryWithACLs {
   private <K> K getTimelineData(String url, Class<K> clazz) {
     Client client = ClientBuilder.newClient();
     WebTarget target = client.target(url);
-
     Response response = target.request(MediaType.APPLICATION_JSON).get();
     assertEquals(200, response.getStatus());
     assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(response.getMediaType()));
-
     String entityStr = response.readEntity(String.class);
     try {
-      JSONObject entity = new JSONObject(entityStr);
-      K converted = convertJSONObjectToTimelineObject(entity, clazz);
+      JSONObject jsonObject = new JSONObject(entityStr);
+      // Handle the nesting introduced by Jersey 2/Jackson
+      JSONObject effectiveJson = jsonObject.has("domain") ? jsonObject.getJSONObject("domain") : jsonObject;
+      K converted = convertJSONObjectToTimelineObject(effectiveJson, clazz);
       assertNotNull(converted);
       return converted;
     } catch (JSONException e) {
@@ -181,9 +182,9 @@ public class TestATSHistoryWithACLs {
       return (K) domain;
     } else if (clazz == TimelineEntity.class) {
       TimelineEntity entity = new TimelineEntity();
-      entity.setEntityId(jsonObj.getString("entity"));
-      entity.setEntityType(jsonObj.getString("entitytype"));
-      entity.setDomainId(jsonObj.getString("domain"));
+      entity.setEntityId(jsonObj.getString(ATSConstants.ENTITY_ID));
+      entity.setEntityType(jsonObj.getString(ATSConstants.ENTITY_TYPE));
+      entity.setDomainId(jsonObj.getString(ATSConstants.DOMAIN_ID));
       entity.setEvents(getEventsFromJSON(jsonObj));
       return (K) entity;
     } else {
@@ -197,7 +198,7 @@ public class TestATSHistoryWithACLs {
     JSONArray arrEvents = jsonObj.getJSONArray("events");
     for (int i = 0; i < arrEvents.length(); i++) {
       TimelineEvent event = new TimelineEvent();
-      event.setEventType(((JSONObject) arrEvents.get(i)).getString("eventtype"));
+      event.setEventType(((JSONObject) arrEvents.get(i)).getString(ATSConstants.EVENT_TYPE));
       events.add(event);
     }
     return events;

--- a/tez-plugins/tez-yarn-timeline-history-with-acls/src/test/java/org/apache/tez/dag/history/ats/acls/TestATSHistoryWithACLs.java
+++ b/tez-plugins/tez-yarn-timeline-history-with-acls/src/test/java/org/apache/tez/dag/history/ats/acls/TestATSHistoryWithACLs.java
@@ -158,8 +158,21 @@ public class TestATSHistoryWithACLs {
     String entityStr = response.readEntity(String.class);
     try {
       JSONObject jsonObject = new JSONObject(entityStr);
+      JSONObject effectiveJson;
       // Handle the nesting introduced by Jersey 2/Jackson
-      JSONObject effectiveJson = jsonObject.has("domain") ? jsonObject.getJSONObject("domain") : jsonObject;
+      if (clazz == TimelineDomain.class) {
+        // TimelineDomain is annotated @XmlRootElement(name="domain"), Jersey 2/Jackson wraps it
+        effectiveJson = jsonObject.has("domain")
+            ? jsonObject.getJSONObject("domain")
+            : jsonObject;
+      } else if (clazz == TimelineEntity.class) {
+        // TimelineEntity is annotated @XmlRootElement(name="entity"), Jersey 2/Jackson wrap it
+        effectiveJson = jsonObject.has("entity")
+            ? jsonObject.getJSONObject("entity")
+            : jsonObject;
+      } else {
+        throw new RuntimeException("Unsupported class for JSON conversion: " + clazz);
+      }
       K converted = convertJSONObjectToTimelineObject(effectiveJson, clazz);
       assertNotNull(converted);
       return converted;

--- a/tez-plugins/tez-yarn-timeline-history-with-acls/src/test/java/org/apache/tez/dag/history/ats/acls/TestATSHistoryWithACLs.java
+++ b/tez-plugins/tez-yarn-timeline-history-with-acls/src/test/java/org/apache/tez/dag/history/ats/acls/TestATSHistoryWithACLs.java
@@ -166,7 +166,7 @@ public class TestATSHistoryWithACLs {
             ? jsonObject.getJSONObject("domain")
             : jsonObject;
       } else if (clazz == TimelineEntity.class) {
-        // TimelineEntity is annotated @XmlRootElement(name="entity"), Jersey 2/Jackson wrap it
+        // TimelineEntity is annotated @XmlRootElement(name="entity"), Jersey 2/Jackson wraps it
         effectiveJson = jsonObject.has("entity")
             ? jsonObject.getJSONObject("entity")
             : jsonObject;

--- a/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
@@ -143,8 +143,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
@@ -51,6 +51,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.tez</groupId>
       <artifactId>tez-tests</artifactId>
       <scope>test</scope>

--- a/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
@@ -56,11 +56,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.tez</groupId>
       <artifactId>tez-tests</artifactId>
       <scope>test</scope>
@@ -155,6 +150,11 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
@@ -56,6 +56,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.tez</groupId>
       <artifactId>tez-tests</artifactId>
       <scope>test</scope>

--- a/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
@@ -148,8 +148,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tez-plugins/tez-yarn-timeline-history/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history/pom.xml
@@ -129,8 +129,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tez-plugins/tez-yarn-timeline-history/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history/pom.xml
@@ -97,6 +97,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
       <scope>test</scope>

--- a/tez-plugins/tez-yarn-timeline-history/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history/pom.xml
@@ -134,8 +134,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tez-plugins/tez-yarn-timeline-history/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history/pom.xml
@@ -102,6 +102,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
       <scope>test</scope>

--- a/tez-plugins/tez-yarn-timeline-history/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history/pom.xml
@@ -102,11 +102,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
       <scope>test</scope>
@@ -141,6 +136,11 @@
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tez-tests/pom.xml
+++ b/tez-tests/pom.xml
@@ -72,6 +72,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-api</artifactId>
     </dependency>

--- a/tez-tests/pom.xml
+++ b/tez-tests/pom.xml
@@ -76,11 +76,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-api</artifactId>
     </dependency>
@@ -137,6 +132,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tez-tests/pom.xml
+++ b/tez-tests/pom.xml
@@ -76,6 +76,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-api</artifactId>
     </dependency>

--- a/tez-tools/analyzers/job-analyzer/pom.xml
+++ b/tez-tools/analyzers/job-analyzer/pom.xml
@@ -153,8 +153,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/tez-tools/analyzers/job-analyzer/pom.xml
+++ b/tez-tools/analyzers/job-analyzer/pom.xml
@@ -153,6 +153,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
       <scope>test</scope>

--- a/tez-tools/analyzers/job-analyzer/pom.xml
+++ b/tez-tools/analyzers/job-analyzer/pom.xml
@@ -157,8 +157,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.sun.jersey</groupId>
-      <artifactId>jersey-json</artifactId>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/tez-tools/analyzers/job-analyzer/pom.xml
+++ b/tez-tools/analyzers/job-analyzer/pom.xml
@@ -157,6 +157,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
       <scope>test</scope>

--- a/tez-tools/analyzers/job-analyzer/pom.xml
+++ b/tez-tools/analyzers/job-analyzer/pom.xml
@@ -157,6 +157,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.media</groupId>
+      <artifactId>jersey-media-json-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -165,15 +174,6 @@
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.jersey.media</groupId>
-      <artifactId>jersey-media-json-jackson</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
     </dependency>
   </dependencies>
 

--- a/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/utils/Utils.java
+++ b/tez-tools/analyzers/job-analyzer/src/main/java/org/apache/tez/analyzer/utils/Utils.java
@@ -23,13 +23,13 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import org.apache.tez.dag.utils.Graph;
 import org.apache.tez.history.parser.datamodel.AdditionalInputOutputDetails;
 import org.apache.tez.history.parser.datamodel.DagInfo;
 import org.apache.tez.history.parser.datamodel.EdgeInfo;
 import org.apache.tez.history.parser.datamodel.VertexInfo;
-
-import com.sun.istack.Nullable;
 
 public final class Utils {
 

--- a/tez-ui/src/main/webapp/app/serializers/ahs-app.js
+++ b/tez-ui/src/main/webapp/app/serializers/ahs-app.js
@@ -44,6 +44,6 @@ export default LoaderSerializer.extend({
     startTime: 'startedTime',
     endTime: 'finishedTime',
 
-    diagnostics: 'otherinfo.diagnostics',
+    diagnostics: 'diagnostics',
   }
 });

--- a/tez-ui/src/main/webapp/app/serializers/app.js
+++ b/tez-ui/src/main/webapp/app/serializers/app.js
@@ -20,13 +20,13 @@ import TimelineSerializer from './timeline';
 
 export default TimelineSerializer.extend({
   maps: {
-    domain: 'domain',
-    user: 'otherinfo.user',
+    domain: 'domainId',
+    user: 'otherInfo.user',
 
-    buildTime: 'otherinfo.tezVersion.buildTime',
-    tezRevision: 'otherinfo.tezVersion.revision',
-    tezVersion: 'otherinfo.tezVersion.version',
+    buildTime: 'otherInfo.tezVersion.buildTime',
+    tezRevision: 'otherInfo.tezVersion.revision',
+    tezVersion: 'otherInfo.tezVersion.version',
 
-    configs: 'otherinfo.config',
+    configs: 'otherInfo.config',
   }
 });

--- a/tez-ui/src/main/webapp/app/serializers/attempt.js
+++ b/tez-ui/src/main/webapp/app/serializers/attempt.js
@@ -21,7 +21,7 @@ import Ember from 'ember';
 import TimelineSerializer from './timeline';
 
 function createContainerLogURL(source) {
-  var logURL = Ember.get(source, 'otherinfo.inProgressLogsURL'),
+  var logURL = Ember.get(source, 'otherInfo.inProgressLogsURL'),
       yarnProtocol = this.get('env.app.yarnProtocol');
 
   if(logURL && logURL.indexOf("://") === -1) {
@@ -31,15 +31,15 @@ function createContainerLogURL(source) {
 
 export default TimelineSerializer.extend({
   maps: {
-    taskID: 'primaryfilters.TEZ_TASK_ID.0',
-    vertexID: 'primaryfilters.TEZ_VERTEX_ID.0',
-    dagID: 'primaryfilters.TEZ_DAG_ID.0',
+    taskID: 'primaryFilters.TEZ_TASK_ID.0',
+    vertexID: 'primaryFilters.TEZ_VERTEX_ID.0',
+    dagID: 'primaryFilters.TEZ_DAG_ID.0',
 
-    containerID: 'otherinfo.containerId',
-    nodeID: 'otherinfo.nodeId',
+    containerID: 'otherInfo.containerId',
+    nodeID: 'otherInfo.nodeId',
 
-    inProgressLogsURL: "otherinfo.inProgressLogsURL",
-    completedLogsURL: "otherinfo.completedLogsURL",
+    inProgressLogsURL: "otherInfo.inProgressLogsURL",
+    completedLogsURL: "otherInfo.completedLogsURL",
 
     containerLogURL: createContainerLogURL
   }

--- a/tez-ui/src/main/webapp/app/serializers/dag-info.js
+++ b/tez-ui/src/main/webapp/app/serializers/dag-info.js
@@ -22,20 +22,20 @@ import TimelineSerializer from './timeline';
 
 export default TimelineSerializer.extend({
   maps: {
-    dagPlan: 'otherinfo.dagPlan',
+    dagPlan: 'otherInfo.dagPlan',
     callerData: 'callerData',
   },
 
   normalizeResourceHash: function (resourceHash) {
     var data = resourceHash.data,
         callerData = {},
-        dagInfo = Ember.get(data, "otherinfo.dagPlan.dagInfo"), // New style, from TEZ-2851
-        dagContext = Ember.get(data, "otherinfo.dagPlan.dagContext"); // Old style
+        dagInfo = Ember.get(data, "otherInfo.dagPlan.dagInfo"), // New style, from TEZ-2851
+        dagContext = Ember.get(data, "otherInfo.dagPlan.dagContext"); // Old style
 
     if(dagContext) {
       callerData.callerContext = Ember.String.classify((Ember.get(dagContext, "context")||"").toLowerCase());
       callerData.callerDescription = Ember.get(dagContext, "description");
-      callerData.callerType = Ember.get(dagContext, "callerType") || Ember.get(data, "otherinfo.callerType");
+      callerData.callerType = Ember.get(dagContext, "callerType") || Ember.get(data, "otherInfo.callerType");
     }
     else if(dagInfo) {
       let infoObj = {};
@@ -45,7 +45,7 @@ export default TimelineSerializer.extend({
         infoObj = dagInfo;
       }
 
-      callerData.callerContext = Ember.get(infoObj, "context") || Ember.get(data, "otherinfo.callerContext");
+      callerData.callerContext = Ember.get(infoObj, "context") || Ember.get(data, "otherInfo.callerContext");
       callerData.callerDescription = Ember.get(infoObj, "description") || Ember.get(dagInfo, "blob") || dagInfo;
     }
 

--- a/tez-ui/src/main/webapp/app/serializers/dag.js
+++ b/tez-ui/src/main/webapp/app/serializers/dag.js
@@ -24,11 +24,11 @@ import DAGInfoSerializer from './dag-info';
 var MoreObject = more.Object;
 
 function getStatus(source) {
-  var status = Ember.get(source, 'otherinfo.status') || Ember.get(source, 'primaryfilters.status.0'),
+  var status = Ember.get(source, 'otherInfo.status') || Ember.get(source, 'primaryFilters.status.0'),
       event = source.events;
 
   if(!status && event) {
-    if(event.findBy('eventtype', 'DAG_STARTED')) {
+    if(event.findBy('eventType', 'DAG_STARTED')) {
       status = 'RUNNING';
     }
   }
@@ -37,11 +37,11 @@ function getStatus(source) {
 }
 
 function getStartTime(source) {
-  var time = Ember.get(source, 'otherinfo.startTime'),
+  var time = Ember.get(source, 'otherInfo.startTime'),
       event = source.events;
 
   if(!time && event) {
-    event = event.findBy('eventtype', 'DAG_STARTED');
+    event = event.findBy('eventType', 'DAG_STARTED');
     if(event) {
       time = event.timestamp;
     }
@@ -51,11 +51,11 @@ function getStartTime(source) {
 }
 
 function getEndTime(source) {
-  var time = Ember.get(source, 'otherinfo.endTime'),
+  var time = Ember.get(source, 'otherInfo.endTime'),
       event = source.events;
 
   if(!time && event) {
-    event = event.findBy('eventtype', 'DAG_FINISHED');
+    event = event.findBy('eventType', 'DAG_FINISHED');
     if(event) {
       time = event.timestamp;
     }
@@ -66,7 +66,7 @@ function getEndTime(source) {
 
 function getContainerLogs(source) {
   var containerLogs = [],
-      otherinfo = Ember.get(source, 'otherinfo');
+      otherinfo = Ember.get(source, 'otherInfo');
 
   if(!otherinfo) {
     return undefined;
@@ -74,7 +74,7 @@ function getContainerLogs(source) {
 
   for (var key in otherinfo) {
     if (key.indexOf('inProgressLogsURL_') === 0) {
-      let logs = Ember.get(source, 'otherinfo.' + key);
+      let logs = Ember.get(source, 'otherInfo.' + key);
       if (logs.indexOf("://") === -1) {
         let yarnProtocol = this.get('env.app.yarnProtocol');
         logs = yarnProtocol + '://' + logs;
@@ -91,7 +91,7 @@ function getContainerLogs(source) {
 }
 
 function getIdNameMap(source) {
-  var nameIdMap = Ember.get(source, 'otherinfo.vertexNameIdMapping'),
+  var nameIdMap = Ember.get(source, 'otherInfo.vertexNameIdMapping'),
       idNameMap = {};
 
   if(nameIdMap) {
@@ -105,11 +105,11 @@ function getIdNameMap(source) {
 
 export default DAGInfoSerializer.extend({
   maps: {
-    name: 'primaryfilters.dagName.0',
+    name: 'primaryFilters.dagName.0',
 
-    submitter: 'primaryfilters.user.0',
+    submitter: 'primaryFilters.user.0',
 
-    callerID: 'primaryfilters.callerId.0',
+    callerID: 'primaryFilters.callerId.0',
 
     atsStatus: getStatus,
     // progress
@@ -119,16 +119,16 @@ export default DAGInfoSerializer.extend({
     // duration
 
     // appID
-    domain: 'domain',
+    domain: 'domainId',
 
-    queueName: 'otherinfo.queueName',
+    queueName: 'otherInfo.queueName',
 
     containerLogs: getContainerLogs,
 
     vertexIdNameMap: getIdNameMap,
-    vertexNameIdMap: 'otherinfo.vertexNameIdMapping',
+    vertexNameIdMap: 'otherInfo.vertexNameIdMapping',
 
-    amWsVersion: 'otherinfo.amWebServiceVersion',
-    failedTaskAttempts: 'otherinfo.numFailedTaskAttempts',
+    amWsVersion: 'otherInfo.amWebServiceVersion',
+    failedTaskAttempts: 'otherInfo.numFailedTaskAttempts',
   }
 });

--- a/tez-ui/src/main/webapp/app/serializers/hive-query.js
+++ b/tez-ui/src/main/webapp/app/serializers/hive-query.js
@@ -21,11 +21,11 @@ import Ember from 'ember';
 import TimelineSerializer from './timeline';
 
 function getEndTime(source) {
-  var time = Ember.get(source, 'otherinfo.endTime'),
+  var time = Ember.get(source, 'otherInfo.endTime'),
       event = source.events;
 
   if(!time && event) {
-    event = event.findBy('eventtype', 'QUERY_COMPLETED');
+    event = event.findBy('eventType', 'QUERY_COMPLETED');
     if(event) {
       time = event.timestamp;
     }
@@ -35,7 +35,7 @@ function getEndTime(source) {
 }
 
 function getStatus(source) {
-  var status = Ember.get(source, 'otherinfo.STATUS');
+  var status = Ember.get(source, 'otherInfo.STATUS');
 
   switch(status) {
     case true:
@@ -49,70 +49,70 @@ function getStatus(source) {
 
 export default TimelineSerializer.extend({
   maps: {
-    queryText: 'otherinfo.QUERY.queryText',
+    queryText: 'otherInfo.QUERY.queryText',
 
-    dagID: 'primaryfilters.DAG_ID',
-    appID: 'primaryfilters.APP_ID',
-    sessionID: 'otherinfo.INVOKER_INFO',
-    operationID: 'primaryfilters.operationid.0',
-    llapAppID: 'otherinfo.LLAP_APP_ID',
+    dagID: 'primaryFilters.DAG_ID',
+    appID: 'primaryFilters.APP_ID',
+    sessionID: 'otherInfo.INVOKER_INFO',
+    operationID: 'primaryFilters.operationid.0',
+    llapAppID: 'otherInfo.LLAP_APP_ID',
 
-    instanceType: 'otherinfo.HIVE_INSTANCE_TYPE',
-    executionMode: 'primaryfilters.executionmode.0',
+    instanceType: 'otherInfo.HIVE_INSTANCE_TYPE',
+    executionMode: 'primaryFilters.executionmode.0',
 
-    domain: 'domain',
-    threadName: 'otherinfo.THREAD_NAME',
-    queue: 'primaryfilters.queue.0',
-    version: 'otherinfo.VERSION',
+    domain: 'domainId',
+    threadName: 'otherInfo.THREAD_NAME',
+    queue: 'primaryFilters.queue.0',
+    version: 'otherInfo.VERSION',
 
-    hiveAddress: 'otherinfo.HIVE_ADDRESS',
-    clientAddress: 'otherinfo.CLIENT_IP_ADDRESS',
+    hiveAddress: 'otherInfo.HIVE_ADDRESS',
+    clientAddress: 'otherInfo.CLIENT_IP_ADDRESS',
 
-    user: 'primaryfilters.user.0',
-    requestUser: 'primaryfilters.requestuser.0',
+    user: 'primaryFilters.user.0',
+    requestUser: 'primaryFilters.requestuser.0',
 
-    tablesRead: 'primaryfilters.tablesread',
-    tablesWritten: 'primaryfilters.tableswritten',
+    tablesRead: 'primaryFilters.tablesread',
+    tablesWritten: 'primaryFilters.tableswritten',
 
     status: getStatus,
 
-    configsJSON: "otherinfo.CONF",
+    configsJSON: "otherInfo.CONF",
 
-    startTime: 'starttime',
+    startTime: 'startTime',
     endTime: getEndTime,
 
-    perf: "otherinfo.PERF"
+    perf: "otherInfo.PERF"
   },
 
   extractAttributes: function (modelClass, resourceHash) {
     var data = resourceHash.data,
-        query = Ember.get(resourceHash, "data.otherinfo.QUERY"),
-        perf = Ember.get(resourceHash, "data.otherinfo.PERF");
+        query = Ember.get(resourceHash, "data.otherInfo.QUERY"),
+        perf = Ember.get(resourceHash, "data.otherInfo.PERF");
 
     if(query) {
       try{
-        data.otherinfo.QUERY = JSON.parse(query);
+        data.otherInfo.QUERY = JSON.parse(query);
       }catch(e){}
     }
 
-    if(!data.otherinfo.CLIENT_IP_ADDRESS) {
-      data.otherinfo.CLIENT_IP_ADDRESS = data.otherinfo.HIVE_ADDRESS;
+    if(!data.otherInfo.CLIENT_IP_ADDRESS) {
+      data.otherInfo.CLIENT_IP_ADDRESS = data.otherInfo.HIVE_ADDRESS;
     }
 
     if(perf) {
       try{
         let PERF = JSON.parse(perf);
         PERF["PostATSHook"] = PERF["PostHook.org.apache.hadoop.hive.ql.hooks.ATSHook"];
-        data.otherinfo.PERF = PERF;
+        data.otherInfo.PERF = PERF;
       }catch(e){}
     }
 
-    data.primaryfilters = data.primaryfilters || {};
-    if(!Ember.get(data, "primaryfilters.tablesread.length")) {
-      data.primaryfilters.tablesread = new Error("None");
+    data.primaryFilters = data.primaryFilters || {};
+    if(!Ember.get(data, "primaryFilters.tablesread.length")) {
+      data.primaryFilters.tablesread = new Error("None");
     }
-    if(!Ember.get(data, "primaryfilters.tableswritten.length")) {
-      data.primaryfilters.tableswritten = new Error("None");
+    if(!Ember.get(data, "primaryFilters.tableswritten.length")) {
+      data.primaryFilters.tableswritten = new Error("None");
     }
 
     return this._super(modelClass, resourceHash);

--- a/tez-ui/src/main/webapp/app/serializers/task.js
+++ b/tez-ui/src/main/webapp/app/serializers/task.js
@@ -20,12 +20,12 @@ import TimelineSerializer from './timeline';
 
 export default TimelineSerializer.extend({
   maps: {
-    vertexID: 'primaryfilters.TEZ_VERTEX_ID.0',
-    dagID: 'primaryfilters.TEZ_DAG_ID.0',
+    vertexID: 'primaryFilters.TEZ_VERTEX_ID.0',
+    dagID: 'primaryFilters.TEZ_DAG_ID.0',
 
-    failedTaskAttempts: 'otherinfo.numFailedTaskAttempts',
+    failedTaskAttempts: 'otherInfo.numFailedTaskAttempts',
 
-    successfulAttemptID: 'otherinfo.successfulAttemptId',
-    attemptIDs: 'relatedentities.TEZ_TASK_ATTEMPT_ID',
+    successfulAttemptID: 'otherInfo.successfulAttemptId',
+    attemptIDs: 'relatedEntities.TEZ_TASK_ATTEMPT_ID',
   }
 });

--- a/tez-ui/src/main/webapp/app/serializers/timeline.js
+++ b/tez-ui/src/main/webapp/app/serializers/timeline.js
@@ -21,7 +21,7 @@ import Ember from 'ember';
 import LoaderSerializer from './loader';
 
 function getDiagnostics(source) {
-  var diagnostics = Ember.get(source, 'otherinfo.diagnostics') || "";
+  var diagnostics = Ember.get(source, 'otherInfo.diagnostics') || "";
 
   diagnostics = diagnostics.replace(/\t/g, "&emsp;&emsp;");
   diagnostics = diagnostics.replace(/\[/g, "<div>&#187; ");
@@ -31,24 +31,28 @@ function getDiagnostics(source) {
 }
 
 export default LoaderSerializer.extend({
-  primaryKey: 'entity',
+  // Hadoop 3.5.0 ATS v1 REST API uses camelCase field names:
+  //   entityId (was: entity), entityType (was: entitytype),
+  //   otherInfo (was: otherinfo), primaryFilters (was: primaryfilters),
+  //   relatedEntities (was: relatedentities), eventType (was: eventtype)
+  primaryKey: 'entityId',
 
   extractArrayPayload: function (payload) {
     return payload.entities;
   },
 
   maps: {
-    entityID: 'entity',
+    entityID: 'entityId',
 
-    atsStatus: 'otherinfo.status',
+    atsStatus: 'otherInfo.status',
 
-    startTime: 'otherinfo.startTime',
-    endTime: 'otherinfo.endTime',
+    startTime: 'otherInfo.startTime',
+    endTime: 'otherInfo.endTime',
 
     diagnostics: getDiagnostics,
 
     events: 'events',
 
-    _counterGroups: 'otherinfo.counters.counterGroups'
+    _counterGroups: 'otherInfo.counters.counterGroups'
   }
 });

--- a/tez-ui/src/main/webapp/app/serializers/vertex.js
+++ b/tez-ui/src/main/webapp/app/serializers/vertex.js
@@ -21,41 +21,41 @@ import Ember from 'ember';
 import TimelineSerializer from './timeline';
 
 function getProcessorClass(source) {
-  var name = Ember.get(source, 'otherinfo.processorClassName') || "";
+  var name = Ember.get(source, 'otherInfo.processorClassName') || "";
   return name.substr(name.lastIndexOf('.') + 1);
 }
 
 export default TimelineSerializer.extend({
   maps: {
-    name: 'otherinfo.vertexName',
+    name: 'otherInfo.vertexName',
 
-    _initTime: 'otherinfo.initTime',
-    _startTime: 'otherinfo.startTime',
-    _endTime: 'otherinfo.endTime',
-    _firstTaskStartTime: 'otherinfo.stats.firstTaskStartTime',
-    _lastTaskFinishTime: 'otherinfo.stats.lastTaskFinishTime',
+    _initTime: 'otherInfo.initTime',
+    _startTime: 'otherInfo.startTime',
+    _endTime: 'otherInfo.endTime',
+    _firstTaskStartTime: 'otherInfo.stats.firstTaskStartTime',
+    _lastTaskFinishTime: 'otherInfo.stats.lastTaskFinishTime',
 
-    totalTasks: 'otherinfo.numTasks',
-    _failedTasks: 'otherinfo.numFailedTasks',
-    _succeededTasks: 'otherinfo.numSucceededTasks',
-    _killedTasks: 'otherinfo.numKilledTasks',
+    totalTasks: 'otherInfo.numTasks',
+    _failedTasks: 'otherInfo.numFailedTasks',
+    _succeededTasks: 'otherInfo.numSucceededTasks',
+    _killedTasks: 'otherInfo.numKilledTasks',
 
-    _failedTaskAttempts: 'otherinfo.numFailedTaskAttempts',
-    _killedTaskAttempts: 'otherinfo.numKilledTaskAttempts',
+    _failedTaskAttempts: 'otherInfo.numFailedTaskAttempts',
+    _killedTaskAttempts: 'otherInfo.numKilledTaskAttempts',
 
-    minDuration:  'otherinfo.stats.minTaskDuration',
-    maxDuration:  'otherinfo.stats.maxTaskDuration',
-    avgDuration:  'otherinfo.stats.avgTaskDuration',
+    minDuration:  'otherInfo.stats.minTaskDuration',
+    maxDuration:  'otherInfo.stats.maxTaskDuration',
+    avgDuration:  'otherInfo.stats.avgTaskDuration',
 
-    firstTasksToStart:  'otherinfo.stats.firstTasksToStart',
-    lastTasksToFinish:  'otherinfo.stats.lastTasksToFinish',
-    shortestDurationTasks:  'otherinfo.stats.shortestDurationTasks',
-    longestDurationTasks:  'otherinfo.stats.longestDurationTasks',
+    firstTasksToStart:  'otherInfo.stats.firstTasksToStart',
+    lastTasksToFinish:  'otherInfo.stats.lastTasksToFinish',
+    shortestDurationTasks:  'otherInfo.stats.shortestDurationTasks',
+    longestDurationTasks:  'otherInfo.stats.longestDurationTasks',
 
     processorClassName: getProcessorClass,
 
-    dagID: 'primaryfilters.TEZ_DAG_ID.0',
+    dagID: 'primaryFilters.TEZ_DAG_ID.0',
 
-    servicePlugin: 'otherinfo.servicePlugin',
+    servicePlugin: 'otherInfo.servicePlugin',
   }
 });

--- a/tez-ui/src/main/webapp/app/utils/download-dag-zip.js
+++ b/tez-ui/src/main/webapp/app/utils/download-dag-zip.js
@@ -454,7 +454,7 @@ export default function downloadDagZip(dag, options) {
 
     // need to handle no more entries , zero entries
     if (data.entities.length > batchSize) {
-      nextBatchStart = data.entities.pop().entity;
+      nextBatchStart = data.entities.pop().entityId;
     }
     obj[context.name] = data.entities;
 

--- a/tez-ui/src/main/webapp/tests/unit/serializers/attempt-test.js
+++ b/tez-ui/src/main/webapp/tests/unit/serializers/attempt-test.js
@@ -40,7 +40,7 @@ test('containerLogURL test', function(assert) {
   });
 
   assert.equal(serializer.maps.containerLogURL.call(serializer, {
-    otherinfo: {
+    otherInfo: {
       inProgressLogsURL: "abc.com/test/link",
     }
   }), "ptcl://abc.com/test/link");

--- a/tez-ui/src/main/webapp/tests/unit/serializers/dag-info-test.js
+++ b/tez-ui/src/main/webapp/tests/unit/serializers/dag-info-test.js
@@ -51,7 +51,7 @@ test('normalizeResourceHash test', function(assert) {
   // dagContext test
   data = serializer.normalizeResourceHash({
     data: {
-      otherinfo: {
+      otherInfo: {
         dagPlan: {
           dagContext: callerInfo
         }
@@ -66,7 +66,7 @@ test('normalizeResourceHash test', function(assert) {
   // dagInfo test
   data = serializer.normalizeResourceHash({
     data: {
-      otherinfo: {
+      otherInfo: {
         dagPlan: {
           dagInfo: `{"context": "${callerInfo.context}", "description": "${callerInfo.description}"}`
         }
@@ -81,7 +81,7 @@ test('normalizeResourceHash test', function(assert) {
   // dagInfo.blob test
   data = serializer.normalizeResourceHash({
     data: {
-      otherinfo: {
+      otherInfo: {
         dagPlan: {
           dagInfo: {
             context: callerInfo.context,
@@ -99,7 +99,7 @@ test('normalizeResourceHash test', function(assert) {
   // dagContext have presidence over dagInfo
   data = serializer.normalizeResourceHash({
     data: {
-      otherinfo: {
+      otherInfo: {
         dagPlan: {
           dagContext: callerInfo,
           dagInfo: `{"context": "RandomContext", "description": "RandomDesc"}`

--- a/tez-ui/src/main/webapp/tests/unit/serializers/dag-test.js
+++ b/tez-ui/src/main/webapp/tests/unit/serializers/dag-test.js
@@ -44,22 +44,22 @@ test('atsStatus test', function(assert) {
       mapper = serializer.maps.atsStatus;
 
   assert.equal(mapper({
-    events: [{eventtype: "SOME_EVENT"}]
+    events: [{eventType: "SOME_EVENT"}]
   }), undefined);
 
   assert.equal(mapper({
-    events: [{eventtype: "DAG_STARTED"}]
+    events: [{eventType: "DAG_STARTED"}]
   }), "RUNNING");
 
   assert.equal(mapper({
-    otherinfo: {status: "STATUS1"},
-    primaryfilters: {status: ["STATUS2"]},
-    events: [{eventtype: "DAG_STARTED"}]
+    otherInfo: {status: "STATUS1"},
+    primaryFilters: {status: ["STATUS2"]},
+    events: [{eventType: "DAG_STARTED"}]
   }), "STATUS1");
 
   assert.equal(mapper({
-    primaryfilters: {status: ["STATUS2"]},
-    events: [{eventtype: "DAG_STARTED"}]
+    primaryFilters: {status: ["STATUS2"]},
+    events: [{eventType: "DAG_STARTED"}]
   }), "STATUS2");
 });
 
@@ -69,16 +69,16 @@ test('startTime test', function(assert) {
       testTimestamp = Date.now();
 
   assert.equal(mapper({
-    events: [{eventtype: "SOME_EVENT"}]
+    events: [{eventType: "SOME_EVENT"}]
   }), undefined);
 
   assert.equal(mapper({
-    events: [{eventtype: "DAG_STARTED", timestamp: testTimestamp}]
+    events: [{eventType: "DAG_STARTED", timestamp: testTimestamp}]
   }), testTimestamp);
 
   assert.equal(mapper({
-    otherinfo: {startTime: testTimestamp},
-    events: [{eventtype: "DAG_STARTED"}]
+    otherInfo: {startTime: testTimestamp},
+    events: [{eventType: "DAG_STARTED"}]
   }), testTimestamp);
 });
 
@@ -88,16 +88,16 @@ test('endTime test', function(assert) {
       testTimestamp = Date.now();
 
   assert.equal(mapper({
-    events: [{eventtype: "SOME_EVENT"}]
+    events: [{eventType: "SOME_EVENT"}]
   }), undefined);
 
   assert.equal(mapper({
-    events: [{eventtype: "DAG_FINISHED", timestamp: testTimestamp}]
+    events: [{eventType: "DAG_FINISHED", timestamp: testTimestamp}]
   }), testTimestamp);
 
   assert.equal(mapper({
-    otherinfo: {endTime: testTimestamp},
-    events: [{eventtype: "DAG_FINISHED"}]
+    otherInfo: {endTime: testTimestamp},
+    events: [{eventType: "DAG_FINISHED"}]
   }), testTimestamp);
 });
 
@@ -106,11 +106,11 @@ test('containerLogs test', function(assert) {
       mapper = serializer.maps.containerLogs;
 
   assert.deepEqual(mapper({
-    otherinfo: {},
+    otherInfo: {},
   }), [], "No logs");
 
   assert.deepEqual(mapper({
-	  otherinfo: {inProgressLogsURL_1: "http://foo", inProgressLogsURL_2: "https://bar"},
+    otherInfo: {inProgressLogsURL_1: "http://foo", inProgressLogsURL_2: "https://bar"},
   }), [{text: "1", href: "http://foo"}, {text: "2", href: "https://bar"}], "2 logs");
 });
 
@@ -119,7 +119,7 @@ test('vertexIdNameMap test', function(assert) {
       mapper = serializer.maps.vertexIdNameMap;
 
   let nameIdMap = {
-    otherinfo: {
+    otherInfo: {
       vertexNameIdMapping: {
         name1: "ID1",
         name2: "ID2",
@@ -150,7 +150,7 @@ test('normalizeResourceHash test', function(assert) {
   // dagContext test
   data = serializer.normalizeResourceHash({
     data: {
-      otherinfo: {
+      otherInfo: {
         dagPlan: {
           dagContext: callerInfo
         }
@@ -165,7 +165,7 @@ test('normalizeResourceHash test', function(assert) {
   // dagInfo test
   data = serializer.normalizeResourceHash({
     data: {
-      otherinfo: {
+      otherInfo: {
         dagPlan: {
           dagInfo: `{"context": "${callerInfo.context}", "description": "${callerInfo.description}"}`
         }
@@ -180,7 +180,7 @@ test('normalizeResourceHash test', function(assert) {
   // dagInfo.blob test
   data = serializer.normalizeResourceHash({
     data: {
-      otherinfo: {
+      otherInfo: {
         dagPlan: {
           dagInfo: {
             context: callerInfo.context,
@@ -198,7 +198,7 @@ test('normalizeResourceHash test', function(assert) {
   // dagContext have presidence over dagInfo
   data = serializer.normalizeResourceHash({
     data: {
-      otherinfo: {
+      otherInfo: {
         dagPlan: {
           dagContext: callerInfo,
           dagInfo: `{"context": "RandomContext", "description": "RandomDesc"}`

--- a/tez-ui/src/main/webapp/tests/unit/serializers/hive-query-test.js
+++ b/tez-ui/src/main/webapp/tests/unit/serializers/hive-query-test.js
@@ -36,12 +36,12 @@ test('getStatus test', function(assert) {
 
   assert.equal(getStatus({}), "RUNNING");
   assert.equal(getStatus({
-    otherinfo: {
+    otherInfo: {
       STATUS: true
     }
   }), "SUCCEEDED");
   assert.equal(getStatus({
-    otherinfo: {
+    otherInfo: {
       STATUS: false
     }
   }), "FAILED");
@@ -55,19 +55,19 @@ test('getEndTime test', function(assert) {
   assert.equal(getEndTime({}), undefined);
 
   assert.equal(getEndTime({
-    otherinfo: {
+    otherInfo: {
       endTime: endTime
     }
   }), endTime);
 
   assert.equal(getEndTime({
     events: [{
-      eventtype: 'X',
+      eventType: 'X',
     }, {
-      eventtype: 'QUERY_COMPLETED',
+      eventType: 'QUERY_COMPLETED',
       timestamp: endTime
     }, {
-      eventtype: 'Y',
+      eventType: 'Y',
     }]
   }), endTime);
 });
@@ -80,7 +80,7 @@ test('extractAttributes test', function(assert) {
       },
       testHiveAddress = "1.2.3.4",
       testData = {
-        otherinfo: {
+        otherInfo: {
           QUERY: JSON.stringify(testQuery),
           HIVE_ADDRESS: testHiveAddress
         }
@@ -91,15 +91,15 @@ test('extractAttributes test', function(assert) {
   }), {
     data: testData
   });
-  assert.deepEqual(testData.otherinfo.QUERY, testQuery);
+  assert.deepEqual(testData.otherInfo.QUERY, testQuery);
 
   //CLIENT_IP_ADDRESS set
-  assert.equal(testHiveAddress, testData.otherinfo.CLIENT_IP_ADDRESS);
+  assert.equal(testHiveAddress, testData.otherInfo.CLIENT_IP_ADDRESS);
 
   // Tables read & tables written
-  assert.ok(testData.primaryfilters);
-  assert.ok(testData.primaryfilters.tablesread instanceof Error);
-  assert.ok(testData.primaryfilters.tableswritten instanceof Error);
-  assert.equal(testData.primaryfilters.tablesread.message, "None");
-  assert.equal(testData.primaryfilters.tableswritten.message, "None");
+  assert.ok(testData.primaryFilters);
+  assert.ok(testData.primaryFilters.tablesread instanceof Error);
+  assert.ok(testData.primaryFilters.tableswritten instanceof Error);
+  assert.equal(testData.primaryFilters.tablesread.message, "None");
+  assert.equal(testData.primaryFilters.tableswritten.message, "None");
 });

--- a/tez-ui/src/main/webapp/tests/unit/serializers/timeline-test.js
+++ b/tez-ui/src/main/webapp/tests/unit/serializers/timeline-test.js
@@ -31,6 +31,7 @@ test('Basic creation test', function(assert) {
   assert.ok(serializer.maps);
 
   assert.equal(Object.keys(serializer.get("maps")).length, 7);
+  assert.equal(serializer.primaryKey, 'entityId');
 });
 
 test('extractArrayPayload test', function(assert) {

--- a/tez-ui/src/main/webapp/tests/unit/serializers/vertex-test.js
+++ b/tez-ui/src/main/webapp/tests/unit/serializers/vertex-test.js
@@ -37,12 +37,12 @@ test('processorClassName test', function(assert) {
 
   assert.equal(processorClassName({}), "");
   assert.equal(processorClassName({
-    otherinfo: {
+    otherInfo: {
       processorClassName: "foo"
     }
   }), "foo");
   assert.equal(processorClassName({
-    otherinfo: {
+    otherInfo: {
       processorClassName: "a.b.foo"
     }
   }), "foo");


### PR DESCRIPTION
## What changes were proposed in this PR?

This PR upgrades Tez to support:
- Hadoop 3.5.0
- Jersey 2.x

As part of the upgrade, several ATS Timeline API response format differences were observed between older Hadoop versions and Hadoop 3.5.0. This PR adds compatibility handling for those schema variations.

Main updates include:

- Migrated Jersey client usage from Jersey 1.x APIs to Jersey 2.x APIs
- Added handling for ATS field name variations observed across versions
Handled ATS compatibility differences including:
- `otherinfo` ↔ `otherInfo`
- `entity` ↔ `entityId`
- `entitytype` ↔ `entityType`
- `domain` / `id` ↔ `domainId`

Additional fixes:
- Handled nested Timeline domain JSON structures
- Stabilized ATS-related unit tests after Jersey 2.x migration

## How was this patch tested?
- with existed UT and all unit tests are green.

jersey upgrade changes taken from PR : https://github.com/apache/tez/pull/429 by @abstractdog  as they need for hadoop 3.5.0 upgrade.