### PR TITLE
TEZ-4713: Sync 3rd party dependency with Hadoop-3.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
     <!--dependency versions in alphabetical order-->
     <asynchttpclient.version>2.12.4</asynchttpclient.version>
-    <bouncycastle.version>1.79</bouncycastle.version>
+    <bouncycastle.version>1.82</bouncycastle.version>
     <build-helper-maven-plugin.version>1.8</build-helper-maven-plugin.version>
     <buildnumber-maven-plugin.version>1.1</buildnumber-maven-plugin.version>
     <checkstyle.version>13.3.0</checkstyle.version>
@@ -80,16 +80,11 @@
     <spotbugs-maven-plugin.version>4.9.3.0</spotbugs-maven-plugin.version>
     <plexus-velocity.version>2.3.0</plexus-velocity.version>
     <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
-    <guava.version>32.0.1-jre</guava.version>
+    <guava.version>33.4.8-jre</guava.version>
     <hadoop.version>3.5.0</hadoop.version>
-    <!-- Align all Jackson modules with the version shipped by Hadoop 3.5.0 (2.18.6).
-         Importing jackson-bom in dependencyManagement ensures any transitive dependency
-         (e.g. avro) that pulls an older jackson-core is automatically overridden.
-         This is the Jackson project's recommended approach for version alignment. -->
     <jackson.version>2.18.6</jackson.version>
     <jersey.version>2.46</jersey.version>
     <jettison.version>1.5.4</jettison.version>
-    <jsr305.version>3.0.0</jsr305.version>
     <junit.version>4.13.2</junit.version>
     <junit.jupiter.version>5.9.3</junit.jupiter.version>
     <leveldbjni-all.version>1.8</leveldbjni-all.version>
@@ -101,8 +96,9 @@
     <protobuf.version>3.25.5</protobuf.version>
     <protoc-jar-maven-plugin.version>3.11.4</protoc-jar-maven-plugin.version>
     <protoc.path>${env.PROTOC_PATH}</protoc.path>
+    <reload4j.version>1.2.22</reload4j.version>
     <restrict-imports.enforcer.version>3.0.0</restrict-imports.enforcer.version>
-    <roaringbitmap.version>1.2.1</roaringbitmap.version>
+    <roaringbitmap.version>1.3.0</roaringbitmap.version>
     <scm.url>scm:git:https://gitbox.apache.org/repos/asf/tez.git</scm.url>
     <servlet-api.version>4.0.4</servlet-api.version>
     <slf4j.version>1.7.36</slf4j.version>
@@ -159,11 +155,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Import jackson-bom to enforce a consistent Jackson version across all
-           transitive sources. avro 1.11.5 (via hadoop-common/mapreduce-client-common)
-           pulls in jackson-core 2.14.3 which lacks BufferRecycler.releaseToPool()
-           required by Jersey 2.46 in Hadoop 3.5.0+. The BOM overrides ALL transitive
-           jackson versions without needing per-library exclusions -->
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
@@ -300,6 +291,11 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.reload4j</groupId>
+        <artifactId>reload4j</artifactId>
+        <version>${reload4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.asynchttpclient</groupId>


### PR DESCRIPTION
- Update BouncyCastle to 1.82
- Update Guava to 33.4.8-jre
- Update RoaringBitmap to 1.3.0
- Add Jackson 2.18.6 and jackson-bom -- Already added in hadoop-3.5.0 #474 
- Add Reload4j 1.2.22
- Remove jsr305 dependency version