### PR TITLE
TEZ-4709: Fix Protobuf linter (buf) failures by upgrading in build environment

### DIFF
--- a/build-tools/docker/Dockerfile
+++ b/build-tools/docker/Dockerfile
@@ -139,10 +139,10 @@ RUN curl -sSL \
 FROM tezbase AS buf
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -sSL \
-      https://github.com/bufbuild/buf/releases/download/v0.21.0/buf-Linux-x86_64.tar.gz \
+      https://github.com/bufbuild/buf/releases/download/v1.68.2/buf-Linux-x86_64.tar.gz \
       -o buf.tar.gz \
     && shasum -a 256 buf.tar.gz \
-    | awk '$1!="95aba62ac0ecc5a9120cc58c65cdcc85038633a816bddfe8398c5ae3b32803f1" {exit(1)}' \
+    | awk '$1!="557ea42d00458466e3421bd1cf5781d882a95b0c1c0e54efffc326fdf9993d02" {exit(1)}' \
     && tar -xzf buf.tar.gz -C /usr/local --strip-components 1 \
     && rm buf.tar.gz
 


### PR DESCRIPTION
Older version (0.21.0): It was `buf check`
<img width="794" height="450" alt="Screenshot 2026-04-18 at 11 43 17 PM" src="https://github.com/user-attachments/assets/1342cca6-6176-4ac3-aac3-3323fa5f80e8" />

Newer Version (1.68.2): It's `buf lint`
<img width="892" height="753" alt="Screenshot 2026-04-18 at 11 43 31 PM" src="https://github.com/user-attachments/assets/4dcff961-ec7e-41af-80c7-149a54ec6e00" />