### PR TITLE
TEZ-4704: Upgrade restrict-imports.enforcer to 3.0.0 to fix warning duing maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <protobuf.version>3.25.5</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <protoc.path>${env.PROTOC_PATH}</protoc.path>
-    <restrict-imports.enforcer.version>2.0.0</restrict-imports.enforcer.version>
+    <restrict-imports.enforcer.version>3.0.0</restrict-imports.enforcer.version>
     <roaringbitmap.version>1.2.1</roaringbitmap.version>
     <scm.url>scm:git:https://gitbox.apache.org/repos/asf/tez.git</scm.url>
     <servlet-api.version>3.1.0</servlet-api.version>


### PR DESCRIPTION
Check [TEZ-4704](https://issues.apache.org/jira/browse/TEZ-4704),
```
[INFO] --- enforcer:3.6.2:enforce (banned-illegal-imports) @ tez-api ---
[WARNING] ruleName restrictImports with implementation org.apache.maven.plugins.enforcer.RestrictImportsuses the deprecated Maven Enforcer Plugin API. This will not be supported in a future version of the plugin. Please contact the rule maintainer to upgrade the rule implementation to the current API.
[INFO] Rule 0: org.apache.maven.plugins.enforcer.RestrictImports passed 
```
After this PR:
```
[INFO] --- enforcer:3.6.2:enforce (banned-illegal-imports) @ tez-api ---
[INFO] Rule 0: org.apache.maven.plugins.enforcer.RestrictImports passed
```

From release notes, the plugin tags we are using have no breaking change in them.