### PR TITLE
TEZ-4706: Use project build directory for Graphviz output and update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@
 .settings
 pom.xml.versionsBackup
 target
-tez-dist/src/docker/cache/

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Optional parameters:
 * `-Dtez.dag.state.classes=<comma-separated list of classes>`
     (Default: DAG, Vertex, Task, TaskAttempt)
 * `-Dtez.graphviz.title` (Default: Tez)
-* `-Dtez.graphviz.output.file` (Default: Tez.gv)
+* `-Dtez.graphviz.output.file` (Default: `tez-dag/target/Tez.gv`)
 
 Example for `DAGImpl`:
 
@@ -197,7 +197,7 @@ mvn compile -Pvisualize \
 Convert the `.gv` file to an image:
 
 ```bash
-dot -Tpng -o Tez.png Tez.gv
+dot -Tpng -o Tez.png tez-dag/target/Tez.gv
 ```
 
 Building Contrib Tools

--- a/tez-dag/pom.xml
+++ b/tez-dag/pom.xml
@@ -30,7 +30,7 @@
     org.apache.tez.dag.app.rm.node.AMNodeImpl,
     org.apache.tez.dag.app.rm.container.AMContainerImpl</tez.dag.state.classes>
     <tez.graphviz.title>Tez</tez.graphviz.title>
-    <tez.graphviz.output.file>Tez.gv</tez.graphviz.output.file>
+    <tez.graphviz.output.file>${project.build.directory}/Tez.gv</tez.graphviz.output.file>
   </properties>
   <artifactId>tez-dag</artifactId>
 


### PR DESCRIPTION
Presently, `Tez.gv` (tez-dag/pom.xml) is created in project root directory. As the Visualize profile is specific to tez-dag, its better to move the `Tez.gv` in `tez-dag/target/` directory.