### PR TITLE
TEZ-4710: Update github workflow to help with Deprecation of Node 20 in github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
 name: Build CI with different platforms/configs
 
-on:
+'on':
   push:
     branches:
       - 'master'
   pull_request:
     branches:
       - 'master'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -31,8 +39,12 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java-version }}
-      - run: mvn clean install -DskipTests -Dmaven.javadoc.skip=true
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: >
+          mvn --batch-mode --no-transfer-progress clean install
+          -DskipTests -Dmaven.javadoc.skip=true


### PR DESCRIPTION
Check: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

<img width="1110" height="199" alt="Screenshot 2026-04-19 at 12 56 12 AM" src="https://github.com/user-attachments/assets/b4e807e2-c4e3-4c73-a67c-02f8b2a5f2e1" />
