### PR TITLE
TEZ-4702: Javadoc generation fails since Java21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -876,6 +876,9 @@
           <configuration>
             <doclint>none</doclint>
             <docfilessubdirs>true</docfilessubdirs>
+            <additionalJOptions>
+              <additionalJOption>-J--add-exports=jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED</additionalJOption>
+            </additionalJOptions>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This is blocked on TEZ-4688, until Hadoop is upgraded to 3.5.0 in tez.
HADOOP-19402, HADOOP-19785 and other patches has fixed `IncludePublicAnnotationsStandardDoclet` class to support JDK17+ syntax

Commands to verify:
```
mvn clean install javadoc:aggregate -DskipTests -pl tez-api -pl tez-mapreduce -pl tez-runtime-library -Dhadoop.version=3.5.0
mvn site -f tez-api -Dhadoop.version=3.5.0
```