### PR TITLE
TEZ-4712: Class-level SpotBugs exclusions for generated Protobuf classes

### DIFF
--- a/tez-api/findbugs-exclude.xml
+++ b/tez-api/findbugs-exclude.xml
@@ -14,57 +14,15 @@
 <FindBugsFilter>
 
   <Match>
-    <Class name="~org\.apache\.tez\.dag\.api\.client\.rpc\.DAGClientAMProtocolRPC\$.*Proto"/>
-    <Field name="unknownFields"/>
-    <Bug pattern="SE_BAD_FIELD"/>
+    <Class name="~org\.apache\.tez\.dag\.api\.client\.rpc\.DAGClientAMProtocolRPC.*"/>
   </Match>
 
   <Match>
-    <Class name="~org\.apache\.tez\.dag\.api\.records\.DAGProtos\$.*"/>
-    <Field name="unknownFields"/>
-    <Bug pattern="SE_BAD_FIELD"/>
+    <Class name="~org\.apache\.tez\.dag\.api\.records\.DAGProtos.*"/>
   </Match>
 
   <Match>
-    <Class name="~org\.apache\.tez\.runtime\.api\.events\.EventProtos\$.*Proto"/>
-    <Field name="unknownFields"/>
-    <Bug pattern="SE_BAD_FIELD"/>
-  </Match>
-
-  <Match>
-    <Class name="~org\.apache\.tez.dag\.api\.client\.rpc\.DAGClientAMProtocolRPC\$.*Proto"/>
-    <Field name="PARSER"/>
-    <Bug pattern="MS_SHOULD_BE_FINAL"/>
-  </Match>
-
-  <Match>
-    <Class name="~org\.apache\.tez\.dag\.api\.records\.DAGProtos\$.*"/>
-    <Field name="PARSER"/>
-    <Bug pattern="MS_SHOULD_BE_FINAL"/>
-  </Match>
-
-  <Match>
-    <Class name="~org\.apache\.tez\.runtime\.api\.events\.EventProtos\$*.*Proto"/>
-    <Field name="PARSER"/>
-    <Bug pattern="MS_SHOULD_BE_FINAL"/>
-  </Match>
-
-  <Match>
-    <Class name="~org\.apache\.tez\.dag\.api\.client\.rpc\.DAGClientAMProtocolRPC\$.*Proto\$Builder"/>
-    <Method name="maybeForceBuilderInitialization"/>
-    <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
-  </Match>
-
-  <Match>
-    <Class name="~org\.apache\.tez\.dag\.api\.records\.DAGProtos\$.*\$Builder"/>
-    <Method name="maybeForceBuilderInitialization"/>
-    <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
-  </Match>
-
-  <Match>
-    <Class name="~org\.apache\.tez\.runtime\.api\.events\.EventProtos\$*.*Proto\$Builder"/>
-    <Method name="maybeForceBuilderInitialization"/>
-    <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
+    <Class name="~org\.apache\.tez\.runtime\.api\.events\.EventProtos.*"/>
   </Match>
 
   <Match>

--- a/tez-dag/findbugs-exclude.xml
+++ b/tez-dag/findbugs-exclude.xml
@@ -25,21 +25,7 @@
   </Match>
 
   <Match>
-    <Class name="~org\.apache\.tez\.dag\.recovery\.records\.RecoveryProtos\$.*Proto"/>
-    <Field name="unknownFields"/>
-    <Bug pattern="SE_BAD_FIELD"/>
-  </Match>
-
-  <Match>
-    <Class name="~org\.apache\.tez\.dag\.recovery\.records\.RecoveryProtos\$.*Proto"/>
-    <Field name="PARSER"/>
-    <Bug pattern="MS_SHOULD_BE_FINAL"/>
-  </Match>
-
-  <Match>
-    <Class name="~org\.apache\.tez\.dag\.recovery\.records\.RecoveryProtos\$.*Proto\$Builder"/>
-    <Method name="maybeForceBuilderInitialization"/>
-    <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
+    <Class name="~org\.apache\.tez\.dag\.recovery\.records\.RecoveryProtos.*"/>
   </Match>
 
   <Match>

--- a/tez-mapreduce/findbugs-exclude.xml
+++ b/tez-mapreduce/findbugs-exclude.xml
@@ -14,21 +14,7 @@
 <FindBugsFilter>
 
   <Match>
-    <Class name="~org\.apache\.tez\.mapreduce\.protos\.MRRuntimeProtos\$.*Proto"/>
-    <Field name="unknownFields"/>
-    <Bug pattern="SE_BAD_FIELD"/>
-  </Match>
-
-  <Match>
-    <Class name="~org\.apache\.tez\.mapreduce\.protos\.MRRuntimeProtos\$.*Proto"/>
-    <Field name="PARSER"/>
-    <Bug pattern="MS_SHOULD_BE_FINAL"/>
-  </Match>
-
-  <Match>
-    <Class name="org.apache.tez.mapreduce.protos.MRRuntimeProtos$MRSplitProto$Builder"/>
-    <Method name="maybeForceBuilderInitialization"/>
-    <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
+    <Class name="~org\.apache\.tez\.mapreduce\.protos\.MRRuntimeProtos.*"/>
   </Match>
 
   <Match>

--- a/tez-runtime-internals/findbugs-exclude.xml
+++ b/tez-runtime-internals/findbugs-exclude.xml
@@ -40,21 +40,7 @@
   </Match>
 
   <Match>
-    <Class name="~org\.apache\.tez\.runtime\.internals\.api\.events\.SystemEventProtos\$.*Proto" />
-    <Field name="PARSER"/>
-    <Bug pattern="MS_SHOULD_BE_FINAL"/>
-  </Match>
-
-  <Match>
-    <Class name="~org\.apache\.tez\.runtime\.internals\.api\.events\.SystemEventProtos\$.*Proto" />
-    <Field name="unknownFields"/>
-    <Bug pattern="SE_BAD_FIELD"/>
-  </Match>
-
-  <Match>
-    <Class name="~org\.apache\.tez\.runtime\.internals\.api\.events\.SystemEventProtos\$.*Proto\$Builder" />
-    <Method name="maybeForceBuilderInitialization"/>
-    <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
+    <Class name="~org\.apache\.tez\.runtime\.internals\.api\.events\.SystemEventProtos.*" />
   </Match>
 
   <Match>

--- a/tez-runtime-library/findbugs-exclude.xml
+++ b/tez-runtime-library/findbugs-exclude.xml
@@ -93,21 +93,15 @@
   </Match>
 
   <Match>
-    <Class name="~org\.apache\.tez\.runtime\.library\.shuffle\.impl\.ShuffleUserPayloads\$.*Proto"/>
-    <Field name="PARSER"/>
-    <Bug pattern="MS_SHOULD_BE_FINAL"/>
+    <Class name="~org\.apache\.tez\.runtime\.library\.shuffle\.impl\.ShuffleUserPayloads.*"/>
   </Match>
 
   <Match>
-    <Class name="~org\.apache\.tez\.runtime\.library\.shuffle\.impl\.ShuffleUserPayloads\$.*Proto"/>
-    <Field name="unknownFields"/>
-    <Bug pattern="SE_BAD_FIELD"/>
+    <Class name="~org\.apache\.tez\.runtime\.library\.cartesianproduct\.CartesianProductUserPayload.*"/>
   </Match>
 
   <Match>
-    <Class name="~org\.apache\.tez\.runtime\.library\.shuffle\.impl\.ShuffleUserPayloads\$.*Proto\$Builder"/>
-    <Method name="maybeForceBuilderInitialization"/>
-    <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
+    <Class name="~org\.apache\.tez\.dag\.library\.vertexmanager\.FairShuffleUserPayloads.*"/>
   </Match>
 
   <Match>
@@ -120,24 +114,6 @@
     <Class name="org.apache.tez.runtime.library.common.TezRuntimeUtils"/>
     <Method name="getHttpConnectionParams" params="org.apache.hadoop.conf.Configuration" return="org.apache.tez.http.HttpConnectionParams"/>
     <Bug pattern="DC_PARTIALLY_CONSTRUCTED"/>
-  </Match>
-
-  <Match>
-    <Class name="org.apache.tez.runtime.library.cartesianproduct.CartesianProductUserPayload$CartesianProductConfigProto"/>
-    <Field name="unknownFields"/>
-    <Bug pattern="SE_BAD_FIELD"/>
-  </Match>
-
-  <Match>
-    <Class name="org.apache.tez.runtime.library.cartesianproduct.CartesianProductUserPayload$CartesianProductConfigProto"/>
-    <Field name="PARSER"/>
-    <Bug pattern="MS_SHOULD_BE_FINAL"/>
-  </Match>
-
-  <Match>
-    <Class name="org.apache.tez.runtime.library.cartesianproduct.CartesianProductUserPayload$CartesianProductConfigProto$Builder"/>
-    <Method name="maybeForceBuilderInitialization"/>
-    <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
   </Match>
 
   <Match>
@@ -158,48 +134,6 @@
       <Field name="totalTasksToSchedule"/>
     </Or>
     <Bug pattern="IS2_INCONSISTENT_SYNC"/>
-  </Match>
-
-  <Match>
-    <Class name="org.apache.tez.dag.library.vertexmanager.FairShuffleUserPayloads$FairShuffleEdgeManagerConfigPayloadProto"/>
-    <Field name="unknownFields"/>
-    <Bug pattern="SE_BAD_FIELD"/>
-  </Match>
-
-  <Match>
-    <Class name="org.apache.tez.dag.library.vertexmanager.FairShuffleUserPayloads$FairShuffleEdgeManagerDestinationTaskPropProto"/>
-    <Field name="unknownFields"/>
-    <Bug pattern="SE_BAD_FIELD"/>
-  </Match>
-
-  <Match>
-    <Class name="org.apache.tez.dag.library.vertexmanager.FairShuffleUserPayloads$RangeProto"/>
-    <Field name="unknownFields"/>
-    <Bug pattern="SE_BAD_FIELD"/>
-  </Match>
-
-  <Match>
-    <Class name="org.apache.tez.dag.library.vertexmanager.FairShuffleUserPayloads$FairShuffleEdgeManagerConfigPayloadProto"/>
-    <Field name="PARSER"/>
-    <Bug pattern="MS_SHOULD_BE_FINAL"/>
-  </Match>
-
-  <Match> 
-    <Class name="org.apache.tez.dag.library.vertexmanager.FairShuffleUserPayloads$FairShuffleEdgeManagerDestinationTaskPropProto"/>
-    <Field name="PARSER"/>
-    <Bug pattern="MS_SHOULD_BE_FINAL"/>
-  </Match>
-
-  <Match>   
-    <Class name="org.apache.tez.dag.library.vertexmanager.FairShuffleUserPayloads$RangeProto"/>
-    <Field name="PARSER"/>
-    <Bug pattern="MS_SHOULD_BE_FINAL"/>
-  </Match>
-
-  <Match>
-    <Class name="org.apache.tez.dag.library.vertexmanager.FairShuffleUserPayloads$RangeProto$Builder"/>
-    <Method name="maybeForceBuilderInitialization"/>
-    <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
   </Match>
 
   <Match>


### PR DESCRIPTION
1. Consolidate specific SpotBugs exclusions into class-level regex matches in findbugs-exclude.xml files.
2. Generated code should not be manually modified to fix SpotBugs warnings.
3. This change removes redundant rules targeting individual fields (e.g., PARSER, unknownFields) and methods (e.g., maybeForceBuilderInitialization).