### PR TITLE
TEZ-4719: Move to Junit6

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[codespell]
+ignore-words-list = thirdparty,afterall,AfterAll

--- a/hadoop-shim/pom.xml
+++ b/hadoop-shim/pom.xml
@@ -34,8 +34,8 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-     <groupId>junit</groupId>
-     <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hadoop-shim/src/test/java/org/apache/tez/hadoop/shim/TestHadoopShimsLoader.java
+++ b/hadoop-shim/src/test/java/org/apache/tez/hadoop/shim/TestHadoopShimsLoader.java
@@ -18,11 +18,15 @@
  */
 package org.apache.tez.hadoop.shim;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.hadoop.shim.DummyShimProvider.DummyShim;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 public class TestHadoopShimsLoader {
 
@@ -30,8 +34,8 @@ public class TestHadoopShimsLoader {
   public void testBasicLoader() {
     HadoopShimsLoader loader = new HadoopShimsLoader(new Configuration(false));
     HadoopShim shim = loader.getHadoopShim();
-    Assert.assertNotNull(shim);
-    Assert.assertEquals(DefaultHadoopShim.class, shim.getClass());
+    assertNotNull(shim);
+    assertEquals(DefaultHadoopShim.class, shim.getClass());
   }
 
   @Test
@@ -40,16 +44,19 @@ public class TestHadoopShimsLoader {
     conf.set(HadoopShimsLoader.TEZ_HADOOP_SHIM_PROVIDER_CLASS, DummyShimProvider.class.getName());
     HadoopShimsLoader loader = new HadoopShimsLoader(conf, true);
     HadoopShim shim = loader.getHadoopShim();
-    Assert.assertNotNull(shim);
-    Assert.assertEquals(DummyShim.class, shim.getClass());
+    assertNotNull(shim);
+    assertEquals(DummyShim.class, shim.getClass());
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testInvalidOverride() {
     Configuration conf = new Configuration(false);
     conf.set(HadoopShimsLoader.TEZ_HADOOP_SHIM_PROVIDER_CLASS, "org.apache.tez.foo");
-    HadoopShimsLoader loader = new HadoopShimsLoader(conf, true);
-    HadoopShim shim = loader.getHadoopShim();
+    assertThrows(
+        RuntimeException.class,
+        () -> {
+          HadoopShimsLoader loader = new HadoopShimsLoader(conf, true);
+          HadoopShim shim = loader.getHadoopShim();
+        });
   }
-
 }

--- a/hadoop-shim/src/test/java/org/apache/tez/hadoop/shim/TestHadoopShimsLoader.java
+++ b/hadoop-shim/src/test/java/org/apache/tez/hadoop/shim/TestHadoopShimsLoader.java
@@ -27,7 +27,6 @@ import org.apache.tez.hadoop.shim.DummyShimProvider.DummyShim;
 
 import org.junit.jupiter.api.Test;
 
-
 public class TestHadoopShimsLoader {
 
   @Test
@@ -52,11 +51,9 @@ public class TestHadoopShimsLoader {
   public void testInvalidOverride() {
     Configuration conf = new Configuration(false);
     conf.set(HadoopShimsLoader.TEZ_HADOOP_SHIM_PROVIDER_CLASS, "org.apache.tez.foo");
-    assertThrows(
-        RuntimeException.class,
-        () -> {
-          HadoopShimsLoader loader = new HadoopShimsLoader(conf, true);
-          HadoopShim shim = loader.getHadoopShim();
-        });
+    assertThrows(RuntimeException.class, () -> {
+      HadoopShimsLoader loader = new HadoopShimsLoader(conf, true);
+      HadoopShim shim = loader.getHadoopShim();
+    });
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,7 @@
     <jackson.version>2.18.6</jackson.version>
     <jersey.version>2.46</jersey.version>
     <jettison.version>1.5.4</jettison.version>
-    <junit.version>4.13.2</junit.version>
-    <junit.jupiter.version>5.9.3</junit.jupiter.version>
+    <junit.version>6.1.0</junit.version>
     <leveldbjni.group>org.fusesource.leveldbjni</leveldbjni.group>
     <leveldb.version>0.12</leveldb.version>
     <leveldbjni-all.version>1.8</leveldbjni-all.version>
@@ -629,8 +628,8 @@
         <version>${hadoop.version}</version>
         <exclusions>
           <exclusion>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
           </exclusion>
           <exclusion>
             <groupId>com.google.inject</groupId>
@@ -891,21 +890,9 @@
         <version>${commons-cli.version}</version>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${junit.jupiter.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>${junit.jupiter.version}</version>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,10 @@
         <version>${pig.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>*</artifactId>
           </exclusion>
@@ -627,10 +631,6 @@
         <artifactId>hadoop-mapreduce-client-core</artifactId>
         <version>${hadoop.version}</version>
         <exclusions>
-          <exclusion>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
@@ -1273,6 +1273,12 @@
                     <bannedImport>org.codehaus.jackson.**</bannedImport>
                   </bannedImports>
                 </RestrictImports>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>junit:junit</exclude>
+                  </excludes>
+                  <message>JUnit 4 is not allowed. Use JUnit 6 (junit-jupiter) instead.</message>
+                </bannedDependencies>
               </rules>
             </configuration>
           </execution>

--- a/tez-api/pom.xml
+++ b/tez-api/pom.xml
@@ -90,8 +90,8 @@
      <artifactId>protobuf-java</artifactId>
     </dependency>
     <dependency>
-     <groupId>junit</groupId>
-     <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>

--- a/tez-api/src/test/java/org/apache/tez/client/TestTezClient.java
+++ b/tez-api/src/test/java/org/apache/tez/client/TestTezClient.java
@@ -18,12 +18,14 @@
  */
 package org.apache.tez.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeast;
@@ -99,9 +101,8 @@ import com.google.common.collect.Maps;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 public class TestTezClient {
@@ -211,27 +212,36 @@ public class TestTezClient {
     return client;
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezClientApp() throws Exception {
     testTezClient(false, true, "testTezClientApp");
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezClientSession() throws Exception {
     testTezClient(true, true, "testTezClientSession");
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezClientReconnect() throws Exception {
     testTezClientReconnect(true);
   }
 
-  @Test (timeout = 5000, expected = IllegalStateException.class)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezClientReconnectNoSession() throws Exception {
-    testTezClientReconnect(false);
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          testTezClientReconnect(false);
+        });
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezClientSessionLargeDAGPlan() throws Exception {
     // request size is within threshold of being serialized
     _testTezClientSessionLargeDAGPlan(10*1024*1024, 10, 10, false);
@@ -294,7 +304,8 @@ public class TestTezClient {
     }
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetClient() throws Exception {
     /* BEGIN first TezClient usage without calling stop() */
     TezClientForTest client = testTezClient(true, false, "testGetClient");
@@ -354,7 +365,7 @@ public class TestTezClient {
     if (isSession) {
       verify(client.mockYarnClient, times(1)).submitApplication(captor.capture());
       ApplicationSubmissionContext context = captor.getValue();
-      Assert.assertEquals(3, context.getAMContainerSpec().getLocalResources().size());
+      assertEquals(3, context.getAMContainerSpec().getLocalResources().size());
       assertTrue(context.getAMContainerSpec().getLocalResources().containsKey(
           TezConstants.TEZ_AM_LOCAL_RESOURCES_PB_FILE_NAME));
       assertTrue(context.getAMContainerSpec().getLocalResources().containsKey(
@@ -387,7 +398,7 @@ public class TestTezClient {
     } else {
       verify(client.mockYarnClient, times(1)).submitApplication(captor.capture());
       ApplicationSubmissionContext context = captor.getValue();
-      Assert.assertEquals(4, context.getAMContainerSpec().getLocalResources().size());
+      assertEquals(4, context.getAMContainerSpec().getLocalResources().size());
       assertTrue(context.getAMContainerSpec().getLocalResources().containsKey(
           TezConstants.TEZ_AM_LOCAL_RESOURCES_PB_FILE_NAME));
       assertTrue(context.getAMContainerSpec().getLocalResources().containsKey(
@@ -424,8 +435,8 @@ public class TestTezClient {
       ArgumentCaptor<SubmitDAGRequestProto> captor1 = ArgumentCaptor.forClass(SubmitDAGRequestProto.class);
       verify(client.sessionAmProxy, times(2)).submitDAG(any(), captor1.capture());
       SubmitDAGRequestProto proto = captor1.getValue();
-      Assert.assertEquals(1, proto.getAdditionalAmResources().getLocalResourcesCount());
-      Assert.assertEquals(lrName2, proto.getAdditionalAmResources().getLocalResources(0).getName());
+      assertEquals(1, proto.getAdditionalAmResources().getLocalResourcesCount());
+      assertEquals(lrName2, proto.getAdditionalAmResources().getLocalResources(0).getName());
     } else {
       // new app master
       assertTrue(dagClient.getExecutionContext().contains(appId2.toString()));
@@ -433,7 +444,7 @@ public class TestTezClient {
       verify(client.mockYarnClient, times(2)).submitApplication(captor.capture());
       // additional resource is added
       ApplicationSubmissionContext context = captor.getValue();
-      Assert.assertEquals(5, context.getAMContainerSpec().getLocalResources().size());
+      assertEquals(5, context.getAMContainerSpec().getLocalResources().size());
       assertTrue(context.getAMContainerSpec().getLocalResources().containsKey(
           TezConstants.TEZ_AM_LOCAL_RESOURCES_PB_FILE_NAME));
       assertTrue(context.getAMContainerSpec().getLocalResources().containsKey(
@@ -482,7 +493,7 @@ public class TestTezClient {
     if (isSession) {
       verify(client.mockYarnClient, times(1)).submitApplication(captor.capture());
       ApplicationSubmissionContext context = captor.getValue();
-      Assert.assertEquals(3, context.getAMContainerSpec().getLocalResources().size());
+      assertEquals(3, context.getAMContainerSpec().getLocalResources().size());
       assertTrue(context.getAMContainerSpec().getLocalResources().containsKey(
               TezConstants.TEZ_AM_LOCAL_RESOURCES_PB_FILE_NAME));
       assertTrue(context.getAMContainerSpec().getLocalResources().containsKey(
@@ -550,7 +561,8 @@ public class TestTezClient {
     client2.stop();
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPreWarm() throws Exception {
     TezClientForTest client = configureAndCreateTezClient();
     client.start();
@@ -575,7 +587,8 @@ public class TestTezClient {
   }
 
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPreWarmCloseStuck() throws Exception {
     TezClientForTest client = configureAndCreateTezClient();
     client.setPrewarmTimeoutMs(10L); // Don't wait too long.
@@ -604,7 +617,8 @@ public class TestTezClient {
                   .setSucceededTaskCount(1).setTotalTaskCount(1).build()).build()).build());
   }
 
-  @Test (timeout=30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testPreWarmWithTimeout() throws Exception {
     long startTime = 0 , endTime = 0;
     TezClientForTest client = configureAndCreateTezClient();
@@ -632,12 +646,11 @@ public class TestTezClient {
       fail("PreWarm should have encountered an Exception!");
     } catch (SessionNotReady te) {
       endTime = Time.monotonicNow();
-      assertTrue("Time taken is not as expected",
-          (endTime - startTime) > timeout);
+      assertTrue((endTime - startTime) > timeout, "Time taken is not as expected");
       verify(spyClient, times(0)).submitDAG(any());
-      Assert.assertTrue("Unexpected Exception message: " + te.getMessage(),
-          te.getMessage().contains("Tez AM not ready"));
-
+      assertTrue(
+          te.getMessage().contains("Tez AM not ready"),
+          "Unexpected Exception message: " + te.getMessage());
     }
 
     when(
@@ -650,8 +663,7 @@ public class TestTezClient {
       startTime = Time.monotonicNow();
       spyClient.preWarm(vertex, timeout, TimeUnit.MILLISECONDS);
       endTime = Time.monotonicNow();
-      assertTrue("Time taken is not as expected",
-          (endTime - startTime) <= timeout);
+      assertTrue((endTime - startTime) <= timeout, "Time taken is not as expected");
       verify(spyClient, times(1)).submitDAG(any());
     } catch (TezException te) {
       fail("PreWarm should have succeeded!");
@@ -685,15 +697,15 @@ public class TestTezClient {
     startTime = Time.monotonicNow();
     spyClient.preWarm(vertex, timeout, TimeUnit.MILLISECONDS);
     endTime = Time.monotonicNow();
-    assertTrue("Time taken is not as expected",
-        (endTime - startTime) <= timeout);
+    assertTrue((endTime - startTime) <= timeout, "Time taken is not as expected");
     verify(spyClient, times(2)).submitDAG(any());
     setClientToReportStoppedDags(client);
     spyClient.stop();
     client.stop();
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleSubmissions() throws Exception {
     testMultipleSubmissionsJob(false);
     testMultipleSubmissionsJob(true);
@@ -735,7 +747,8 @@ public class TestTezClient {
     client2.stop();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWaitTillReady_Interrupt() throws Exception {
     final TezClientForTest client = configureAndCreateTezClient();
     client.start();
@@ -757,11 +770,12 @@ public class TestTezClient {
     thread.join(250);
     thread.interrupt();
     thread.join();
-    Assert.assertThat(exceptionReference.get(), CoreMatchers.instanceOf(InterruptedException.class));
+    assertInstanceOf(InterruptedException.class, exceptionReference.get());
     client.stop();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWaitTillReadyAppFailed() throws Exception {
     final TezClientForTest client = configureAndCreateTezClient();
     client.start();
@@ -779,7 +793,8 @@ public class TestTezClient {
     client.stop();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWaitTillReadyAppFailedNoDiagnostics() throws Exception {
     final TezClientForTest client = configureAndCreateTezClient();
     client.start();
@@ -794,7 +809,8 @@ public class TestTezClient {
     client.stop();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSubmitDAGAppFailed() throws Exception {
     final TezClientForTest client = configureAndCreateTezClient();
     client.start();
@@ -819,7 +835,8 @@ public class TestTezClient {
     client.stop();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezClientCounterLimits() throws YarnException, IOException, ServiceException {
     Limits.reset();
     int defaultCounterLimit = TezConfiguration.TEZ_COUNTERS_MAX_DEFAULT;
@@ -843,7 +860,8 @@ public class TestTezClient {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testClientBuilder() {
     TezConfiguration tezConfWitSession = new TezConfiguration();
     tezConfWitSession.setBoolean(TezConfiguration.TEZ_AM_SESSION_MODE, true);
@@ -914,7 +932,8 @@ public class TestTezClient {
     // No-op class
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidJavaOptsChecker1() throws YarnException, IOException, ServiceException,
       TezException {
     TezConfiguration conf = new TezConfiguration();
@@ -923,7 +942,8 @@ public class TestTezClient {
     client.start();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidJavaOptsChecker2() throws YarnException, IOException, ServiceException,
       TezException {
     TezConfiguration conf = new TezConfiguration();
@@ -932,7 +952,8 @@ public class TestTezClient {
     client.start();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testStopRetriesUntilTerminalState() throws Exception {
     TezConfiguration conf = new TezConfiguration();
     conf.setBoolean(TezConfiguration.TEZ_CLIENT_ASYNCHRONOUS_STOP, false);
@@ -944,12 +965,13 @@ public class TestTezClient {
     try {
       client.stop();
     } catch (Exception e) {
-      Assert.fail("Expected ApplicationNotFoundException");
+      fail("Expected ApplicationNotFoundException");
     }
     verify(client.mockYarnClient, atLeast(2)).getApplicationReport(client.mockAppId);
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testStopRetriesUntilTimeout() throws Exception {
     TezConfiguration conf = new TezConfiguration();
     conf.setBoolean(TezConfiguration.TEZ_CLIENT_ASYNCHRONOUS_STOP, false);
@@ -962,28 +984,30 @@ public class TestTezClient {
     try {
       client.stop();
     } catch (Exception e) {
-      Assert.fail("Stop should complete without exception: " + e);
+      fail("Stop should complete without exception: " + e);
     }
     long end = System.currentTimeMillis();
     verify(client.mockYarnClient, atLeast(2)).getApplicationReport(client.mockAppId);
-    Assert.assertTrue("Stop ended before timeout", end - start > HARD_KILL_TIMEOUT);
+    assertTrue(end - start > HARD_KILL_TIMEOUT, "Stop ended before timeout");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSubmitHostPopulated() throws YarnException, IOException, ServiceException, TezException {
 
     TezConfiguration conf = new TezConfiguration();
     configureAndCreateTezClient(conf);
     InetAddress ip = InetAddress.getLocalHost();
     if (ip != null) {
-      Assert.assertEquals(ip.getCanonicalHostName(), conf.get(TezConfigurationConstants.TEZ_SUBMIT_HOST));
-      Assert.assertEquals(ip.getHostAddress(), conf.get(TezConfigurationConstants.TEZ_SUBMIT_HOST_ADDRESS));
+      assertEquals(ip.getCanonicalHostName(), conf.get(TezConfigurationConstants.TEZ_SUBMIT_HOST));
+      assertEquals(ip.getHostAddress(), conf.get(TezConfigurationConstants.TEZ_SUBMIT_HOST_ADDRESS));
     } else {
-      Assert.fail("Failed to retrieve local host information");
+      fail("Failed to retrieve local host information");
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testClientResubmit() throws Exception {
     TezClientForTest client = configureAndCreateTezClient(null, true, null);
     client.start();
@@ -1002,15 +1026,16 @@ public class TestTezClient {
     for (int i = 0; i < 3; ++i) {
       try {
         client.submitDAG(dag);
-        Assert.fail("Expected TezUncheckedException here.");
+        fail("Expected TezUncheckedException here.");
       } catch(TezUncheckedException ex) {
-        Assert.assertTrue(ex.getMessage().contains("Invalid/conflicting GC options found"));
+        assertTrue(ex.getMessage().contains("Invalid/conflicting GC options found"));
       }
     }
     client.stop();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testMissingYarnAppStatus() throws Exception {
     // verify an app not found exception is thrown when YARN reports a null app status
     ApplicationId appId1 = ApplicationId.newInstance(0, 1);
@@ -1029,7 +1054,8 @@ public class TestTezClient {
     }
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testAMClientHeartbeat() throws Exception {
     TezConfiguration conf = new TezConfiguration();
     conf.setInt(TezConfiguration.TEZ_AM_CLIENT_HEARTBEAT_TIMEOUT_SECS, 10);
@@ -1059,7 +1085,8 @@ public class TestTezClient {
     verify(client2.sessionAmProxy, times(0)).getAMStatus(any(), any());
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testAMHeartbeatFailOnGetAMProxy_AppNotStarted() throws Exception {
     int amHeartBeatTimeoutSecs = 3;
     TezConfiguration conf = new TezConfiguration();
@@ -1075,7 +1102,8 @@ public class TestTezClient {
     assertFalse(client.getAMKeepAliveService().isTerminated());
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testAMHeartbeatFailOnGetAMProxy_AppFailed() throws Exception {
     int amHeartBeatTimeoutSecs = 3;
     TezConfiguration conf = new TezConfiguration();
@@ -1091,7 +1119,8 @@ public class TestTezClient {
     assertTrue(client.getAMKeepAliveService().isTerminated());
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testAMHeartbeatFailOnGetAMStatus() throws Exception {
     int amHeartBeatTimeoutSecs = 3;
     TezConfiguration conf = new TezConfiguration();
@@ -1109,7 +1138,8 @@ public class TestTezClient {
   }
 
   //See TEZ-3874
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testYarnZkDeprecatedConf() {
     Configuration conf = new Configuration(false);
     String val = "hostname:2181";

--- a/tez-api/src/test/java/org/apache/tez/client/TestTezClient.java
+++ b/tez-api/src/test/java/org/apache/tez/client/TestTezClient.java
@@ -232,12 +232,8 @@ public class TestTezClient {
 
   @Test
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testTezClientReconnectNoSession() throws Exception {
-    assertThrows(
-        IllegalStateException.class,
-        () -> {
-          testTezClientReconnect(false);
-        });
+  public void testTezClientReconnectNoSession() {
+    assertThrows(IllegalStateException.class, () -> testTezClientReconnect(false));
   }
 
   @Test
@@ -648,9 +644,7 @@ public class TestTezClient {
       endTime = Time.monotonicNow();
       assertTrue((endTime - startTime) > timeout, "Time taken is not as expected");
       verify(spyClient, times(0)).submitDAG(any());
-      assertTrue(
-          te.getMessage().contains("Tez AM not ready"),
-          "Unexpected Exception message: " + te.getMessage());
+      assertTrue(te.getMessage().contains("Tez AM not ready"), "Unexpected Exception message: " + te.getMessage());
     }
 
     when(

--- a/tez-api/src/test/java/org/apache/tez/client/TestTezClientUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/client/TestTezClientUtils.java
@@ -129,15 +129,13 @@ public class TestTezClientUtils {
 
   @Test
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void validateSetTezJarLocalResourcesDefinedNonExistingDirectory() throws Exception {
-
+  public void validateSetTezJarLocalResourcesDefinedNonExistingDirectory() {
     TezConfiguration conf = new TezConfiguration();
     conf.set(TezConfiguration.TEZ_LIB_URIS, "file:///foo");
     Credentials credentials = new Credentials();
-    Map<String,LocalResource> resources = new HashMap<String, LocalResource>();
-    assertThrows(FileNotFoundException.class, () -> {
-      TezClientUtils.setupTezJarsLocalResources(conf, credentials, resources);
-    });
+    Map<String, LocalResource> resources = new HashMap<>();
+    assertThrows(FileNotFoundException.class,
+        () -> TezClientUtils.setupTezJarsLocalResources(conf, credentials, resources));
   }
 
   private static List<URL> getDirAndFileURL() throws MalformedURLException {
@@ -603,8 +601,7 @@ public class TestTezClientUtils {
     String taskOptsConstructed = TezClientUtils.addDefaultsToTaskLaunchCmdOpts("", tezConf);
     expected =
         TezConfiguration.TEZ_TASK_LAUNCH_CLUSTER_DEFAULT_CMD_OPTS_DEFAULT + " " + taskCommandOpts;
-    assertTrue(
-        taskOptsConstructed.startsWith(expected),
+    assertTrue(taskOptsConstructed.startsWith(expected),
         "Did not find Expected prefix: [" + expected + "] in string [" + taskOptsConstructed + "]");
 
     // Test2: Setup cluster-default command opts explicitly
@@ -614,8 +611,7 @@ public class TestTezClientUtils {
         TezConfiguration.TEZ_TASK_LAUNCH_CLUSTER_DEFAULT_CMD_OPTS, taskClusterDefaultCommandOpts);
     taskOptsConstructed = TezClientUtils.addDefaultsToTaskLaunchCmdOpts("", tezConf);
     expected = taskClusterDefaultCommandOpts + " " + taskCommandOpts;
-    assertTrue(
-        taskOptsConstructed.startsWith(expected),
+    assertTrue(taskOptsConstructed.startsWith(expected),
         "Did not find Expected prefix: [" + expected + "] in string [" + taskOptsConstructed + "]");
 
     // Test3: Don't setup Xmx explicitly
@@ -624,8 +620,7 @@ public class TestTezClientUtils {
     taskOptsConstructed =
         TezClientUtils.addDefaultsToTaskLaunchCmdOpts("", tezConf);
     expected = taskClusterDefaultCommandOpts + " " + taskCommandOpts;
-    assertTrue(
-        taskOptsConstructed.startsWith(expected),
+    assertTrue(taskOptsConstructed.startsWith(expected),
         "Did not find Expected prefix: [" + expected + "] in string [" + taskOptsConstructed + "]");
 
     // Test4: Pass in a dag-configured value.
@@ -634,8 +629,7 @@ public class TestTezClientUtils {
         TezClientUtils.addDefaultsToTaskLaunchCmdOpts(programmaticTaskOpts, tezConf);
     // Container logging is always added at the end, if it's required.
     expected = taskClusterDefaultCommandOpts + " " + taskCommandOpts + " " + programmaticTaskOpts;
-    assertTrue(
-        taskOptsConstructed.startsWith(expected),
+    assertTrue(taskOptsConstructed.startsWith(expected),
         "Did not find Expected prefix: [" + expected + "] in string [" + taskOptsConstructed + "]");
   }
 
@@ -809,19 +803,13 @@ public class TestTezClientUtils {
       Map<String, LocalResource> lrMap = new HashMap<String, LocalResource>();
       TezClientUtils.setupTezJarsLocalResources(tezConf, new Credentials(), lrMap);
 
-      assertEquals(
-          LocalResourceVisibility.PUBLIC,
-          lrMap.get(publicFile.getName()).getVisibility(),
+      assertEquals(LocalResourceVisibility.PUBLIC, lrMap.get(publicFile.getName()).getVisibility(),
           publicFile.getName());
 
-      assertEquals(
-          LocalResourceVisibility.PRIVATE,
-          lrMap.get(privateFile.getName()).getVisibility(),
+      assertEquals(LocalResourceVisibility.PRIVATE, lrMap.get(privateFile.getName()).getVisibility(),
           privateFile.getName());
 
-      assertEquals(
-          LocalResourceVisibility.PRIVATE,
-          lrMap.get(publicFileInPrivateSubdir.getName()).getVisibility(),
+      assertEquals(LocalResourceVisibility.PRIVATE, lrMap.get(publicFileInPrivateSubdir.getName()).getVisibility(),
           publicFileInPrivateSubdir.getName());
 
       // test tar.gz
@@ -975,9 +963,7 @@ public class TestTezClientUtils {
     String vOpts = "";
     String opts = TezClientUtils.addDefaultsToTaskLaunchCmdOpts(vOpts, conf);
 
-    assertEquals(adminOpts + " "
-        + TezConfiguration.TEZ_TASK_LAUNCH_CMD_OPTS_DEFAULT + " " + vOpts,
-            opts);
+    assertEquals(adminOpts + " " + TezConfiguration.TEZ_TASK_LAUNCH_CMD_OPTS_DEFAULT + " " + vOpts, opts);
 
     vOpts = "foo";
     opts = TezClientUtils.addDefaultsToTaskLaunchCmdOpts(vOpts, conf);

--- a/tez-api/src/test/java/org/apache/tez/client/TestTezClientUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/client/TestTezClientUtils.java
@@ -18,11 +18,14 @@
  */
 package org.apache.tez.client;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -32,7 +35,6 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -40,6 +42,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -78,8 +81,8 @@ import org.apache.tez.dag.api.records.DAGProtos.ConfigurationProto;
 import org.apache.tez.dag.api.records.DAGProtos.PlanKeyValuePair;
 import org.apache.tez.serviceplugins.api.ServicePluginsDescriptor;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 /**
  *
  */
@@ -91,7 +94,8 @@ public class TestTezClientUtils {
   /**
    *
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void validateSetTezJarLocalResourcesNotDefined() throws Exception {
 
     TezConfiguration conf = new TezConfiguration(false);
@@ -99,40 +103,41 @@ public class TestTezClientUtils {
     try {
       Map<String,LocalResource> resources = new HashMap<String, LocalResource>();
       TezClientUtils.setupTezJarsLocalResources(conf, credentials, resources);
-      Assert.fail("Expected TezUncheckedException");
+      fail("Expected TezUncheckedException");
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains("Invalid configuration of tez jars"));
+      assertTrue(e.getMessage().contains("Invalid configuration of tez jars"));
     }
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void validateSetTezJarLocalResourcesDefinedButEmpty() throws Exception {
     File emptyDir = new File(TEST_ROOT_DIR, "emptyDir");
     emptyDir.deleteOnExit();
-    Assert.assertTrue(emptyDir.mkdirs());
+    assertTrue(emptyDir.mkdirs());
     TezConfiguration conf = new TezConfiguration();
     conf.set(TezConfiguration.TEZ_LIB_URIS, emptyDir.toURI().toURL().toString());
     Credentials credentials = new Credentials();
     try {
       Map<String,LocalResource> resources = new HashMap<String, LocalResource>();
       TezClientUtils.setupTezJarsLocalResources(conf, credentials, resources);
-      Assert.fail("Expected TezUncheckedException");
+      fail("Expected TezUncheckedException");
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains("No files found in locations"));
+      assertTrue(e.getMessage().contains("No files found in locations"));
     }
   }
 
-  /**
-   *
-   */
-  @Test(expected=FileNotFoundException.class, timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void validateSetTezJarLocalResourcesDefinedNonExistingDirectory() throws Exception {
 
     TezConfiguration conf = new TezConfiguration();
     conf.set(TezConfiguration.TEZ_LIB_URIS, "file:///foo");
     Credentials credentials = new Credentials();
     Map<String,LocalResource> resources = new HashMap<String, LocalResource>();
-    TezClientUtils.setupTezJarsLocalResources(conf, credentials, resources);
+    assertThrows(FileNotFoundException.class, () -> {
+      TezClientUtils.setupTezJarsLocalResources(conf, credentials, resources);
+    });
   }
 
   private static List<URL> getDirAndFileURL() throws MalformedURLException {
@@ -155,7 +160,8 @@ public class TestTezClientUtils {
     return urls;
   }
 
-  @Test (timeout=20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void validateSetTezJarLocalResourcesDefinedExistingDirectory() throws Exception {
     List<URL> cp = getDirAndFileURL();
     StringBuffer buffer = new StringBuffer();
@@ -169,7 +175,7 @@ public class TestTezClientUtils {
     Map<String, LocalResource> localizedMap = new HashMap<String, LocalResource>();
     boolean usingArchive = TezClientUtils.setupTezJarsLocalResources(conf, credentials,
         localizedMap);
-    Assert.assertFalse(usingArchive);
+    assertFalse(usingArchive);
     Set<String> resourceNames = localizedMap.keySet();
     boolean assertedDir = false;
     boolean assertedFile = false;
@@ -198,7 +204,8 @@ public class TestTezClientUtils {
    *
    * @throws Exception
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void validateSetTezJarLocalResourcesDefinedExistingDirectoryIgnored() throws Exception {
     List<URL> cp = getDirAndFileURL();
     StringBuffer buffer = new StringBuffer();
@@ -211,7 +218,7 @@ public class TestTezClientUtils {
     conf.setBoolean(TezConfiguration.TEZ_IGNORE_LIB_URIS, true);
     Credentials credentials = new Credentials();
     Map<String, LocalResource> localizedMap = new HashMap<String, LocalResource>();
-    Assert.assertFalse(TezClientUtils.setupTezJarsLocalResources(conf, credentials, localizedMap));
+    assertFalse(TezClientUtils.setupTezJarsLocalResources(conf, credentials, localizedMap));
     assertTrue(localizedMap.isEmpty());
   }
 
@@ -219,7 +226,8 @@ public class TestTezClientUtils {
    *
    * @throws Exception
    */
-  @Test (timeout=20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void validateSetTezJarLocalResourcesDefinedExistingDirectoryIgnoredSetToFalse() throws Exception {
     List<URL> cp = getDirAndFileURL();
     StringBuffer buffer = new StringBuffer();
@@ -232,7 +240,7 @@ public class TestTezClientUtils {
     conf.setBoolean(TezConfiguration.TEZ_IGNORE_LIB_URIS, false);
     Credentials credentials = new Credentials();
     Map<String, LocalResource> localizedMap = new HashMap<String, LocalResource>();
-    Assert.assertFalse(TezClientUtils.setupTezJarsLocalResources(conf, credentials, localizedMap));
+    assertFalse(TezClientUtils.setupTezJarsLocalResources(conf, credentials, localizedMap));
     assertFalse(localizedMap.isEmpty());
   }
 
@@ -240,7 +248,8 @@ public class TestTezClientUtils {
     /**
    *
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezDefaultFS() throws Exception {
     FileSystem localFs = FileSystem.getLocal(new Configuration());
     StringBuilder tezLibUris = new StringBuilder();
@@ -253,7 +262,7 @@ public class TestTezClientUtils {
 
     Path file = new Path(topDir, "file.jar");
 
-    Assert.assertTrue(localFs.createNewFile(file));
+    assertTrue(localFs.createNewFile(file));
     tezLibUris.append(localFs.makeQualified(file).toString());
 
     TezConfiguration conf = new TezConfiguration();
@@ -263,14 +272,15 @@ public class TestTezClientUtils {
     Map<String, LocalResource> localizedMap = new HashMap<String, LocalResource>();
     TezClientUtils.setupTezJarsLocalResources(conf, credentials, localizedMap);
 
-    Assert.assertTrue(localFs.delete(file, true));
-    Assert.assertTrue(localFs.delete(topDir, true));
+    assertTrue(localFs.delete(file, true));
+    assertTrue(localFs.delete(topDir, true));
   }
 
     /**
    *
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void validateSetTezJarLocalResourcesMultipleTarballs() throws Exception {
     FileSystem localFs = FileSystem.getLocal(new Configuration());
     StringBuilder tezLibUris = new StringBuilder();
@@ -285,8 +295,8 @@ public class TestTezClientUtils {
     Path tarFile1 = new Path(topDir, "f1.tar.gz");
     Path tarFile2 = new Path(topDir, "f2.tar.gz");
 
-    Assert.assertTrue(localFs.createNewFile(tarFile1));
-    Assert.assertTrue(localFs.createNewFile(tarFile2));
+    assertTrue(localFs.createNewFile(tarFile1));
+    assertTrue(localFs.createNewFile(tarFile2));
     tezLibUris.append(localFs.makeQualified(tarFile1).toString()).append("#tar1").append(",");
     tezLibUris.append(localFs.makeQualified(tarFile2).toString()).append("#tar2").append(",");
 
@@ -296,22 +306,23 @@ public class TestTezClientUtils {
     Map<String, LocalResource> localizedMap = new HashMap<String, LocalResource>();
     TezClientUtils.setupTezJarsLocalResources(conf, credentials, localizedMap);
     Set<String> resourceNames = localizedMap.keySet();
-    Assert.assertEquals(2, resourceNames.size());
-    Assert.assertTrue(resourceNames.contains("tar1"));
-    Assert.assertTrue(resourceNames.contains("tar2"));
-    Assert.assertFalse(resourceNames.contains("f1.tar.gz"));
-    Assert.assertFalse(resourceNames.contains("f2.tar.gz"));
+    assertEquals(2, resourceNames.size());
+    assertTrue(resourceNames.contains("tar1"));
+    assertTrue(resourceNames.contains("tar2"));
+    assertFalse(resourceNames.contains("f1.tar.gz"));
+    assertFalse(resourceNames.contains("f2.tar.gz"));
 
 
-    Assert.assertTrue(localFs.delete(tarFile1, true));
-    Assert.assertTrue(localFs.delete(tarFile2, true));
-    Assert.assertTrue(localFs.delete(topDir, true));
+    assertTrue(localFs.delete(tarFile1, true));
+    assertTrue(localFs.delete(tarFile2, true));
+    assertTrue(localFs.delete(topDir, true));
   }
 
     /**
    *
    */
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void validateSetTezJarLocalResourcesMixTarballAndJar() throws Exception {
     FileSystem localFs = FileSystem.getLocal(new Configuration());
     StringBuilder tezLibUris = new StringBuilder();
@@ -327,9 +338,9 @@ public class TestTezClientUtils {
     Path jarFile2 = new Path(topDir, "f2.jar");
     Path jarFile3 = new Path(topDir, "f3.jar");
 
-    Assert.assertTrue(localFs.createNewFile(tarFile1));
-    Assert.assertTrue(localFs.createNewFile(jarFile2));
-    Assert.assertTrue(localFs.createNewFile(jarFile3));
+    assertTrue(localFs.createNewFile(tarFile1));
+    assertTrue(localFs.createNewFile(jarFile2));
+    assertTrue(localFs.createNewFile(jarFile3));
 
     tezLibUris.append(localFs.makeQualified(topDir).toString()).append(",");
     tezLibUris.append(localFs.makeQualified(tarFile1).toString()).append("#tar1").append(",");
@@ -340,19 +351,20 @@ public class TestTezClientUtils {
     Map<String, LocalResource> localizedMap = new HashMap<String, LocalResource>();
     TezClientUtils.setupTezJarsLocalResources(conf, credentials, localizedMap);
     Set<String> resourceNames = localizedMap.keySet();
-    Assert.assertEquals(4, resourceNames.size());
-    Assert.assertTrue(resourceNames.contains("tar1"));
-    Assert.assertTrue(resourceNames.contains("f1.tar.gz"));
-    Assert.assertTrue(resourceNames.contains("f2.jar"));
-    Assert.assertTrue(resourceNames.contains("f3.jar"));
+    assertEquals(4, resourceNames.size());
+    assertTrue(resourceNames.contains("tar1"));
+    assertTrue(resourceNames.contains("f1.tar.gz"));
+    assertTrue(resourceNames.contains("f2.jar"));
+    assertTrue(resourceNames.contains("f3.jar"));
 
-    Assert.assertTrue(localFs.delete(tarFile1, true));
-    Assert.assertTrue(localFs.delete(jarFile2, true));
-    Assert.assertTrue(localFs.delete(jarFile3, true));
-    Assert.assertTrue(localFs.delete(topDir, true));
+    assertTrue(localFs.delete(tarFile1, true));
+    assertTrue(localFs.delete(jarFile2, true));
+    assertTrue(localFs.delete(jarFile3, true));
+    assertTrue(localFs.delete(topDir, true));
   }
 
-  @Test(timeout = 2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   // this test checks if the priority field is set properly in the
   // ApplicationSubmissionContext
   public void testAppSubmissionContextForPriority() throws Exception {
@@ -377,7 +389,8 @@ public class TestTezClientUtils {
     assertEquals(testpriority, appcontext.getPriority().getPriority());
   }
 
-  @Test(timeout=1000)
+  @Test
+  @Timeout(value = 1000, unit = TimeUnit.MILLISECONDS)
   // when tez config property for app priority not set,
   // tez should not set app priority and let YARN deal with it.
   public void testSetApplicationPriority() {
@@ -389,7 +402,8 @@ public class TestTezClientUtils {
     assertNull(appContext.getPriority());
   }
 
-  @Test(timeout=1000)
+  @Test
+  @Timeout(value = 1000, unit = TimeUnit.MILLISECONDS)
   public void testSetApplicationTags() {
     TezConfiguration conf = new TezConfiguration(false);
     conf.set(TezConfiguration.TEZ_APPLICATION_TAGS, "foo,bar");
@@ -404,7 +418,8 @@ public class TestTezClientUtils {
     assertTrue(appContext.getApplicationTags().contains("bar"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSessionTokenInAmClc() throws IOException, YarnException {
 
     TezConfiguration tezConf = new TezConfiguration();
@@ -438,10 +453,11 @@ public class TestTezClientUtils {
     Token<JobTokenIdentifier> jtSent = new Token<JobTokenIdentifier>();
     jtSent.readFields(dibb);
 
-    assertTrue(Arrays.equals(jobToken.getIdentifier(), jtSent.getIdentifier()));
+    assertArrayEquals(jobToken.getIdentifier(), jtSent.getIdentifier());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAMLoggingOptsSimple() throws IOException, YarnException {
 
     TezConfiguration tezConf = new TezConfiguration();
@@ -481,7 +497,8 @@ public class TestTezClientUtils {
     assertNull(logEnv);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAMLoggingOptsPerLogger() throws IOException, YarnException {
 
     TezConfiguration tezConf = new TezConfiguration();
@@ -523,7 +540,8 @@ public class TestTezClientUtils {
     assertEquals("org.apache.hadoop.ipc=DEBUG;org.apache.hadoop.security=DEBUG", logEnv);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAMCommandOpts() {
     Path tmpDir = new Path(Environment.PWD.$(),
         YarnConfiguration.DEFAULT_CONTAINER_TEMP_DIR);
@@ -573,7 +591,8 @@ public class TestTezClientUtils {
         + TezConfiguration.TEZ_AM_LAUNCH_CLUSTER_ADD_OPENS_DEFAULT, amOptsConstructed);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskCommandOpts() throws TezException {
     TezConfiguration tezConf = new TezConfiguration();
     String taskCommandOpts = "-Xmx 200m -Dtest.property";
@@ -585,8 +604,8 @@ public class TestTezClientUtils {
     expected =
         TezConfiguration.TEZ_TASK_LAUNCH_CLUSTER_DEFAULT_CMD_OPTS_DEFAULT + " " + taskCommandOpts;
     assertTrue(
-        "Did not find Expected prefix: [" + expected + "] in string [" + taskOptsConstructed +
-            "]", taskOptsConstructed.startsWith(expected));
+        taskOptsConstructed.startsWith(expected),
+        "Did not find Expected prefix: [" + expected + "] in string [" + taskOptsConstructed + "]");
 
     // Test2: Setup cluster-default command opts explicitly
     String taskClusterDefaultCommandOpts =
@@ -596,8 +615,8 @@ public class TestTezClientUtils {
     taskOptsConstructed = TezClientUtils.addDefaultsToTaskLaunchCmdOpts("", tezConf);
     expected = taskClusterDefaultCommandOpts + " " + taskCommandOpts;
     assertTrue(
-        "Did not find Expected prefix: [" + expected + "] in string [" + taskOptsConstructed +
-            "]", taskOptsConstructed.startsWith(expected));
+        taskOptsConstructed.startsWith(expected),
+        "Did not find Expected prefix: [" + expected + "] in string [" + taskOptsConstructed + "]");
 
     // Test3: Don't setup Xmx explicitly
     taskCommandOpts = "-Dtest.property";
@@ -606,8 +625,8 @@ public class TestTezClientUtils {
         TezClientUtils.addDefaultsToTaskLaunchCmdOpts("", tezConf);
     expected = taskClusterDefaultCommandOpts + " " + taskCommandOpts;
     assertTrue(
-        "Did not find Expected prefix: [" + expected + "] in string [" + taskOptsConstructed +
-            "]", taskOptsConstructed.startsWith(expected));
+        taskOptsConstructed.startsWith(expected),
+        "Did not find Expected prefix: [" + expected + "] in string [" + taskOptsConstructed + "]");
 
     // Test4: Pass in a dag-configured value.
     String programmaticTaskOpts = "-Dset.programatically=true -Djava.net.preferIPv4Stack=false";
@@ -616,72 +635,74 @@ public class TestTezClientUtils {
     // Container logging is always added at the end, if it's required.
     expected = taskClusterDefaultCommandOpts + " " + taskCommandOpts + " " + programmaticTaskOpts;
     assertTrue(
-        "Did not find Expected prefix: [" + expected + "] in string [" + taskOptsConstructed +
-            "]", taskOptsConstructed.startsWith(expected));
+        taskOptsConstructed.startsWith(expected),
+        "Did not find Expected prefix: [" + expected + "] in string [" + taskOptsConstructed + "]");
   }
 
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDefaultMemoryJavaOpts() {
     final double factor = 0.8;
     String origJavaOpts = "-Xmx";
     String javaOpts = TezClientUtils.maybeAddDefaultMemoryJavaOpts(origJavaOpts,
         Resource.newInstance(1000, 1), factor);
-    Assert.assertEquals(origJavaOpts, javaOpts);
+    assertEquals(origJavaOpts, javaOpts);
 
     origJavaOpts = "";
     javaOpts = TezClientUtils.maybeAddDefaultMemoryJavaOpts(origJavaOpts,
         Resource.newInstance(1000, 1), factor);
-    Assert.assertTrue(javaOpts.contains("-Xmx800m"));
+    assertTrue(javaOpts.contains("-Xmx800m"));
 
     origJavaOpts = "";
     javaOpts = TezClientUtils.maybeAddDefaultMemoryJavaOpts(origJavaOpts,
         Resource.newInstance(1, 1), factor);
-    Assert.assertTrue(javaOpts.contains("-Xmx1m"));
+    assertTrue(javaOpts.contains("-Xmx1m"));
 
     origJavaOpts = "";
     javaOpts = TezClientUtils.maybeAddDefaultMemoryJavaOpts(origJavaOpts,
         Resource.newInstance(-1, 1), factor);
-    Assert.assertEquals(origJavaOpts, javaOpts);
+    assertEquals(origJavaOpts, javaOpts);
 
     origJavaOpts = "";
     javaOpts = TezClientUtils.maybeAddDefaultMemoryJavaOpts(origJavaOpts,
         Resource.newInstance(355, 1), factor);
-    Assert.assertTrue(javaOpts.contains("-Xmx284m"));
+    assertTrue(javaOpts.contains("-Xmx284m"));
 
     origJavaOpts = " -Xms100m ";
     javaOpts = TezClientUtils.maybeAddDefaultMemoryJavaOpts(origJavaOpts,
         Resource.newInstance(355, 1), factor);
-    Assert.assertFalse(javaOpts.contains("-Xmx284m"));
-    Assert.assertTrue(javaOpts.contains("-Xms100m"));
+    assertFalse(javaOpts.contains("-Xmx284m"));
+    assertTrue(javaOpts.contains("-Xms100m"));
 
     origJavaOpts = "";
     javaOpts = TezClientUtils.maybeAddDefaultMemoryJavaOpts(origJavaOpts,
         Resource.newInstance(355, 1), 0);
-    Assert.assertEquals(origJavaOpts, javaOpts);
+    assertEquals(origJavaOpts, javaOpts);
 
     origJavaOpts = "";
     javaOpts = TezClientUtils.maybeAddDefaultMemoryJavaOpts(origJavaOpts,
         Resource.newInstance(355, 1), 100);
-    Assert.assertEquals(origJavaOpts, javaOpts);
+    assertEquals(origJavaOpts, javaOpts);
 
     origJavaOpts = "";
     javaOpts = TezClientUtils.maybeAddDefaultMemoryJavaOpts(origJavaOpts,
         Resource.newInstance(1000, 1), -1);
-    Assert.assertTrue(javaOpts.contains("-Xmx700m"));
+    assertTrue(javaOpts.contains("-Xmx700m"));
 
     origJavaOpts = "";
     javaOpts = TezClientUtils.maybeAddDefaultMemoryJavaOpts(origJavaOpts,
         Resource.newInstance(5000, 1), -1);
-    Assert.assertTrue(javaOpts.contains("-Xmx4000m"));
+    assertTrue(javaOpts.contains("-Xmx4000m"));
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDefaultLoggingJavaOpts() {
     String origJavaOpts = null;
     String javaOpts = TezClientUtils.maybeAddDefaultLoggingJavaOpts("FOOBAR", origJavaOpts);
-    Assert.assertNotNull(javaOpts);
-    Assert.assertTrue(javaOpts.contains("-D" + TezConstants.TEZ_ROOT_LOGGER_NAME + "=FOOBAR")
+    assertNotNull(javaOpts);
+    assertTrue(javaOpts.contains("-D" + TezConstants.TEZ_ROOT_LOGGER_NAME + "=FOOBAR")
         && javaOpts.contains(TezConstants.TEZ_CONTAINER_LOG4J_PROPERTIES_FILE)
         &&
         javaOpts.contains("-Dlog4j.configuratorClass=org.apache.tez.common.TezLog4jConfigurator"));
@@ -691,14 +712,15 @@ public class TestTezClientUtils {
   public void testDefaultLoggingJavaOptsWithRootLogger() {
     String origJavaOpts = "-D" + TezConstants.TEZ_ROOT_LOGGER_NAME + "=INFO -DtestProperty=value";
     String javaOpts = TezClientUtils.maybeAddDefaultLoggingJavaOpts("FOOBAR", origJavaOpts);
-    Assert.assertNotNull(javaOpts);
-    Assert.assertTrue(javaOpts.contains("-D" + TezConstants.TEZ_ROOT_LOGGER_NAME + "=FOOBAR"));
-    Assert.assertTrue(javaOpts.contains(TezConstants.TEZ_CONTAINER_LOG4J_PROPERTIES_FILE)
+    assertNotNull(javaOpts);
+    assertTrue(javaOpts.contains("-D" + TezConstants.TEZ_ROOT_LOGGER_NAME + "=FOOBAR"));
+    assertTrue(javaOpts.contains(TezConstants.TEZ_CONTAINER_LOG4J_PROPERTIES_FILE)
         && javaOpts.contains("-Dlog4j.configuratorClass=org.apache.tez.common.TezLog4jConfigurator"));
-    Assert.assertTrue(javaOpts.contains("-DtestProperty=value"));
+    assertTrue(javaOpts.contains("-DtestProperty=value"));
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConfYarnZkWorkaround() {
     Configuration conf = new Configuration(false);
     String val = "localhost:2181";
@@ -714,13 +736,14 @@ public class TestTezClientUtils {
         String v = expected.remove(kvPair.getKey());
         // this way the test still validates that the original
         // key/value pairs can be found in the proto's conf
-        assertEquals("Unexpected value for key: " + kvPair.getKey(), v, kvPair.getValue());
+        assertEquals(v, kvPair.getValue(), "Unexpected value for key: " + kvPair.getKey());
       }
     }
-    assertTrue("Expected keys not found in conf: " + expected.keySet(), expected.isEmpty());
+    assertTrue(expected.isEmpty(), "Expected keys not found in conf: " + expected.keySet());
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConfSerializationForAm() {
     Configuration conf =new Configuration(false);
     String val1 = "fixedProperty";
@@ -758,24 +781,24 @@ public class TestTezClientUtils {
       String fsURI = remoteFs.getUri().toString();
 
       topLevelDir = new Path(fsURI, "/testLRVisibility");
-      Assert.assertTrue(remoteFs.mkdirs(topLevelDir, publicDirPerms));
+      assertTrue(remoteFs.mkdirs(topLevelDir, publicDirPerms));
 
       Path publicSubDir = new Path(topLevelDir, "public_sub_dir");
-      Assert.assertTrue(remoteFs.mkdirs(publicSubDir, publicDirPerms));
+      assertTrue(remoteFs.mkdirs(publicSubDir, publicDirPerms));
 
       Path privateSubDir = new Path(topLevelDir, "private_sub_dir");
-      Assert.assertTrue(remoteFs.mkdirs(privateSubDir, privateDirPerms));
+      assertTrue(remoteFs.mkdirs(privateSubDir, privateDirPerms));
 
       Path publicFile = new Path(publicSubDir, "public_file");
-      Assert.assertTrue(remoteFs.createNewFile(publicFile));
+      assertTrue(remoteFs.createNewFile(publicFile));
       remoteFs.setPermission(publicFile, publicFilePerms);
 
       Path privateFile = new Path(publicSubDir, "private_file");
-      Assert.assertTrue(remoteFs.createNewFile(privateFile));
+      assertTrue(remoteFs.createNewFile(privateFile));
       remoteFs.setPermission(privateFile, privateFilePerms);
 
       Path publicFileInPrivateSubdir = new Path(privateSubDir, "public_file_in_private_subdir");
-      Assert.assertTrue(remoteFs.createNewFile(publicFileInPrivateSubdir));
+      assertTrue(remoteFs.createNewFile(publicFileInPrivateSubdir));
       remoteFs.setPermission(publicFileInPrivateSubdir, publicFilePerms);
 
       TezConfiguration tezConf = new TezConfiguration(conf);
@@ -786,35 +809,41 @@ public class TestTezClientUtils {
       Map<String, LocalResource> lrMap = new HashMap<String, LocalResource>();
       TezClientUtils.setupTezJarsLocalResources(tezConf, new Credentials(), lrMap);
 
-      Assert.assertEquals(publicFile.getName(), LocalResourceVisibility.PUBLIC,
-          lrMap.get(publicFile.getName()).getVisibility());
+      assertEquals(
+          LocalResourceVisibility.PUBLIC,
+          lrMap.get(publicFile.getName()).getVisibility(),
+          publicFile.getName());
 
-      Assert.assertEquals(privateFile.getName(), LocalResourceVisibility.PRIVATE,
-          lrMap.get(privateFile.getName()).getVisibility());
+      assertEquals(
+          LocalResourceVisibility.PRIVATE,
+          lrMap.get(privateFile.getName()).getVisibility(),
+          privateFile.getName());
 
-      Assert.assertEquals(publicFileInPrivateSubdir.getName(), LocalResourceVisibility.PRIVATE,
-          lrMap.get(publicFileInPrivateSubdir.getName()).getVisibility());
+      assertEquals(
+          LocalResourceVisibility.PRIVATE,
+          lrMap.get(publicFileInPrivateSubdir.getName()).getVisibility(),
+          publicFileInPrivateSubdir.getName());
 
       // test tar.gz
       tezConf = new TezConfiguration(conf);
       Path tarFile = new Path(topLevelDir, "foo.tar.gz");
-      Assert.assertTrue(remoteFs.createNewFile(tarFile));
+      assertTrue(remoteFs.createNewFile(tarFile));
 
       //public
       remoteFs.setPermission(tarFile, publicFilePerms);
       tezConf.set(TezConfiguration.TEZ_LIB_URIS, tarFile.toString());
       lrMap.clear();
-      Assert.assertTrue(
+      assertTrue(
           TezClientUtils.setupTezJarsLocalResources(tezConf, new Credentials(), lrMap));
 
-      Assert.assertEquals(LocalResourceVisibility.PUBLIC,
+      assertEquals(LocalResourceVisibility.PUBLIC,
           lrMap.get(TezConstants.TEZ_TAR_LR_NAME).getVisibility());
 
       //private
       remoteFs.setPermission(tarFile, privateFilePerms);
       lrMap.clear();
       TezClientUtils.setupTezJarsLocalResources(tezConf, new Credentials(), lrMap);
-      Assert.assertEquals(LocalResourceVisibility.PRIVATE,
+      assertEquals(LocalResourceVisibility.PRIVATE,
           lrMap.get(TezConstants.TEZ_TAR_LR_NAME).getVisibility());
 
     } finally {
@@ -824,7 +853,8 @@ public class TestTezClientUtils {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConfigurationAllowAll() {
     Configuration srcConf = new Configuration(false);
 
@@ -855,7 +885,8 @@ public class TestTezClientUtils {
     return fs.makeQualified(f1);
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void validateSetTezAuxLocalResourcesWithFilesAndFolders() throws Exception {
     FileSystem localFs = FileSystem.getLocal(new Configuration());
     List<String> resources = new ArrayList<String>();
@@ -889,12 +920,13 @@ public class TestTezClientUtils {
     Map<String, LocalResource> localizedMap = new HashMap<String, LocalResource>();
     TezClientUtils.setupTezJarsLocalResources(conf, credentials, localizedMap);
     Set<String> resourceNames = localizedMap.keySet();
-    Assert.assertEquals(2, resourceNames.size());
-    Assert.assertTrue(resourceNames.contains("f1.txt"));
-    Assert.assertTrue(resourceNames.contains("dir2-f.txt"));
+    assertEquals(2, resourceNames.size());
+    assertTrue(resourceNames.contains("f1.txt"));
+    assertTrue(resourceNames.contains("dir2-f.txt"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testServiceDescriptorSerializationForAM() {
     Configuration conf = new Configuration(false);
     ServicePluginsDescriptor servicePluginsDescriptor = ServicePluginsDescriptor.create(true);
@@ -906,33 +938,35 @@ public class TestTezClientUtils {
     assertTrue(confProto.getAmPluginDescriptor().getUberEnabled());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskLaunchCmdOptsSetup() throws TezException {
     Configuration conf = new Configuration(false);
     String vOpts = "";
     String opts = TezClientUtils.addDefaultsToTaskLaunchCmdOpts(vOpts, conf);
 
-    Assert.assertEquals(opts,
+    assertEquals(opts,
         TezConfiguration.TEZ_TASK_LAUNCH_CLUSTER_DEFAULT_CMD_OPTS_DEFAULT + " "
             + TezConfiguration.TEZ_TASK_LAUNCH_CMD_OPTS_DEFAULT + " " + vOpts);
 
     vOpts = "foo";
     opts = TezClientUtils.addDefaultsToTaskLaunchCmdOpts(vOpts, conf);
 
-    Assert.assertEquals(opts,
+    assertEquals(opts,
         TezConfiguration.TEZ_TASK_LAUNCH_CLUSTER_DEFAULT_CMD_OPTS_DEFAULT + "  " + vOpts);
 
     String taskOpts = "taskOpts";
     conf.set(TezConfiguration.TEZ_TASK_LAUNCH_CMD_OPTS, taskOpts);
     opts = TezClientUtils.addDefaultsToTaskLaunchCmdOpts(vOpts, conf);
 
-    Assert.assertEquals(opts,
+    assertEquals(opts,
         TezConfiguration.TEZ_TASK_LAUNCH_CLUSTER_DEFAULT_CMD_OPTS_DEFAULT
             + " " + taskOpts + " " + vOpts);
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testClusterTaskLaunchCmdOptsSetup() throws TezException {
     Configuration conf = new Configuration(false);
     String adminOpts = "adminOpts";
@@ -941,20 +975,20 @@ public class TestTezClientUtils {
     String vOpts = "";
     String opts = TezClientUtils.addDefaultsToTaskLaunchCmdOpts(vOpts, conf);
 
-    Assert.assertEquals(opts,
-        adminOpts + " "
-            + TezConfiguration.TEZ_TASK_LAUNCH_CMD_OPTS_DEFAULT + " " + vOpts);
+    assertEquals(adminOpts + " "
+        + TezConfiguration.TEZ_TASK_LAUNCH_CMD_OPTS_DEFAULT + " " + vOpts,
+            opts);
 
     vOpts = "foo";
     opts = TezClientUtils.addDefaultsToTaskLaunchCmdOpts(vOpts, conf);
 
-    Assert.assertEquals(opts, adminOpts + "  " + vOpts);
+    assertEquals(adminOpts + "  " + vOpts, opts);
 
     String taskOpts = "taskOpts";
     conf.set(TezConfiguration.TEZ_TASK_LAUNCH_CMD_OPTS, taskOpts);
     opts = TezClientUtils.addDefaultsToTaskLaunchCmdOpts(vOpts, conf);
 
-    Assert.assertEquals(opts, adminOpts + " " + taskOpts + " " + vOpts);
+    assertEquals(adminOpts + " " + taskOpts + " " + vOpts, opts);
 
   }
 
@@ -981,6 +1015,6 @@ public class TestTezClientUtils {
 
     // if there is another token in am conf creds of the same token type,
     // session token should be applied while creating ContainerLaunchContext
-    Assert.assertEquals(sessionToken, amLaunchCredentials.getToken(tokenType));
+    assertEquals(sessionToken, amLaunchCredentials.getToken(tokenType));
   }
 }

--- a/tez-api/src/test/java/org/apache/tez/client/registry/TestAMRecord.java
+++ b/tez-api/src/test/java/org/apache/tez/client/registry/TestAMRecord.java
@@ -18,7 +18,11 @@
  */
 package org.apache.tez.client.registry;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -26,7 +30,8 @@ import org.apache.hadoop.registry.client.types.ServiceRecord;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.client.registry.zookeeper.ZkConfig;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 public class TestAMRecord {
 
@@ -228,12 +233,12 @@ public class TestAMRecord {
 
     assertNotNull(str);
     // Validate actual JSON-like snippets from the string
-    assertTrue("Should contain appId=value snippet", str.contains("appId=" + appId.toString()));
-    assertTrue("Should contain hostName=value snippet", str.contains("hostName=" + hostName));
-    assertTrue("Should contain hostIp=value snippet", str.contains("hostIp=" + hostIp));
-    assertTrue("Should contain port=value snippet", str.contains("port=" + port));
-    assertTrue("Should contain externalId=value snippet", str.contains("externalId=" + externalId));
-    assertTrue("Should contain computeName=value snippet", str.contains("computeName=" + computeName));
+    assertTrue(str.contains("appId=" + appId.toString()), "Should contain appId=value snippet");
+    assertTrue(str.contains("hostName=" + hostName), "Should contain hostName=value snippet");
+    assertTrue(str.contains("hostIp=" + hostIp), "Should contain hostIp=value snippet");
+    assertTrue(str.contains("port=" + port), "Should contain port=value snippet");
+    assertTrue(str.contains("externalId=" + externalId), "Should contain externalId=value snippet");
+    assertTrue(str.contains("computeName=" + computeName), "Should contain computeName=value snippet");
   }
 
   @Test

--- a/tez-api/src/test/java/org/apache/tez/client/registry/TestAMRecord.java
+++ b/tez-api/src/test/java/org/apache/tez/client/registry/TestAMRecord.java
@@ -32,7 +32,6 @@ import org.apache.tez.client.registry.zookeeper.ZkConfig;
 
 import org.junit.jupiter.api.Test;
 
-
 public class TestAMRecord {
 
   @Test

--- a/tez-api/src/test/java/org/apache/tez/client/registry/zookeeper/TestZkConfig.java
+++ b/tez-api/src/test/java/org/apache/tez/client/registry/zookeeper/TestZkConfig.java
@@ -31,7 +31,6 @@ import org.apache.tez.dag.api.TezConfiguration;
 
 import org.junit.jupiter.api.Test;
 
-
 public class TestZkConfig {
 
   @Test

--- a/tez-api/src/test/java/org/apache/tez/client/registry/zookeeper/TestZkConfig.java
+++ b/tez-api/src/test/java/org/apache/tez/client/registry/zookeeper/TestZkConfig.java
@@ -18,8 +18,9 @@
  */
 package org.apache.tez.client.registry.zookeeper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.concurrent.TimeUnit;
 
@@ -28,7 +29,8 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.dag.api.TezConfiguration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 public class TestZkConfig {
 
@@ -189,34 +191,36 @@ public class TestZkConfig {
     assertEquals(zkConfig.getZkQuorum(), curator.getZookeeperClient().getCurrentConnectionString());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullZkQuorum() {
     TezConfiguration conf = new TezConfiguration();
     // Don't set zkQuorum
-    new ZkConfig(conf);
+    assertThrows(IllegalArgumentException.class, () -> new ZkConfig(conf));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEmptyZkQuorum() {
     TezConfiguration conf = new TezConfiguration();
     conf.set(TezConfiguration.TEZ_AM_ZOOKEEPER_QUORUM, "");
-    new ZkConfig(conf);
+    assertThrows(IllegalArgumentException.class, () -> new ZkConfig(conf));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testNullNamespace() {
     TezConfiguration conf = new TezConfiguration();
     conf.set(TezConfiguration.TEZ_AM_ZOOKEEPER_QUORUM, "localhost:2181");
-    conf.set(TezConfiguration.TEZ_AM_REGISTRY_NAMESPACE, null);
-    new ZkConfig(conf);
+    assertThrows(IllegalArgumentException.class, () -> {
+      conf.set(TezConfiguration.TEZ_AM_REGISTRY_NAMESPACE, null);
+      new ZkConfig(conf);
+    });
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEmptyNamespace() {
     TezConfiguration conf = new TezConfiguration();
     conf.set(TezConfiguration.TEZ_AM_ZOOKEEPER_QUORUM, "localhost:2181");
     conf.set(TezConfiguration.TEZ_AM_REGISTRY_NAMESPACE, "");
-    new ZkConfig(conf);
+    assertThrows(IllegalArgumentException.class, () -> new ZkConfig(conf));
   }
 
   @Test

--- a/tez-api/src/test/java/org/apache/tez/client/registry/zookeeper/TestZkFrameworkClient.java
+++ b/tez-api/src/test/java/org/apache/tez/client/registry/zookeeper/TestZkFrameworkClient.java
@@ -176,18 +176,10 @@ public class TestZkFrameworkClient {
     YarnClientApplication clientApp = zkFrameworkClient.createApplication();
 
     assertNotNull(clientApp, "YarnClientApplication should not be null");
-    assertNotNull(
-        clientApp.getApplicationSubmissionContext(),
-        "ApplicationSubmissionContext should not be null");
-    assertEquals(
-        appId,
-        clientApp.getApplicationSubmissionContext().getApplicationId(),
-        "Application ID should match");
-    assertNotNull(
-        clientApp.getNewApplicationResponse(), "GetNewApplicationResponse should not be null");
-    assertEquals(
-        appId,
-        clientApp.getNewApplicationResponse().getApplicationId(),
+    assertNotNull(clientApp.getApplicationSubmissionContext(), "ApplicationSubmissionContext should not be null");
+    assertEquals(appId, clientApp.getApplicationSubmissionContext().getApplicationId(), "Application ID should match");
+    assertNotNull(clientApp.getNewApplicationResponse(), "GetNewApplicationResponse should not be null");
+    assertEquals(appId, clientApp.getNewApplicationResponse().getApplicationId(),
         "Response application ID should match");
   }
 

--- a/tez-api/src/test/java/org/apache/tez/client/registry/zookeeper/TestZkFrameworkClient.java
+++ b/tez-api/src/test/java/org/apache/tez/client/registry/zookeeper/TestZkFrameworkClient.java
@@ -18,7 +18,10 @@
  */
 package org.apache.tez.client.registry.zookeeper;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -37,9 +40,10 @@ import org.apache.tez.client.registry.AMRecord;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.zookeeper.CreateMode;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,22 +59,26 @@ public class TestZkFrameworkClient {
   private static final File TEST_DIR = new File(System.getProperty("test.build.data", "target"),
       TestZkFrameworkClient.class.getName()).getAbsoluteFile();
 
-  private TestingServer zkServer;
+  private static TestingServer zkServer;
   private ZkFrameworkClient zkFrameworkClient;
   private CuratorFramework curatorClient;
 
-  @Before
-  public void setup() throws Exception {
+  @BeforeAll
+  public static void setup() throws Exception {
     zkServer = new TestingServer(true);
     LOG.info("Started ZooKeeper test server on port: {}", zkServer.getPort());
   }
 
-  @After
-  public void teardown() throws Exception {
+  @AfterEach
+  public void teardownEach() throws Exception {
     if (zkFrameworkClient != null) {
       zkFrameworkClient.close();
     }
     IOUtils.closeQuietly(curatorClient);
+  }
+
+  @AfterAll
+  public static void teardown() throws Exception {
     IOUtils.closeQuietly(zkServer);
   }
 
@@ -84,13 +92,13 @@ public class TestZkFrameworkClient {
     zkFrameworkClient = new ZkFrameworkClient();
     zkFrameworkClient.init(tezConf);
 
-    assertFalse("Client should not be running after init", zkFrameworkClient.isRunning());
+    assertFalse(zkFrameworkClient.isRunning(), "Client should not be running after init");
 
     zkFrameworkClient.start();
-    assertTrue("Client should be running after start", zkFrameworkClient.isRunning());
+    assertTrue(zkFrameworkClient.isRunning(), "Client should be running after start");
 
     zkFrameworkClient.stop();
-    assertFalse("Client should not be running after stop", zkFrameworkClient.isRunning());
+    assertFalse(zkFrameworkClient.isRunning(), "Client should not be running after stop");
   }
 
   /**
@@ -114,12 +122,12 @@ public class TestZkFrameworkClient {
 
     ApplicationReport report = zkFrameworkClient.getApplicationReport(appId);
 
-    assertNotNull("Application report should not be null", report);
-    assertEquals("Application ID should match", appId, report.getApplicationId());
-    assertEquals("Host should match", testHostName, report.getHost());
-    assertEquals("Port should match", testPort, report.getRpcPort());
-    assertEquals("AM host should be cached", testHostName, zkFrameworkClient.getAmHost());
-    assertEquals("AM port should be cached", testPort, zkFrameworkClient.getAmPort());
+    assertNotNull(report, "Application report should not be null");
+    assertEquals(appId, report.getApplicationId(), "Application ID should match");
+    assertEquals(testHostName, report.getHost(), "Host should match");
+    assertEquals(testPort, report.getRpcPort(), "Port should match");
+    assertEquals(testHostName, zkFrameworkClient.getAmHost(), "AM host should be cached");
+    assertEquals(testPort, zkFrameworkClient.getAmPort(), "AM port should be cached");
   }
 
   /**
@@ -139,12 +147,10 @@ public class TestZkFrameworkClient {
 
     ApplicationReport report = zkFrameworkClient.getApplicationReport(appId);
 
-    assertNotNull("Application report should not be null", report);
-    assertEquals("Application ID should match", appId, report.getApplicationId());
-    assertEquals("Final status should be FAILED", FinalApplicationStatus.FAILED,
-        report.getFinalApplicationStatus());
-    assertTrue("Diagnostics should mention missing AM",
-        report.getDiagnostics().contains("AM record not found"));
+    assertNotNull(report, "Application report should not be null");
+    assertEquals(appId, report.getApplicationId(), "Application ID should match");
+    assertEquals(FinalApplicationStatus.FAILED, report.getFinalApplicationStatus(), "Final status should be FAILED");
+    assertTrue(report.getDiagnostics().contains("AM record not found"), "Diagnostics should mention missing AM");
   }
 
   /**
@@ -169,12 +175,20 @@ public class TestZkFrameworkClient {
 
     YarnClientApplication clientApp = zkFrameworkClient.createApplication();
 
-    assertNotNull("YarnClientApplication should not be null", clientApp);
-    assertNotNull("ApplicationSubmissionContext should not be null", clientApp.getApplicationSubmissionContext());
-    assertEquals("Application ID should match", appId, clientApp.getApplicationSubmissionContext().getApplicationId());
-    assertNotNull("GetNewApplicationResponse should not be null", clientApp.getNewApplicationResponse());
-    assertEquals("Response application ID should match",
-        appId, clientApp.getNewApplicationResponse().getApplicationId());
+    assertNotNull(clientApp, "YarnClientApplication should not be null");
+    assertNotNull(
+        clientApp.getApplicationSubmissionContext(),
+        "ApplicationSubmissionContext should not be null");
+    assertEquals(
+        appId,
+        clientApp.getApplicationSubmissionContext().getApplicationId(),
+        "Application ID should match");
+    assertNotNull(
+        clientApp.getNewApplicationResponse(), "GetNewApplicationResponse should not be null");
+    assertEquals(
+        appId,
+        clientApp.getNewApplicationResponse().getApplicationId(),
+        "Response application ID should match");
   }
 
   /**

--- a/tez-api/src/test/java/org/apache/tez/common/TestJavaOptsChecker.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestJavaOptsChecker.java
@@ -48,8 +48,7 @@ public class TestJavaOptsChecker {
       javaOptsChecker.checkOpts(opts);
       fail("Expected check to fail with opts=" + opts);
     } catch (TezException e) {
-      assertTrue(e.getMessage().contains("Invalid/conflicting GC options found"),
-              e.getMessage());
+      assertTrue(e.getMessage().contains("Invalid/conflicting GC options found"), e.getMessage());
     }
   }
 

--- a/tez-api/src/test/java/org/apache/tez/common/TestJavaOptsChecker.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestJavaOptsChecker.java
@@ -18,64 +18,69 @@
  */
 package org.apache.tez.common;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.TimeUnit;
+
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.TezException;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestJavaOptsChecker {
 
   private final JavaOptsChecker javaOptsChecker = new JavaOptsChecker();
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasicChecker() throws TezException {
     javaOptsChecker.checkOpts(TezConfiguration.TEZ_TASK_LAUNCH_CMD_OPTS_DEFAULT);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleGC() {
     // Clashing GC values
     String opts = "-XX:+UseSerialGC -XX:+UseG1GC -XX:+UseParallelGC ";
     try {
       javaOptsChecker.checkOpts(opts);
-      Assert.fail("Expected check to fail with opts=" + opts);
+      fail("Expected check to fail with opts=" + opts);
     } catch (TezException e) {
-      Assert.assertTrue(e.getMessage(),
-          e.getMessage().contains("Invalid/conflicting GC options found"));
+      assertTrue(e.getMessage().contains("Invalid/conflicting GC options found"),
+              e.getMessage());
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPositiveNegativeOpts() throws TezException {
     // Multiple positive GC values
     String opts = "-XX:+UseSerialGC -XX:+UseG1GC -XX:+UseParallelGC -XX:-UseG1GC ";
     try {
       javaOptsChecker.checkOpts(opts);
-      Assert.fail("Expected check to fail with opts=" + opts);
+      fail("Expected check to fail with opts=" + opts);
     } catch (TezException e) {
-      Assert.assertTrue(e.getMessage(),
-          e.getMessage().contains("Invalid/conflicting GC options found"));
+      assertTrue(e.getMessage().contains("Invalid/conflicting GC options found"), e.getMessage());
     }
 
     // Positive following a negative is still a positive
     opts = " -XX:-UseG1GC -XX:+UseParallelGC -XX:-UseG1GC  -XX:+UseG1GC";
     try {
       javaOptsChecker.checkOpts(opts);
-      Assert.fail("Expected check to fail with opts=" + opts);
+      fail("Expected check to fail with opts=" + opts);
     } catch (TezException e) {
-      Assert.assertTrue(e.getMessage(),
-          e.getMessage().contains("Invalid/conflicting GC options found"));
+      assertTrue(e.getMessage().contains("Invalid/conflicting GC options found"), e.getMessage());
     }
 
     // Order of positive and negative matters
     opts = " -XX:+UseG1GC -XX:-UseG1GC -XX:+UseParallelGC -XX:-UseG1GC  -XX:+UseG1GC";
     try {
       javaOptsChecker.checkOpts(opts);
-      Assert.fail("Expected check to fail with opts=" + opts);
+      fail("Expected check to fail with opts=" + opts);
     } catch (TezException e) {
-      Assert.assertTrue(e.getMessage(),
-          e.getMessage().contains("Invalid/conflicting GC options found"));
+      assertTrue(e.getMessage().contains("Invalid/conflicting GC options found"), e.getMessage());
     }
 
     // Sanity check for good condition

--- a/tez-api/src/test/java/org/apache/tez/common/TestRPCUtil.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestRPCUtil.java
@@ -162,12 +162,9 @@ public class TestRPCUtil {
       t = thrown;
     }
 
-    assertTrue(
-        expectedLocalException.isInstance(t),
+    assertTrue(expectedLocalException.isInstance(t),
         "Expected exception [" + expectedLocalException + "] but found " + t);
-    assertTrue(
-        t.getMessage().contains(message),
-        "Expected message [" + message + "] but found " + t.getMessage());
+    assertTrue(t.getMessage().contains(message), "Expected message [" + message + "] but found " + t.getMessage());
   }
 
   @Test

--- a/tez-api/src/test/java/org/apache/tez/common/TestRPCUtil.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestRPCUtil.java
@@ -18,8 +18,11 @@
  */
 package org.apache.tez.common;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.tez.dag.api.SessionNotRunning;
@@ -27,12 +30,13 @@ import org.apache.tez.dag.api.TezException;
 
 import com.google.protobuf.ServiceException;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestRPCUtil {
 
-  @Test (timeout=1000)
+  @Test
+  @Timeout(value = 1000, unit = TimeUnit.MILLISECONDS)
   public void testUnknownExceptionUnwrapping() {
     Class<? extends Throwable> exception = TezException.class;
     String className = "UnknownException.class";
@@ -97,8 +101,8 @@ public class TestRPCUtil {
       t = thrown;
     }
 
-    Assert.assertTrue(IOException.class.isInstance(t));
-    Assert.assertTrue(t.getMessage().contains(message));
+    assertTrue(IOException.class.isInstance(t));
+    assertTrue(t.getMessage().contains(message));
   }
 
   @Test
@@ -113,8 +117,8 @@ public class TestRPCUtil {
     } catch (Throwable thrown) {
       t = thrown;
     }
-    Assert.assertTrue(FileNotFoundException.class.isInstance(t));
-    Assert.assertTrue(t.getMessage().contains(message));
+    assertTrue(FileNotFoundException.class.isInstance(t));
+    assertTrue(t.getMessage().contains(message));
   }
 
   @Test
@@ -130,8 +134,8 @@ public class TestRPCUtil {
       t = thrown;
     }
 
-    Assert.assertTrue(NullPointerException.class.isInstance(t));
-    Assert.assertTrue(t.getMessage().contains(message));
+    assertTrue(NullPointerException.class.isInstance(t));
+    assertTrue(t.getMessage().contains(message));
   }
 
   private void verifyRemoteExceptionUnwrapping(
@@ -158,15 +162,16 @@ public class TestRPCUtil {
       t = thrown;
     }
 
-    Assert.assertTrue("Expected exception [" + expectedLocalException
-        + "] but found " + t, expectedLocalException.isInstance(t));
-    Assert.assertTrue(
-        "Expected message [" + message + "] but found " + t.getMessage(), t
-            .getMessage().contains(message));
+    assertTrue(
+        expectedLocalException.isInstance(t),
+        "Expected exception [" + expectedLocalException + "] but found " + t);
+    assertTrue(
+        t.getMessage().contains(message),
+        "Expected message [" + message + "] but found " + t.getMessage());
   }
 
-
-  @Test (timeout=1000)
+  @Test
+  @Timeout(value = 1000, unit = TimeUnit.MILLISECONDS)
   public void testRemoteNonIOExceptionUnwrapping() {
     Class<? extends Throwable> exception = TezException.class;
     verifyRemoteExceptionUnwrapping(exception, IOException.class.getName(), false);

--- a/tez-api/src/test/java/org/apache/tez/common/TestReflectionUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestReflectionUtils.java
@@ -53,12 +53,11 @@ public class TestReflectionUtils {
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConstructorWithParameters() throws TezReflectionException {
     Class<?>[] parameterTypes = new Class[] {String.class, Integer.TYPE};
-    Object[] parameters = new Object[] {new String("test"), 1};
+    Object[] parameters = new Object[] {"test", 1};
     ParameterizedConstructorClass instance =
-        ReflectionUtils.createClazzInstance(
-            ParameterizedConstructorClass.class.getName(), parameterTypes, parameters);
-    assertEquals(instance.first, "test", "Class not constructed with first parameter correctly");
-    assertEquals(instance.second, 1, "Class not constructed with second parameter correctly");
+        ReflectionUtils.createClazzInstance(ParameterizedConstructorClass.class.getName(), parameterTypes, parameters);
+    assertEquals("test", instance.first, "Class not constructed with first parameter correctly");
+    assertEquals(1, instance.second, "Class not constructed with second parameter correctly");
   }
 
   @Test

--- a/tez-api/src/test/java/org/apache/tez/common/TestReflectionUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestReflectionUtils.java
@@ -18,15 +18,16 @@
  */
 package org.apache.tez.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -34,7 +35,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.tez.dag.api.TezException;
 import org.apache.tez.dag.api.TezReflectionException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestReflectionUtils {
 
@@ -47,18 +49,20 @@ public class TestReflectionUtils {
     }
   }
 
-  @Test(timeout = 5000)
-  public void testConstructorWithParameters() throws TezReflectionException
-  {
-    Class<?>[] parameterTypes = new Class[] { String.class, Integer.TYPE };
-    Object[] parameters = new Object[] { new String("test"), 1 };
-    ParameterizedConstructorClass instance = ReflectionUtils.createClazzInstance(
-        ParameterizedConstructorClass.class.getName(), parameterTypes, parameters);
-    assertEquals("Class not constructed with first parameter correctly", instance.first, "test");
-    assertEquals("Class not constructed with second parameter correctly", instance.second, 1);
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testConstructorWithParameters() throws TezReflectionException {
+    Class<?>[] parameterTypes = new Class[] {String.class, Integer.TYPE};
+    Object[] parameters = new Object[] {new String("test"), 1};
+    ParameterizedConstructorClass instance =
+        ReflectionUtils.createClazzInstance(
+            ParameterizedConstructorClass.class.getName(), parameterTypes, parameters);
+    assertEquals(instance.first, "test", "Class not constructed with first parameter correctly");
+    assertEquals(instance.second, 1, "Class not constructed with second parameter correctly");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAddResourceToClasspath() throws IOException, TezException {
     TezClassLoader.setupTezClassLoader();
     String rsrcName = "dummyfile.xml";

--- a/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
@@ -18,9 +18,17 @@
  */
 package org.apache.tez.common;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
@@ -38,10 +46,10 @@ import org.apache.tez.dag.api.TezUncheckedException;
 
 import com.google.common.collect.Maps;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +66,7 @@ public class TestTezCommonUtils {
   private static FileSystem remoteFs = null;
   private static final Logger LOG = LoggerFactory.getLogger(TestTezCommonUtils.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     conf.set(TezConfiguration.TEZ_AM_STAGING_DIR, STAGE_DIR);
     LOG.info("Starting mini clusters");
@@ -74,7 +82,7 @@ public class TestTezCommonUtils {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws InterruptedException {
     if (dfsCluster != null) {
       try {
@@ -87,23 +95,25 @@ public class TestTezCommonUtils {
   }
 
   // Testing base staging dir
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezBaseStagingPath() throws Exception {
     Configuration localConf = new Configuration();
     // Check if default works with localFS
     localConf.set(TezConfiguration.TEZ_AM_STAGING_DIR, LOCAL_STAGING_DIR.getAbsolutePath());
     localConf.set("fs.defaultFS", "file:///");
     Path stageDir = TezCommonUtils.getTezBaseStagingPath(localConf);
-    Assert.assertEquals("file:" + LOCAL_STAGING_DIR, stageDir.toString());
+    assertEquals("file:" + LOCAL_STAGING_DIR, stageDir.toString());
 
     // check if user set something, indeed works
     conf.set(TezConfiguration.TEZ_AM_STAGING_DIR, STAGE_DIR);
     stageDir = TezCommonUtils.getTezBaseStagingPath(conf);
-    Assert.assertEquals(stageDir.toString(), RESOLVED_STAGE_DIR);
+    assertEquals(stageDir.toString(), RESOLVED_STAGE_DIR);
   }
 
   // Testing System staging dir if createed
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCreateTezSysStagingPath() throws Exception {
     String strAppId = "testAppId";
     String expectedStageDir = RESOLVED_STAGE_DIR + Path.SEPARATOR
@@ -116,24 +126,26 @@ public class TestTezCommonUtils {
     if (fs.exists(stagePath)) {
       fs.delete(stagePath, true);
     }
-    Assert.assertFalse(fs.exists(stagePath));
+    assertFalse(fs.exists(stagePath));
     Path stageDir = TezCommonUtils.createTezSystemStagingPath(conf, strAppId);
-    Assert.assertEquals(stageDir.toString(), expectedStageDir);
-    Assert.assertTrue(fs.exists(stagePath));
+    assertEquals(stageDir.toString(), expectedStageDir);
+    assertTrue(fs.exists(stagePath));
   }
 
   // Testing System staging dir
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezSysStagingPath() throws Exception {
     String strAppId = "testAppId";
     Path stageDir = TezCommonUtils.getTezSystemStagingPath(conf, strAppId);
     String expectedStageDir = RESOLVED_STAGE_DIR + Path.SEPARATOR
         + TezCommonUtils.TEZ_SYSTEM_SUB_DIR + Path.SEPARATOR + strAppId;
-    Assert.assertEquals(stageDir.toString(), expectedStageDir);
+    assertEquals(stageDir.toString(), expectedStageDir);
   }
 
   // Testing conf staging dir
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezConfStagingPath() throws Exception {
     String strAppId = "testAppId";
     Path stageDir = TezCommonUtils.getTezSystemStagingPath(conf, strAppId);
@@ -141,11 +153,12 @@ public class TestTezCommonUtils {
     String expectedDir = RESOLVED_STAGE_DIR + Path.SEPARATOR
         + TezCommonUtils.TEZ_SYSTEM_SUB_DIR + Path.SEPARATOR + strAppId + Path.SEPARATOR
         + TezConstants.TEZ_PB_BINARY_CONF_NAME;
-    Assert.assertEquals(confStageDir.toString(), expectedDir);
+    assertEquals(confStageDir.toString(), expectedDir);
   }
 
   // Testing session jars staging dir
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezSessionJarStagingPath() throws Exception {
     String strAppId = "testAppId";
     Path stageDir = TezCommonUtils.getTezSystemStagingPath(conf, strAppId);
@@ -153,11 +166,12 @@ public class TestTezCommonUtils {
     String expectedDir = RESOLVED_STAGE_DIR + Path.SEPARATOR
         + TezCommonUtils.TEZ_SYSTEM_SUB_DIR + Path.SEPARATOR + strAppId + Path.SEPARATOR
         + TezConstants.TEZ_AM_LOCAL_RESOURCES_PB_FILE_NAME;
-    Assert.assertEquals(confStageDir.toString(), expectedDir);
+    assertEquals(confStageDir.toString(), expectedDir);
   }
 
   // Testing bin plan staging dir
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezBinPlanStagingPath() throws Exception {
     String strAppId = "testAppId";
     Path stageDir = TezCommonUtils.getTezSystemStagingPath(conf, strAppId);
@@ -165,11 +179,12 @@ public class TestTezCommonUtils {
     String expectedDir = RESOLVED_STAGE_DIR + Path.SEPARATOR
         + TezCommonUtils.TEZ_SYSTEM_SUB_DIR + Path.SEPARATOR + strAppId + Path.SEPARATOR
         + TezConstants.TEZ_PB_PLAN_BINARY_NAME;
-    Assert.assertEquals(confStageDir.toString(), expectedDir);
+    assertEquals(confStageDir.toString(), expectedDir);
   }
 
   // Testing text plan staging dir
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezTextPlanStagingPath() throws Exception {
     String strAppId = "testAppId";
     String dagPBName = "testDagPBName";
@@ -179,11 +194,12 @@ public class TestTezCommonUtils {
     String expectedDir = RESOLVED_STAGE_DIR + Path.SEPARATOR
         + TezCommonUtils.TEZ_SYSTEM_SUB_DIR + Path.SEPARATOR + strAppId + Path.SEPARATOR
         + strAppId + "-" + dagPBName + "-" + TezConstants.TEZ_PB_PLAN_TEXT_NAME;
-    Assert.assertEquals(confStageDir.toString(), expectedDir);
+    assertEquals(confStageDir.toString(), expectedDir);
   }
 
   // Testing recovery path staging dir
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezRecoveryStagingPath() throws Exception {
     String strAppId = "testAppId";
     Path stageDir = TezCommonUtils.getTezSystemStagingPath(conf, strAppId);
@@ -191,11 +207,12 @@ public class TestTezCommonUtils {
     String expectedDir = RESOLVED_STAGE_DIR + Path.SEPARATOR
         + TezCommonUtils.TEZ_SYSTEM_SUB_DIR + Path.SEPARATOR + strAppId + Path.SEPARATOR
         + TezConstants.DAG_RECOVERY_DATA_DIR_NAME;
-    Assert.assertEquals(confStageDir.toString(), expectedDir);
+    assertEquals(confStageDir.toString(), expectedDir);
   }
 
   // Testing app attempt specific recovery path staging dir
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezAttemptRecoveryStagingPath() throws Exception {
     String strAppId = "testAppId";
     Path stageDir = TezCommonUtils.getTezSystemStagingPath(conf, strAppId);
@@ -205,11 +222,12 @@ public class TestTezCommonUtils {
     String expectedDir = RESOLVED_STAGE_DIR + Path.SEPARATOR
         + TezCommonUtils.TEZ_SYSTEM_SUB_DIR + Path.SEPARATOR + strAppId + Path.SEPARATOR
         + TezConstants.DAG_RECOVERY_DATA_DIR_NAME + Path.SEPARATOR + "2";
-    Assert.assertEquals(recoveryStageDir.toString(), expectedDir);
+    assertEquals(recoveryStageDir.toString(), expectedDir);
   }
 
   // Testing DAG specific recovery path staging dir
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezDAGRecoveryStagingPath() throws Exception {
     String strAppId = "testAppId";
     Path stageDir = TezCommonUtils.getTezSystemStagingPath(conf, strAppId);
@@ -222,11 +240,12 @@ public class TestTezCommonUtils {
         + TezCommonUtils.TEZ_SYSTEM_SUB_DIR + Path.SEPARATOR + strAppId + Path.SEPARATOR
         + TezConstants.DAG_RECOVERY_DATA_DIR_NAME + Path.SEPARATOR + "2" + Path.SEPARATOR
         + "dag_123" + TezConstants.DAG_RECOVERY_RECOVER_FILE_SUFFIX;
-    Assert.assertEquals(expectedDir, dagRecoveryPathj.toString());
+    assertEquals(expectedDir, dagRecoveryPathj.toString());
   }
 
   // Testing Summary recovery path staging dir
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezSummaryRecoveryStagingPath() throws Exception {
     String strAppId = "testAppId";
     Path stageDir = TezCommonUtils.getTezSystemStagingPath(conf, strAppId);
@@ -238,26 +257,29 @@ public class TestTezCommonUtils {
         + TezCommonUtils.TEZ_SYSTEM_SUB_DIR + Path.SEPARATOR + strAppId + Path.SEPARATOR
         + TezConstants.DAG_RECOVERY_DATA_DIR_NAME + Path.SEPARATOR + "2" + Path.SEPARATOR
         + TezConstants.DAG_RECOVERY_SUMMARY_FILE_SUFFIX;
-    Assert.assertEquals(expectedDir, summaryRecoveryPathj.toString());
+    assertEquals(expectedDir, summaryRecoveryPathj.toString());
   }
 
   // This test is running here to leverage existing mini cluster
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLocalResourceVisibility() throws Exception {
     TestTezClientUtils.testLocalResourceVisibility(dfsCluster.getFileSystem(), conf);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testStringTokenize() {
     String s = "foo:bar:xyz::too";
     String[] expectedTokens = { "foo", "bar" , "xyz" , "too"};
     String[] tokens = new String[4];
     TezCommonUtils.tokenizeString(s, ":").toArray(tokens);
-    Assert.assertArrayEquals(expectedTokens, tokens);
+    assertArrayEquals(expectedTokens, tokens);
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAddAdditionalLocalResources() {
     String lrName = "LR";
     Map<String, LocalResource> originalLrs;
@@ -289,9 +311,9 @@ public class TestTezCommonUtils {
         LocalResourceType.FILE, LocalResourceVisibility.PUBLIC, 100, 1));
     try {
       TezCommonUtils.addAdditionalLocalResources(additionalLrs, originalLrs, "");
-      Assert.fail("Duplicate LRs with different sizes expected to fail");
+      fail("Duplicate LRs with different sizes expected to fail");
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains("Duplicate Resources found with different size"));
+      assertTrue(e.getMessage().contains("Duplicate Resources found with different size"));
     }
 
     // Different path, same size, diff timestamp
@@ -314,56 +336,57 @@ public class TestTezCommonUtils {
         LocalResourceType.FILE, LocalResourceVisibility.PUBLIC, 100, 1));
     try {
       TezCommonUtils.addAdditionalLocalResources(additionalLrs, originalLrs, "");
-      Assert.fail("Duplicate LRs with different sizes expected to fail");
+      fail("Duplicate LRs with different sizes expected to fail");
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains("Duplicate Resources found with different size"));
+      assertTrue(e.getMessage().contains("Duplicate Resources found with different size"));
     }
 
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAMClientHeartBeatTimeout() {
     TezConfiguration conf = new TezConfiguration(false);
 
     // -1 for any negative value
-    Assert.assertEquals(-1,
+    assertEquals(-1,
         TezCommonUtils.getAMClientHeartBeatTimeoutMillis(conf));
     conf.setInt(TezConfiguration.TEZ_AM_CLIENT_HEARTBEAT_TIMEOUT_SECS, -2);
-    Assert.assertEquals(-1,
+    assertEquals(-1,
         TezCommonUtils.getAMClientHeartBeatTimeoutMillis(conf));
 
     // For any value > 0 but less than min, revert to min
     conf.setInt(TezConfiguration.TEZ_AM_CLIENT_HEARTBEAT_TIMEOUT_SECS,
         TezConstants.TEZ_AM_CLIENT_HEARTBEAT_TIMEOUT_SECS_MINIMUM - 1);
-    Assert.assertEquals(TezConstants.TEZ_AM_CLIENT_HEARTBEAT_TIMEOUT_SECS_MINIMUM * 1000,
+    assertEquals(TezConstants.TEZ_AM_CLIENT_HEARTBEAT_TIMEOUT_SECS_MINIMUM * 1000,
         TezCommonUtils.getAMClientHeartBeatTimeoutMillis(conf));
 
     // For val > min, should remain val as configured
     conf.setInt(TezConfiguration.TEZ_AM_CLIENT_HEARTBEAT_TIMEOUT_SECS,
         TezConstants.TEZ_AM_CLIENT_HEARTBEAT_TIMEOUT_SECS_MINIMUM * 2);
-    Assert.assertEquals(TezConstants.TEZ_AM_CLIENT_HEARTBEAT_TIMEOUT_SECS_MINIMUM * 2000,
+    assertEquals(TezConstants.TEZ_AM_CLIENT_HEARTBEAT_TIMEOUT_SECS_MINIMUM * 2000,
         TezCommonUtils.getAMClientHeartBeatTimeoutMillis(conf));
 
     conf = new TezConfiguration(false);
-    Assert.assertEquals(-1, TezCommonUtils.getAMClientHeartBeatPollIntervalMillis(conf, -1, 10));
-    Assert.assertEquals(-1, TezCommonUtils.getAMClientHeartBeatPollIntervalMillis(conf, -123, 10));
-    Assert.assertEquals(-1, TezCommonUtils.getAMClientHeartBeatPollIntervalMillis(conf, 0, 10));
+    assertEquals(-1, TezCommonUtils.getAMClientHeartBeatPollIntervalMillis(conf, -1, 10));
+    assertEquals(-1, TezCommonUtils.getAMClientHeartBeatPollIntervalMillis(conf, -123, 10));
+    assertEquals(-1, TezCommonUtils.getAMClientHeartBeatPollIntervalMillis(conf, 0, 10));
 
     // min poll interval is 1000
-    Assert.assertEquals(1000, TezCommonUtils.getAMClientHeartBeatPollIntervalMillis(conf, 600, 10));
+    assertEquals(1000, TezCommonUtils.getAMClientHeartBeatPollIntervalMillis(conf, 600, 10));
 
     // Poll interval is heartbeat interval/10
-    Assert.assertEquals(2000,
+    assertEquals(2000,
         TezCommonUtils.getAMClientHeartBeatPollIntervalMillis(conf, 20000, 10));
 
     // Configured poll interval ignored
     conf.setInt(TezConfiguration.TEZ_AM_CLIENT_HEARTBEAT_POLL_INTERVAL_MILLIS, -1);
-    Assert.assertEquals(4000,
+    assertEquals(4000,
         TezCommonUtils.getAMClientHeartBeatPollIntervalMillis(conf, 20000, 5));
 
     // Positive poll interval is allowed
     conf.setInt(TezConfiguration.TEZ_AM_CLIENT_HEARTBEAT_POLL_INTERVAL_MILLIS, 2000);
-    Assert.assertEquals(2000,
+    assertEquals(2000,
         TezCommonUtils.getAMClientHeartBeatPollIntervalMillis(conf, 20000, 5));
 
 
@@ -376,7 +399,7 @@ public class TestTezCommonUtils {
     conf.set(TezConfiguration.TEZ_JVM_SYSTEM_PROPERTIES_TO_LOG, " ");
     String value = TezCommonUtils.getSystemPropertiesToLog(conf);
     for(String key: TezConfiguration.TEZ_JVM_SYSTEM_PROPERTIES_TO_LOG_DEFAULT) {
-      Assert.assertTrue(value.contains(key));
+      assertTrue(value.contains(key));
     }
 
     // test logging of selected keys
@@ -385,32 +408,33 @@ public class TestTezCommonUtils {
     String version = "java.version";
     conf.set(TezConfiguration.TEZ_JVM_SYSTEM_PROPERTIES_TO_LOG, classpath + ", " + os);
     value = TezCommonUtils.getSystemPropertiesToLog(conf);
-    Assert.assertNotNull(value);
-    Assert.assertTrue(value.contains(classpath));
-    Assert.assertTrue(value.contains(os));
-    Assert.assertFalse(value.contains(version));
+    assertNotNull(value);
+    assertTrue(value.contains(classpath));
+    assertTrue(value.contains(os));
+    assertFalse(value.contains(version));
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetDAGSessionTimeout() {
     Configuration conf = new Configuration(false);
-    Assert.assertEquals(TezConfiguration.TEZ_SESSION_AM_DAG_SUBMIT_TIMEOUT_SECS_DEFAULT*1000,
+    assertEquals(TezConfiguration.TEZ_SESSION_AM_DAG_SUBMIT_TIMEOUT_SECS_DEFAULT*1000,
         TezCommonUtils.getDAGSessionTimeout(conf));
 
     // set to 1 month - * 1000 guaranteed to cross positive integer boundary
     conf.setInt(TezConfiguration.TEZ_SESSION_AM_DAG_SUBMIT_TIMEOUT_SECS,
         24 * 60 * 60 * 30);
-    Assert.assertEquals(86400l*1000*30,
+    assertEquals(86400l*1000*30,
         TezCommonUtils.getDAGSessionTimeout(conf));
 
     // set to negative val
     conf.setInt(TezConfiguration.TEZ_SESSION_AM_DAG_SUBMIT_TIMEOUT_SECS,
         -24 * 60 * 60 * 30);
-    Assert.assertEquals(-1,
+    assertEquals(-1,
         TezCommonUtils.getDAGSessionTimeout(conf));
 
     conf.setInt(TezConfiguration.TEZ_SESSION_AM_DAG_SUBMIT_TIMEOUT_SECS, 0);
-    Assert.assertEquals(1000,
+    assertEquals(1000,
         TezCommonUtils.getDAGSessionTimeout(conf));
 
   }
@@ -426,7 +450,7 @@ public class TestTezCommonUtils {
     FileSystem remoteFileSystem = miniDFS.getFileSystem();
     Path path = new Path(TEST_ROOT_DIR + "/testMkDirForAM");
     TezCommonUtils.mkDirForAM(remoteFileSystem, path);
-    Assert.assertEquals(TezCommonUtils.TEZ_AM_DIR_PERMISSION, remoteFileSystem.getFileStatus(path).getPermission());
+    assertEquals(TezCommonUtils.TEZ_AM_DIR_PERMISSION, remoteFileSystem.getFileStatus(path).getPermission());
     miniDFS.shutdown();
   }
 }

--- a/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestTezCommonUtils.java
@@ -442,15 +442,12 @@ public class TestTezCommonUtils {
 
   @Test
   public void testMkDirForAM() throws IOException {
-    Configuration remoteConf = new Configuration();
-    remoteConf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEST_ROOT_DIR);
+    Configuration remoteConf = new Configuration(conf);
     remoteConf.set(CommonConfigurationKeys.FS_PERMISSIONS_UMASK_KEY, "777");
-    MiniDFSCluster miniDFS = new MiniDFSCluster.Builder(remoteConf).numDataNodes(3).format(true).racks(null)
-        .build();
-    FileSystem remoteFileSystem = miniDFS.getFileSystem();
-    Path path = new Path(TEST_ROOT_DIR + "/testMkDirForAM");
-    TezCommonUtils.mkDirForAM(remoteFileSystem, path);
-    assertEquals(TezCommonUtils.TEZ_AM_DIR_PERMISSION, remoteFileSystem.getFileStatus(path).getPermission());
-    miniDFS.shutdown();
+    try (FileSystem remoteFileSystem = FileSystem.newInstance(remoteFs.getUri(), remoteConf)) {
+      Path path = new Path(TEST_ROOT_DIR + "/testMkDirForAM");
+      TezCommonUtils.mkDirForAM(remoteFileSystem, path);
+      assertEquals(TezCommonUtils.TEZ_AM_DIR_PERMISSION, remoteFileSystem.getFileStatus(path).getPermission());
+    }
   }
 }

--- a/tez-api/src/test/java/org/apache/tez/common/TestTezYARNUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestTezYARNUtils.java
@@ -105,19 +105,13 @@ public class TestTezYARNUtils {
   public void testSetupDefaultEnvironment() {
     Configuration conf = new Configuration(false);
     conf.set(TezConfiguration.TEZ_AM_LAUNCH_ENV, "LD_LIBRARY_PATH=USER_PATH,USER_KEY=USER_VALUE");
-    conf.set(
-        TezConfiguration.TEZ_AM_LAUNCH_CLUSTER_DEFAULT_ENV,
+    conf.set(TezConfiguration.TEZ_AM_LAUNCH_CLUSTER_DEFAULT_ENV,
         "LD_LIBRARY_PATH=DEFAULT_PATH,DEFAULT_KEY=DEFAULT_VALUE");
 
-    Map<String, String> environment = new TreeMap<String, String>();
-    TezYARNUtils.setupDefaultEnv(
-        environment,
-        conf,
-        TezConfiguration.TEZ_AM_LAUNCH_ENV,
-        TezConfiguration.TEZ_AM_LAUNCH_ENV_DEFAULT,
-        TezConfiguration.TEZ_AM_LAUNCH_CLUSTER_DEFAULT_ENV,
-        TezConfiguration.TEZ_AM_LAUNCH_CLUSTER_DEFAULT_ENV_DEFAULT,
-        false);
+    Map<String, String> environment = new TreeMap<>();
+    TezYARNUtils.setupDefaultEnv(environment, conf, TezConfiguration.TEZ_AM_LAUNCH_ENV,
+        TezConfiguration.TEZ_AM_LAUNCH_ENV_DEFAULT, TezConfiguration.TEZ_AM_LAUNCH_CLUSTER_DEFAULT_ENV,
+        TezConfiguration.TEZ_AM_LAUNCH_CLUSTER_DEFAULT_ENV_DEFAULT, false);
 
     String value1 = environment.get("USER_KEY");
     assertEquals("USER_VALUE", value1, "User env should merge with default env");
@@ -136,8 +130,7 @@ public class TestTezYARNUtils {
     String classpath = TezYARNUtils.getFrameworkClasspath(conf, true);
     assertTrue(classpath.contains("foobar"));
     assertTrue(classpath.contains(Environment.PWD.$()));
-    assertTrue(classpath.indexOf("foobar") >
-        classpath.indexOf(Environment.PWD.$()));
+    assertTrue(classpath.indexOf("foobar") > classpath.indexOf(Environment.PWD.$()));
   }
 
   @Test
@@ -162,7 +155,7 @@ public class TestTezYARNUtils {
     String badEnv = "0=,1,,2=a=b,3=a=,4==,5==a,==,c-3=3,=";
     environment.clear();
     appendToEnvFromInputString(environment, badEnv, File.pathSeparator);
-    assertEquals(environment.size(), 0);
+    assertEquals(0, environment.size());
 
     // Test "=" in the value part
     environment.clear();

--- a/tez-api/src/test/java/org/apache/tez/common/TestTezYARNUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestTezYARNUtils.java
@@ -19,12 +19,15 @@
 package org.apache.tez.common;
 
 import static org.apache.tez.common.TezYARNUtils.appendToEnvFromInputString;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.Shell;
@@ -32,97 +35,108 @@ import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.TezConstants;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTezYARNUtils {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAuxClasspath() {
     Configuration conf = new Configuration(false);
     conf.set(TezConfiguration.TEZ_CLUSTER_ADDITIONAL_CLASSPATH_PREFIX, "foobar");
     String classpath = TezYARNUtils.getFrameworkClasspath(conf, true);
-    Assert.assertTrue(classpath.contains("foobar"));
-    Assert.assertTrue(classpath.indexOf("foobar") <
+    assertTrue(classpath.contains("foobar"));
+    assertTrue(classpath.indexOf("foobar") <
         classpath.indexOf(TezConstants.TEZ_TAR_LR_NAME));
-    Assert.assertTrue(classpath.indexOf("foobar") <
+    assertTrue(classpath.indexOf("foobar") <
         classpath.indexOf(Environment.PWD.$()));
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testUserClasspathFirstFalse() {
     Configuration conf = new Configuration(false);
     conf.setBoolean(TezConfiguration.TEZ_USER_CLASSPATH_FIRST, false);
     conf.set(TezConfiguration.TEZ_CLUSTER_ADDITIONAL_CLASSPATH_PREFIX, "foobar");
     String classpath = TezYARNUtils.getFrameworkClasspath(conf, true);
-    Assert.assertTrue(classpath.contains("foobar"));
-    Assert.assertTrue(classpath.indexOf("foobar") >
+    assertTrue(classpath.contains("foobar"));
+    assertTrue(classpath.indexOf("foobar") >
         classpath.indexOf(TezConstants.TEZ_TAR_LR_NAME));
-    Assert.assertTrue(classpath.indexOf("foobar") >
+    assertTrue(classpath.indexOf("foobar") >
         classpath.indexOf(Environment.PWD.$()));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasicArchiveClasspath() {
     Configuration conf = new Configuration(false);
     String classpath = TezYARNUtils.getFrameworkClasspath(conf, true);
-    Assert.assertTrue(classpath.contains(Environment.PWD.$()));
-    Assert.assertTrue(classpath.contains(Environment.PWD.$() + File.separator + "*"));
-    Assert.assertTrue(classpath.contains(TezConstants.TEZ_TAR_LR_NAME + File.separator + "*"));
-    Assert.assertTrue(classpath.contains(TezConstants.TEZ_TAR_LR_NAME + File.separator
+    assertTrue(classpath.contains(Environment.PWD.$()));
+    assertTrue(classpath.contains(Environment.PWD.$() + File.separator + "*"));
+    assertTrue(classpath.contains(TezConstants.TEZ_TAR_LR_NAME + File.separator + "*"));
+    assertTrue(classpath.contains(TezConstants.TEZ_TAR_LR_NAME + File.separator
         + "lib" + File.separator + "*"));
-    Assert.assertTrue(!classpath.contains(Environment.HADOOP_CONF_DIR.$()));
-    Assert.assertTrue(classpath.indexOf(Environment.PWD.$()) <
+    assertFalse(classpath.contains(Environment.HADOOP_CONF_DIR.$()));
+    assertTrue(classpath.indexOf(Environment.PWD.$()) <
         classpath.indexOf(TezConstants.TEZ_TAR_LR_NAME));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNoHadoopConfInClasspath() {
     Configuration conf = new Configuration(false);
     conf.setBoolean(TezConfiguration.TEZ_CLASSPATH_ADD_HADOOP_CONF, true);
     String classpath = TezYARNUtils.getFrameworkClasspath(conf, true);
-    Assert.assertTrue(classpath.contains(Environment.PWD.$()));
-    Assert.assertTrue(classpath.contains(Environment.PWD.$() + File.separator + "*"));
-    Assert.assertTrue(classpath.contains(TezConstants.TEZ_TAR_LR_NAME + File.separator + "*"));
-    Assert.assertTrue(classpath.contains(TezConstants.TEZ_TAR_LR_NAME + File.separator
+    assertTrue(classpath.contains(Environment.PWD.$()));
+    assertTrue(classpath.contains(Environment.PWD.$() + File.separator + "*"));
+    assertTrue(classpath.contains(TezConstants.TEZ_TAR_LR_NAME + File.separator + "*"));
+    assertTrue(classpath.contains(TezConstants.TEZ_TAR_LR_NAME + File.separator
         + "lib" + File.separator + "*"));
-    Assert.assertTrue(classpath.contains(Environment.HADOOP_CONF_DIR.$()));
-    Assert.assertTrue(classpath.indexOf(Environment.PWD.$()) <
+    assertTrue(classpath.contains(Environment.HADOOP_CONF_DIR.$()));
+    assertTrue(classpath.indexOf(Environment.PWD.$()) <
         classpath.indexOf(TezConstants.TEZ_TAR_LR_NAME));
-    Assert.assertTrue(classpath.indexOf(TezConstants.TEZ_TAR_LR_NAME) <
+    assertTrue(classpath.indexOf(TezConstants.TEZ_TAR_LR_NAME) <
         classpath.indexOf(Environment.HADOOP_CONF_DIR.$()));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSetupDefaultEnvironment() {
     Configuration conf = new Configuration(false);
     conf.set(TezConfiguration.TEZ_AM_LAUNCH_ENV, "LD_LIBRARY_PATH=USER_PATH,USER_KEY=USER_VALUE");
-    conf.set(TezConfiguration.TEZ_AM_LAUNCH_CLUSTER_DEFAULT_ENV, "LD_LIBRARY_PATH=DEFAULT_PATH,DEFAULT_KEY=DEFAULT_VALUE");
+    conf.set(
+        TezConfiguration.TEZ_AM_LAUNCH_CLUSTER_DEFAULT_ENV,
+        "LD_LIBRARY_PATH=DEFAULT_PATH,DEFAULT_KEY=DEFAULT_VALUE");
 
     Map<String, String> environment = new TreeMap<String, String>();
-    TezYARNUtils.setupDefaultEnv(environment, conf,
+    TezYARNUtils.setupDefaultEnv(
+        environment,
+        conf,
         TezConfiguration.TEZ_AM_LAUNCH_ENV,
         TezConfiguration.TEZ_AM_LAUNCH_ENV_DEFAULT,
         TezConfiguration.TEZ_AM_LAUNCH_CLUSTER_DEFAULT_ENV,
-        TezConfiguration.TEZ_AM_LAUNCH_CLUSTER_DEFAULT_ENV_DEFAULT, false);
+        TezConfiguration.TEZ_AM_LAUNCH_CLUSTER_DEFAULT_ENV_DEFAULT,
+        false);
 
     String value1 = environment.get("USER_KEY");
-    Assert.assertEquals("User env should merge with default env", "USER_VALUE", value1);
+    assertEquals("USER_VALUE", value1, "User env should merge with default env");
     String value2 = environment.get("DEFAULT_KEY");
-    Assert.assertEquals("User env should merge with default env", "DEFAULT_VALUE", value2);
+    assertEquals("DEFAULT_VALUE", value2, "User env should merge with default env");
     String value3 = environment.get("LD_LIBRARY_PATH");
-    Assert.assertEquals("User env should append default env",
-        Environment.PWD.$() + File.pathSeparator + "USER_PATH" + File.pathSeparator + "DEFAULT_PATH", value3);
-    }
+    assertEquals(Environment.PWD.$() + File.pathSeparator + "USER_PATH" + File.pathSeparator + "DEFAULT_PATH", value3,
+        "User env should append default env");
+  }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezLibUrisClasspath() {
     Configuration conf = new Configuration(false);
     conf.set(TezConfiguration.TEZ_LIB_URIS_CLASSPATH, "foobar");
     String classpath = TezYARNUtils.getFrameworkClasspath(conf, true);
-    Assert.assertTrue(classpath.contains("foobar"));
-    Assert.assertTrue(classpath.contains(Environment.PWD.$()));
-    Assert.assertTrue(classpath.indexOf("foobar") >
+    assertTrue(classpath.contains("foobar"));
+    assertTrue(classpath.contains(Environment.PWD.$()));
+    assertTrue(classpath.indexOf("foobar") >
         classpath.indexOf(Environment.PWD.$()));
   }
 

--- a/tez-api/src/test/java/org/apache/tez/common/TestVersionInfo.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestVersionInfo.java
@@ -18,8 +18,12 @@
  */
 package org.apache.tez.common;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestVersionInfo {
 
@@ -28,34 +32,38 @@ public class TestVersionInfo {
   private static final String BUILD_TIME = "20141024-1052";
   private static final String SCM_URL = "scm:git:https://gitbox.apache.org/repos/asf/tez.git";
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTest1File() {
     VersionInfo versionInfo = new VersionInfo("test1");
-    Assert.assertEquals(VERSION, versionInfo.getVersion());
-    Assert.assertEquals(REVISION, versionInfo.getRevision());
-    Assert.assertEquals(BUILD_TIME, versionInfo.getBuildTime());
-    Assert.assertEquals(SCM_URL, versionInfo.getSCMURL());
+    assertEquals(VERSION, versionInfo.getVersion());
+    assertEquals(REVISION, versionInfo.getRevision());
+    assertEquals(BUILD_TIME, versionInfo.getBuildTime());
+    assertEquals(SCM_URL, versionInfo.getSCMURL());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTest2File() {
     VersionInfo versionInfo = new VersionInfo("test2");
-    Assert.assertEquals(VERSION, versionInfo.getVersion());
-    Assert.assertEquals(REVISION, versionInfo.getRevision());
-    Assert.assertEquals(BUILD_TIME, versionInfo.getBuildTime());
-    Assert.assertEquals(VersionInfo.UNKNOWN, versionInfo.getSCMURL());
+    assertEquals(VERSION, versionInfo.getVersion());
+    assertEquals(REVISION, versionInfo.getRevision());
+    assertEquals(BUILD_TIME, versionInfo.getBuildTime());
+    assertEquals(VersionInfo.UNKNOWN, versionInfo.getSCMURL());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTest3File() {
     VersionInfo versionInfo = new VersionInfo("test3");
-    Assert.assertEquals(VERSION, versionInfo.getVersion());
-    Assert.assertEquals(REVISION, versionInfo.getRevision());
-    Assert.assertEquals("", versionInfo.getBuildTime());
-    Assert.assertEquals(SCM_URL, versionInfo.getSCMURL());
+    assertEquals(VERSION, versionInfo.getVersion());
+    assertEquals(REVISION, versionInfo.getRevision());
+    assertEquals("", versionInfo.getBuildTime());
+    assertEquals(SCM_URL, versionInfo.getSCMURL());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNonExistentFile() {
     VersionInfo versionInfo = new VersionInfo("test4");
   }

--- a/tez-api/src/test/java/org/apache/tez/common/security/TestACLConfigurationParser.java
+++ b/tez-api/src/test/java/org/apache/tez/common/security/TestACLConfigurationParser.java
@@ -18,17 +18,24 @@
  */
 package org.apache.tez.common.security;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.TezConstants;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestACLConfigurationParser {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testACLConfigParser() {
 
     Configuration conf = new Configuration(false);
@@ -39,43 +46,44 @@ public class TestACLConfigurationParser {
     conf.set(TezConfiguration.TEZ_AM_VIEW_ACLS, viewACLs);
 
     ACLConfigurationParser parser = new ACLConfigurationParser(conf);
-    Assert.assertTrue(parser.getAllowedUsers().containsKey(ACLType.AM_VIEW_ACL));
-    Assert.assertFalse(parser.getAllowedUsers().containsKey(ACLType.AM_MODIFY_ACL));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.AM_VIEW_ACL).contains("user1"));
-    Assert.assertFalse(parser.getAllowedUsers().get(ACLType.AM_VIEW_ACL).contains("user3"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.AM_VIEW_ACL).contains("user4"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin1"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin4"));
-    Assert.assertFalse(parser.getAllowedGroups().isEmpty());
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp3"));
-    Assert.assertFalse(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp6"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp4"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp5"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp3"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp4"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp5"));
+    assertTrue(parser.getAllowedUsers().containsKey(ACLType.AM_VIEW_ACL));
+    assertFalse(parser.getAllowedUsers().containsKey(ACLType.AM_MODIFY_ACL));
+    assertTrue(parser.getAllowedUsers().get(ACLType.AM_VIEW_ACL).contains("user1"));
+    assertFalse(parser.getAllowedUsers().get(ACLType.AM_VIEW_ACL).contains("user3"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.AM_VIEW_ACL).contains("user4"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin1"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin4"));
+    assertFalse(parser.getAllowedGroups().isEmpty());
+    assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp3"));
+    assertFalse(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp6"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp4"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp5"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp3"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp4"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp5"));
 
     conf.set(TezConfiguration.TEZ_AM_MODIFY_ACLS, modifyACLs);
     parser = new ACLConfigurationParser(conf);
-    Assert.assertTrue(parser.getAllowedUsers().containsKey(ACLType.AM_VIEW_ACL));
-    Assert.assertTrue(parser.getAllowedUsers().containsKey(ACLType.AM_MODIFY_ACL));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.AM_VIEW_ACL).contains("user1"));
-    Assert.assertFalse(parser.getAllowedUsers().get(ACLType.AM_VIEW_ACL).contains("user3"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.AM_VIEW_ACL).contains("user4"));
-    Assert.assertFalse(parser.getAllowedUsers().get(ACLType.AM_MODIFY_ACL).contains("user1"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.AM_MODIFY_ACL).contains("user3"));
-    Assert.assertFalse(parser.getAllowedGroups().isEmpty());
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp3"));
-    Assert.assertFalse(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp6"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp4"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp5"));
-    Assert.assertFalse(parser.getAllowedGroups().isEmpty());
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp3"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp4"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp5"));
+    assertTrue(parser.getAllowedUsers().containsKey(ACLType.AM_VIEW_ACL));
+    assertTrue(parser.getAllowedUsers().containsKey(ACLType.AM_MODIFY_ACL));
+    assertTrue(parser.getAllowedUsers().get(ACLType.AM_VIEW_ACL).contains("user1"));
+    assertFalse(parser.getAllowedUsers().get(ACLType.AM_VIEW_ACL).contains("user3"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.AM_VIEW_ACL).contains("user4"));
+    assertFalse(parser.getAllowedUsers().get(ACLType.AM_MODIFY_ACL).contains("user1"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.AM_MODIFY_ACL).contains("user3"));
+    assertFalse(parser.getAllowedGroups().isEmpty());
+    assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp3"));
+    assertFalse(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp6"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp4"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp5"));
+    assertFalse(parser.getAllowedGroups().isEmpty());
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp3"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp4"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp5"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGroupsOnly() {
     Configuration conf = new Configuration(false);
     String adminACLs = "admin1,admin4,       admgrp3,admgrp4,admgrp5  ";
@@ -84,20 +92,21 @@ public class TestACLConfigurationParser {
     conf.set(YarnConfiguration.YARN_ADMIN_ACL, adminACLs);
 
     ACLConfigurationParser parser = new ACLConfigurationParser(conf);
-    Assert.assertFalse(parser.getAllowedUsers().isEmpty());
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin1"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin4"));
-    Assert.assertFalse(parser.getAllowedGroups().isEmpty());
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp3"));
-    Assert.assertFalse(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp6"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp4"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp5"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp3"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp4"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp5"));
+    assertFalse(parser.getAllowedUsers().isEmpty());
+    assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin1"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin4"));
+    assertFalse(parser.getAllowedGroups().isEmpty());
+    assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp3"));
+    assertFalse(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp6"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp4"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.AM_VIEW_ACL).contains("grp5"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp3"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp4"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp5"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGACLConfigParser() {
 
     Configuration conf = new Configuration(false);
@@ -108,44 +117,44 @@ public class TestACLConfigurationParser {
     conf.set(YarnConfiguration.YARN_ADMIN_ACL, adminACLs);
 
     ACLConfigurationParser parser = new ACLConfigurationParser(conf, true);
-    Assert.assertTrue(parser.getAllowedUsers().containsKey(ACLType.DAG_VIEW_ACL));
-    Assert.assertFalse(parser.getAllowedUsers().containsKey(ACLType.DAG_MODIFY_ACL));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.DAG_VIEW_ACL).contains("user1"));
-    Assert.assertFalse(parser.getAllowedUsers().get(ACLType.DAG_VIEW_ACL).contains("user3"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.DAG_VIEW_ACL).contains("user4"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin1"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin4"));
-    Assert.assertFalse(parser.getAllowedGroups().isEmpty());
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp3"));
-    Assert.assertFalse(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp6"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp4"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp5"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp3"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp4"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp5"));
+    assertTrue(parser.getAllowedUsers().containsKey(ACLType.DAG_VIEW_ACL));
+    assertFalse(parser.getAllowedUsers().containsKey(ACLType.DAG_MODIFY_ACL));
+    assertTrue(parser.getAllowedUsers().get(ACLType.DAG_VIEW_ACL).contains("user1"));
+    assertFalse(parser.getAllowedUsers().get(ACLType.DAG_VIEW_ACL).contains("user3"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.DAG_VIEW_ACL).contains("user4"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin1"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin4"));
+    assertFalse(parser.getAllowedGroups().isEmpty());
+    assertTrue(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp3"));
+    assertFalse(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp6"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp4"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp5"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp3"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp4"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp5"));
 
     conf.set(TezConstants.TEZ_DAG_MODIFY_ACLS, modifyACLs);
     parser = new ACLConfigurationParser(conf, true);
-    Assert.assertTrue(parser.getAllowedUsers().containsKey(ACLType.DAG_VIEW_ACL));
-    Assert.assertTrue(parser.getAllowedUsers().containsKey(ACLType.DAG_MODIFY_ACL));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.DAG_VIEW_ACL).contains("user1"));
-    Assert.assertFalse(parser.getAllowedUsers().get(ACLType.DAG_VIEW_ACL).contains("user3"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.DAG_VIEW_ACL).contains("user4"));
-    Assert.assertFalse(parser.getAllowedUsers().get(ACLType.DAG_MODIFY_ACL).contains("user1"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.DAG_MODIFY_ACL).contains("user3"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin1"));
-    Assert.assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin4"));
-    Assert.assertFalse(parser.getAllowedGroups().isEmpty());
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp3"));
-    Assert.assertFalse(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp6"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp4"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp5"));
-    Assert.assertNotNull(parser.getAllowedGroups().get(ACLType.DAG_MODIFY_ACL));
-    Assert.assertFalse(parser.getAllowedGroups().get(ACLType.DAG_MODIFY_ACL).contains("grp6"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.DAG_MODIFY_ACL).contains("grp4"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp3"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp4"));
-    Assert.assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp5"));
+    assertTrue(parser.getAllowedUsers().containsKey(ACLType.DAG_VIEW_ACL));
+    assertTrue(parser.getAllowedUsers().containsKey(ACLType.DAG_MODIFY_ACL));
+    assertTrue(parser.getAllowedUsers().get(ACLType.DAG_VIEW_ACL).contains("user1"));
+    assertFalse(parser.getAllowedUsers().get(ACLType.DAG_VIEW_ACL).contains("user3"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.DAG_VIEW_ACL).contains("user4"));
+    assertFalse(parser.getAllowedUsers().get(ACLType.DAG_MODIFY_ACL).contains("user1"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.DAG_MODIFY_ACL).contains("user3"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin1"));
+    assertTrue(parser.getAllowedUsers().get(ACLType.YARN_ADMIN_ACL).contains("admin4"));
+    assertFalse(parser.getAllowedGroups().isEmpty());
+    assertTrue(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp3"));
+    assertFalse(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp6"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp4"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.DAG_VIEW_ACL).contains("grp5"));
+    assertNotNull(parser.getAllowedGroups().get(ACLType.DAG_MODIFY_ACL));
+    assertFalse(parser.getAllowedGroups().get(ACLType.DAG_MODIFY_ACL).contains("grp6"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.DAG_MODIFY_ACL).contains("grp4"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp3"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp4"));
+    assertTrue(parser.getAllowedGroups().get(ACLType.YARN_ADMIN_ACL).contains("admgrp5"));
   }
 
 }

--- a/tez-api/src/test/java/org/apache/tez/common/security/TestACLManager.java
+++ b/tez-api/src/test/java/org/apache/tez/common/security/TestACLManager.java
@@ -18,8 +18,13 @@
  */
 package org.apache.tez.common.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -28,15 +33,16 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.records.DAGProtos.ACLInfo;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 
 public class TestACLManager {
 
   private static final String[] noGroups = new String[0];
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCurrentUserACLChecks() {
     UserGroupInformation currentUser = UserGroupInformation.createUserForTesting("currentUser", noGroups);
     UserGroupInformation dagUser = UserGroupInformation.createUserForTesting("dagUser", noGroups);
@@ -46,36 +52,37 @@ public class TestACLManager {
 
     UserGroupInformation user = user1;
 
-    Assert.assertFalse(aclManager.checkAccess(user, ACLType.AM_VIEW_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user, ACLType.AM_MODIFY_ACL));
+    assertFalse(aclManager.checkAccess(user, ACLType.AM_VIEW_ACL));
+    assertFalse(aclManager.checkAccess(user, ACLType.AM_MODIFY_ACL));
 
     user = currentUser;
-    Assert.assertTrue(aclManager.checkAccess(user, ACLType.AM_VIEW_ACL));
-    Assert.assertTrue(aclManager.checkAccess(user, ACLType.AM_MODIFY_ACL));
+    assertTrue(aclManager.checkAccess(user, ACLType.AM_VIEW_ACL));
+    assertTrue(aclManager.checkAccess(user, ACLType.AM_MODIFY_ACL));
 
     aclManager = new ACLManager(currentUser.getShortUserName(), new Configuration(false));
 
     user = user1;
-    Assert.assertFalse(aclManager.checkAccess(user, ACLType.AM_VIEW_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user, ACLType.AM_MODIFY_ACL));
+    assertFalse(aclManager.checkAccess(user, ACLType.AM_VIEW_ACL));
+    assertFalse(aclManager.checkAccess(user, ACLType.AM_MODIFY_ACL));
 
     user = currentUser;
-    Assert.assertTrue(aclManager.checkAccess(user, ACLType.AM_VIEW_ACL));
-    Assert.assertTrue(aclManager.checkAccess(user, ACLType.AM_MODIFY_ACL));
+    assertTrue(aclManager.checkAccess(user, ACLType.AM_VIEW_ACL));
+    assertTrue(aclManager.checkAccess(user, ACLType.AM_MODIFY_ACL));
 
     ACLManager dagAclManager = new ACLManager(aclManager, dagUser.getShortUserName(),
         ACLInfo.getDefaultInstance());
     user = dagUser;
-    Assert.assertFalse(dagAclManager.checkAccess(user, ACLType.AM_VIEW_ACL));
-    Assert.assertFalse(dagAclManager.checkAccess(user, ACLType.AM_MODIFY_ACL));
-    Assert.assertTrue(dagAclManager.checkAccess(user, ACLType.DAG_VIEW_ACL));
-    Assert.assertTrue(dagAclManager.checkAccess(user, ACLType.DAG_MODIFY_ACL));
+    assertFalse(dagAclManager.checkAccess(user, ACLType.AM_VIEW_ACL));
+    assertFalse(dagAclManager.checkAccess(user, ACLType.AM_MODIFY_ACL));
+    assertTrue(dagAclManager.checkAccess(user, ACLType.DAG_VIEW_ACL));
+    assertTrue(dagAclManager.checkAccess(user, ACLType.DAG_MODIFY_ACL));
     user = user1;
-    Assert.assertFalse(dagAclManager.checkAccess(user, ACLType.DAG_VIEW_ACL));
-    Assert.assertFalse(dagAclManager.checkAccess(user, ACLType.DAG_MODIFY_ACL));
+    assertFalse(dagAclManager.checkAccess(user, ACLType.DAG_VIEW_ACL));
+    assertFalse(dagAclManager.checkAccess(user, ACLType.DAG_MODIFY_ACL));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOtherUserACLChecks() throws IOException {
     String[] groups1 = new String[] {"grp1", "grp2"};
     String[] groups2 = new String[] {"grp3", "grp4"};
@@ -100,24 +107,25 @@ public class TestACLManager {
 
     ACLManager aclManager = new ACLManager(currentUser.getShortUserName(), conf);
 
-    Assert.assertTrue(aclManager.checkAccess(currentUser, ACLType.AM_VIEW_ACL));
-    Assert.assertTrue(aclManager.checkAccess(user1, ACLType.AM_VIEW_ACL));
-    Assert.assertTrue(aclManager.checkAccess(user2, ACLType.AM_VIEW_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user3, ACLType.AM_VIEW_ACL));
-    Assert.assertTrue(aclManager.checkAccess(user4, ACLType.AM_VIEW_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user5,  ACLType.AM_VIEW_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user6, ACLType.AM_VIEW_ACL));
+    assertTrue(aclManager.checkAccess(currentUser, ACLType.AM_VIEW_ACL));
+    assertTrue(aclManager.checkAccess(user1, ACLType.AM_VIEW_ACL));
+    assertTrue(aclManager.checkAccess(user2, ACLType.AM_VIEW_ACL));
+    assertFalse(aclManager.checkAccess(user3, ACLType.AM_VIEW_ACL));
+    assertTrue(aclManager.checkAccess(user4, ACLType.AM_VIEW_ACL));
+    assertFalse(aclManager.checkAccess(user5,  ACLType.AM_VIEW_ACL));
+    assertFalse(aclManager.checkAccess(user6, ACLType.AM_VIEW_ACL));
 
-    Assert.assertTrue(aclManager.checkAccess(currentUser, ACLType.AM_MODIFY_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user1, ACLType.AM_MODIFY_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user2, ACLType.AM_MODIFY_ACL));
-    Assert.assertTrue(aclManager.checkAccess(user3, ACLType.AM_MODIFY_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user4, ACLType.AM_MODIFY_ACL));
-    Assert.assertTrue(aclManager.checkAccess(user5, ACLType.AM_MODIFY_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user6, ACLType.AM_MODIFY_ACL));
+    assertTrue(aclManager.checkAccess(currentUser, ACLType.AM_MODIFY_ACL));
+    assertFalse(aclManager.checkAccess(user1, ACLType.AM_MODIFY_ACL));
+    assertFalse(aclManager.checkAccess(user2, ACLType.AM_MODIFY_ACL));
+    assertTrue(aclManager.checkAccess(user3, ACLType.AM_MODIFY_ACL));
+    assertFalse(aclManager.checkAccess(user4, ACLType.AM_MODIFY_ACL));
+    assertTrue(aclManager.checkAccess(user5, ACLType.AM_MODIFY_ACL));
+    assertFalse(aclManager.checkAccess(user6, ACLType.AM_MODIFY_ACL));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNoGroupsACLChecks() throws IOException {
     String[] groups1 = new String[] {"grp1", "grp2"};
     String[] groups2 = new String[] {"grp3", "grp4"};
@@ -140,24 +148,25 @@ public class TestACLManager {
     conf.set(TezConfiguration.TEZ_AM_MODIFY_ACLS, modifyACLs);
 
     ACLManager aclManager = new ACLManager(currentUser.getShortUserName(), conf);
-    Assert.assertTrue(aclManager.checkAccess(currentUser, ACLType.AM_VIEW_ACL));
-    Assert.assertTrue(aclManager.checkAccess(user1, ACLType.AM_VIEW_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user2, ACLType.AM_VIEW_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user3, ACLType.AM_VIEW_ACL));
-    Assert.assertTrue(aclManager.checkAccess(user4, ACLType.AM_VIEW_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user5, ACLType.AM_VIEW_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user6, ACLType.AM_VIEW_ACL));
+    assertTrue(aclManager.checkAccess(currentUser, ACLType.AM_VIEW_ACL));
+    assertTrue(aclManager.checkAccess(user1, ACLType.AM_VIEW_ACL));
+    assertFalse(aclManager.checkAccess(user2, ACLType.AM_VIEW_ACL));
+    assertFalse(aclManager.checkAccess(user3, ACLType.AM_VIEW_ACL));
+    assertTrue(aclManager.checkAccess(user4, ACLType.AM_VIEW_ACL));
+    assertFalse(aclManager.checkAccess(user5, ACLType.AM_VIEW_ACL));
+    assertFalse(aclManager.checkAccess(user6, ACLType.AM_VIEW_ACL));
 
-    Assert.assertTrue(aclManager.checkAccess(currentUser, ACLType.AM_MODIFY_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user1, ACLType.AM_MODIFY_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user2, ACLType.AM_MODIFY_ACL));
-    Assert.assertTrue(aclManager.checkAccess(user3, ACLType.AM_MODIFY_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user4, ACLType.AM_MODIFY_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user5, ACLType.AM_MODIFY_ACL));
-    Assert.assertFalse(aclManager.checkAccess(user6, ACLType.AM_MODIFY_ACL));
+    assertTrue(aclManager.checkAccess(currentUser, ACLType.AM_MODIFY_ACL));
+    assertFalse(aclManager.checkAccess(user1, ACLType.AM_MODIFY_ACL));
+    assertFalse(aclManager.checkAccess(user2, ACLType.AM_MODIFY_ACL));
+    assertTrue(aclManager.checkAccess(user3, ACLType.AM_MODIFY_ACL));
+    assertFalse(aclManager.checkAccess(user4, ACLType.AM_MODIFY_ACL));
+    assertFalse(aclManager.checkAccess(user5, ACLType.AM_MODIFY_ACL));
+    assertFalse(aclManager.checkAccess(user6, ACLType.AM_MODIFY_ACL));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void checkAMACLs() throws IOException {
     String[] groups1 = new String[] {"grp1", "grp2"};
     String[] groups2 = new String[] {"grp3", "grp4"};
@@ -187,48 +196,49 @@ public class TestACLManager {
 
     ACLManager aclManager = new ACLManager(currentUser.getShortUserName(), conf);
 
-    Assert.assertTrue(aclManager.checkAMViewAccess(currentUser));
-    Assert.assertTrue(aclManager.checkAMViewAccess(user1));
-    Assert.assertTrue(aclManager.checkAMViewAccess(user2));
-    Assert.assertFalse(aclManager.checkAMViewAccess(user3));
-    Assert.assertTrue(aclManager.checkAMViewAccess(user4));
-    Assert.assertFalse(aclManager.checkAMViewAccess(user5));
-    Assert.assertFalse(aclManager.checkAMViewAccess(user6));
-    Assert.assertTrue(aclManager.checkAMViewAccess(admuser1));
-    Assert.assertTrue(aclManager.checkAMViewAccess(admuser2));
+    assertTrue(aclManager.checkAMViewAccess(currentUser));
+    assertTrue(aclManager.checkAMViewAccess(user1));
+    assertTrue(aclManager.checkAMViewAccess(user2));
+    assertFalse(aclManager.checkAMViewAccess(user3));
+    assertTrue(aclManager.checkAMViewAccess(user4));
+    assertFalse(aclManager.checkAMViewAccess(user5));
+    assertFalse(aclManager.checkAMViewAccess(user6));
+    assertTrue(aclManager.checkAMViewAccess(admuser1));
+    assertTrue(aclManager.checkAMViewAccess(admuser2));
 
-    Assert.assertTrue(aclManager.checkAMModifyAccess(currentUser));
-    Assert.assertFalse(aclManager.checkAMModifyAccess(user1));
-    Assert.assertFalse(aclManager.checkAMModifyAccess(user2));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(user3));
-    Assert.assertFalse(aclManager.checkAMModifyAccess(user4));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(user5));
-    Assert.assertFalse(aclManager.checkAMModifyAccess(user6));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(admuser1));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(admuser2));
+    assertTrue(aclManager.checkAMModifyAccess(currentUser));
+    assertFalse(aclManager.checkAMModifyAccess(user1));
+    assertFalse(aclManager.checkAMModifyAccess(user2));
+    assertTrue(aclManager.checkAMModifyAccess(user3));
+    assertFalse(aclManager.checkAMModifyAccess(user4));
+    assertTrue(aclManager.checkAMModifyAccess(user5));
+    assertFalse(aclManager.checkAMModifyAccess(user6));
+    assertTrue(aclManager.checkAMModifyAccess(admuser1));
+    assertTrue(aclManager.checkAMModifyAccess(admuser2));
 
-    Assert.assertTrue(aclManager.checkDAGViewAccess(currentUser));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(user1));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(user2));
-    Assert.assertFalse(aclManager.checkDAGViewAccess(user3));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(user4));
-    Assert.assertFalse(aclManager.checkDAGViewAccess(user5));
-    Assert.assertFalse(aclManager.checkDAGViewAccess(user6));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(admuser1));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(admuser2));
+    assertTrue(aclManager.checkDAGViewAccess(currentUser));
+    assertTrue(aclManager.checkDAGViewAccess(user1));
+    assertTrue(aclManager.checkDAGViewAccess(user2));
+    assertFalse(aclManager.checkDAGViewAccess(user3));
+    assertTrue(aclManager.checkDAGViewAccess(user4));
+    assertFalse(aclManager.checkDAGViewAccess(user5));
+    assertFalse(aclManager.checkDAGViewAccess(user6));
+    assertTrue(aclManager.checkDAGViewAccess(admuser1));
+    assertTrue(aclManager.checkDAGViewAccess(admuser2));
 
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(currentUser));
-    Assert.assertFalse(aclManager.checkDAGModifyAccess(user1));
-    Assert.assertFalse(aclManager.checkDAGModifyAccess(user2));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(user3));
-    Assert.assertFalse(aclManager.checkDAGModifyAccess(user4));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(user5));
-    Assert.assertFalse(aclManager.checkDAGModifyAccess(user6));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(admuser1));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(admuser2));
+    assertTrue(aclManager.checkDAGModifyAccess(currentUser));
+    assertFalse(aclManager.checkDAGModifyAccess(user1));
+    assertFalse(aclManager.checkDAGModifyAccess(user2));
+    assertTrue(aclManager.checkDAGModifyAccess(user3));
+    assertFalse(aclManager.checkDAGModifyAccess(user4));
+    assertTrue(aclManager.checkDAGModifyAccess(user5));
+    assertFalse(aclManager.checkDAGModifyAccess(user6));
+    assertTrue(aclManager.checkDAGModifyAccess(admuser1));
+    assertTrue(aclManager.checkDAGModifyAccess(admuser2));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void checkDAGACLs() throws IOException {
     String[] groups1 = new String[] {"grp1", "grp2"};
     String[] groups2 = new String[] {"grp3", "grp4"};
@@ -271,53 +281,54 @@ public class TestACLManager {
     ACLManager aclManager = new ACLManager(amAclManager, dagUser.getShortUserName(),
         builder.build());
 
-    Assert.assertTrue(aclManager.checkAMViewAccess(currentUser));
-    Assert.assertFalse(aclManager.checkAMViewAccess(dagUser));
-    Assert.assertTrue(aclManager.checkAMViewAccess(user1));
-    Assert.assertTrue(aclManager.checkAMViewAccess(user2));
-    Assert.assertFalse(aclManager.checkAMViewAccess(user3));
-    Assert.assertTrue(aclManager.checkAMViewAccess(user4));
-    Assert.assertFalse(aclManager.checkAMViewAccess(user5));
-    Assert.assertFalse(aclManager.checkAMViewAccess(user6));
-    Assert.assertTrue(aclManager.checkAMViewAccess(admuser1));
-    Assert.assertTrue(aclManager.checkAMViewAccess(admuser2));
+    assertTrue(aclManager.checkAMViewAccess(currentUser));
+    assertFalse(aclManager.checkAMViewAccess(dagUser));
+    assertTrue(aclManager.checkAMViewAccess(user1));
+    assertTrue(aclManager.checkAMViewAccess(user2));
+    assertFalse(aclManager.checkAMViewAccess(user3));
+    assertTrue(aclManager.checkAMViewAccess(user4));
+    assertFalse(aclManager.checkAMViewAccess(user5));
+    assertFalse(aclManager.checkAMViewAccess(user6));
+    assertTrue(aclManager.checkAMViewAccess(admuser1));
+    assertTrue(aclManager.checkAMViewAccess(admuser2));
 
-    Assert.assertTrue(aclManager.checkAMModifyAccess(currentUser));
-    Assert.assertFalse(aclManager.checkAMModifyAccess(dagUser));
-    Assert.assertFalse(aclManager.checkAMModifyAccess(user1));
-    Assert.assertFalse(aclManager.checkAMModifyAccess(user2));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(user3));
-    Assert.assertFalse(aclManager.checkAMModifyAccess(user4));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(user5));
-    Assert.assertFalse(aclManager.checkAMModifyAccess(user6));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(admuser1));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(admuser2));
+    assertTrue(aclManager.checkAMModifyAccess(currentUser));
+    assertFalse(aclManager.checkAMModifyAccess(dagUser));
+    assertFalse(aclManager.checkAMModifyAccess(user1));
+    assertFalse(aclManager.checkAMModifyAccess(user2));
+    assertTrue(aclManager.checkAMModifyAccess(user3));
+    assertFalse(aclManager.checkAMModifyAccess(user4));
+    assertTrue(aclManager.checkAMModifyAccess(user5));
+    assertFalse(aclManager.checkAMModifyAccess(user6));
+    assertTrue(aclManager.checkAMModifyAccess(admuser1));
+    assertTrue(aclManager.checkAMModifyAccess(admuser2));
 
-    Assert.assertTrue(aclManager.checkDAGViewAccess(currentUser));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(dagUser));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(user1));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(user2));
-    Assert.assertFalse(aclManager.checkDAGViewAccess(user3));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(user4));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(user5));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(user6));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(admuser1));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(admuser2));
+    assertTrue(aclManager.checkDAGViewAccess(currentUser));
+    assertTrue(aclManager.checkDAGViewAccess(dagUser));
+    assertTrue(aclManager.checkDAGViewAccess(user1));
+    assertTrue(aclManager.checkDAGViewAccess(user2));
+    assertFalse(aclManager.checkDAGViewAccess(user3));
+    assertTrue(aclManager.checkDAGViewAccess(user4));
+    assertTrue(aclManager.checkDAGViewAccess(user5));
+    assertTrue(aclManager.checkDAGViewAccess(user6));
+    assertTrue(aclManager.checkDAGViewAccess(admuser1));
+    assertTrue(aclManager.checkDAGViewAccess(admuser2));
 
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(currentUser));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(dagUser));
-    Assert.assertFalse(aclManager.checkDAGModifyAccess(user1));
-    Assert.assertFalse(aclManager.checkDAGModifyAccess(user2));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(user3));
-    Assert.assertFalse(aclManager.checkDAGModifyAccess(user4));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(user5));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(user6));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(admuser1));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(admuser2));
+    assertTrue(aclManager.checkDAGModifyAccess(currentUser));
+    assertTrue(aclManager.checkDAGModifyAccess(dagUser));
+    assertFalse(aclManager.checkDAGModifyAccess(user1));
+    assertFalse(aclManager.checkDAGModifyAccess(user2));
+    assertTrue(aclManager.checkDAGModifyAccess(user3));
+    assertFalse(aclManager.checkDAGModifyAccess(user4));
+    assertTrue(aclManager.checkDAGModifyAccess(user5));
+    assertTrue(aclManager.checkDAGModifyAccess(user6));
+    assertTrue(aclManager.checkDAGModifyAccess(admuser1));
+    assertTrue(aclManager.checkDAGModifyAccess(admuser2));
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWildCardCheck() {
     Configuration conf = new Configuration(false);
     String viewACLs = "   *  ";
@@ -329,17 +340,18 @@ public class TestACLManager {
     UserGroupInformation u1 = UserGroupInformation.createUserForTesting("u1", noGroups);
 
     ACLManager aclManager = new ACLManager(a1.getShortUserName(), conf);
-    Assert.assertTrue(aclManager.checkAMViewAccess(a1));
-    Assert.assertTrue(aclManager.checkAMViewAccess(u1));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(a1));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(u1));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(a1));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(u1));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(a1));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(u1));
+    assertTrue(aclManager.checkAMViewAccess(a1));
+    assertTrue(aclManager.checkAMViewAccess(u1));
+    assertTrue(aclManager.checkAMModifyAccess(a1));
+    assertTrue(aclManager.checkAMModifyAccess(u1));
+    assertTrue(aclManager.checkDAGViewAccess(a1));
+    assertTrue(aclManager.checkDAGViewAccess(u1));
+    assertTrue(aclManager.checkDAGModifyAccess(a1));
+    assertTrue(aclManager.checkDAGModifyAccess(u1));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAdminWildCardCheck() {
     Configuration conf = new Configuration(false);
     String yarnAdminACLs = " *  ";
@@ -349,17 +361,18 @@ public class TestACLManager {
     UserGroupInformation u1 = UserGroupInformation.createUserForTesting("u1", noGroups);
 
     ACLManager aclManager = new ACLManager(a1.getShortUserName(), conf);
-    Assert.assertTrue(aclManager.checkAMViewAccess(a1));
-    Assert.assertTrue(aclManager.checkAMViewAccess(u1));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(a1));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(u1));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(a1));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(u1));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(a1));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(u1));
+    assertTrue(aclManager.checkAMViewAccess(a1));
+    assertTrue(aclManager.checkAMViewAccess(u1));
+    assertTrue(aclManager.checkAMModifyAccess(a1));
+    assertTrue(aclManager.checkAMModifyAccess(u1));
+    assertTrue(aclManager.checkDAGViewAccess(a1));
+    assertTrue(aclManager.checkDAGViewAccess(u1));
+    assertTrue(aclManager.checkDAGModifyAccess(a1));
+    assertTrue(aclManager.checkDAGModifyAccess(u1));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testACLsDisabled() {
     Configuration conf = new Configuration(false);
     conf.setBoolean(TezConfiguration.TEZ_AM_ACLS_ENABLED, false);
@@ -372,27 +385,28 @@ public class TestACLManager {
     UserGroupInformation u1 = UserGroupInformation.createUserForTesting("u1", noGroups);
 
     ACLManager aclManager = new ACLManager(a1.getShortUserName(), conf);
-    Assert.assertTrue(aclManager.checkAMViewAccess(a1));
-    Assert.assertTrue(aclManager.checkAMViewAccess(u1));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(a1));
-    Assert.assertTrue(aclManager.checkAMModifyAccess(u1));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(a1));
-    Assert.assertTrue(aclManager.checkDAGViewAccess(u1));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(a1));
-    Assert.assertTrue(aclManager.checkDAGModifyAccess(u1));
+    assertTrue(aclManager.checkAMViewAccess(a1));
+    assertTrue(aclManager.checkAMViewAccess(u1));
+    assertTrue(aclManager.checkAMModifyAccess(a1));
+    assertTrue(aclManager.checkAMModifyAccess(u1));
+    assertTrue(aclManager.checkDAGViewAccess(a1));
+    assertTrue(aclManager.checkDAGViewAccess(u1));
+    assertTrue(aclManager.checkDAGModifyAccess(a1));
+    assertTrue(aclManager.checkDAGModifyAccess(u1));
 
     ACLManager dagAclManager = new ACLManager(aclManager, "dagUser", null);
-    Assert.assertTrue(dagAclManager.checkAMViewAccess(a1));
-    Assert.assertTrue(dagAclManager.checkAMViewAccess(u1));
-    Assert.assertTrue(dagAclManager.checkAMModifyAccess(a1));
-    Assert.assertTrue(dagAclManager.checkAMModifyAccess(u1));
-    Assert.assertTrue(dagAclManager.checkDAGViewAccess(a1));
-    Assert.assertTrue(dagAclManager.checkDAGViewAccess(u1));
-    Assert.assertTrue(dagAclManager.checkDAGModifyAccess(a1));
-    Assert.assertTrue(dagAclManager.checkDAGModifyAccess(u1));
+    assertTrue(dagAclManager.checkAMViewAccess(a1));
+    assertTrue(dagAclManager.checkAMViewAccess(u1));
+    assertTrue(dagAclManager.checkAMModifyAccess(a1));
+    assertTrue(dagAclManager.checkAMModifyAccess(u1));
+    assertTrue(dagAclManager.checkDAGViewAccess(a1));
+    assertTrue(dagAclManager.checkDAGViewAccess(u1));
+    assertTrue(dagAclManager.checkDAGModifyAccess(a1));
+    assertTrue(dagAclManager.checkDAGModifyAccess(u1));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertToYARNACLs() {
     String currentUser = "c1";
     Configuration conf = new Configuration(false);
@@ -402,18 +416,18 @@ public class TestACLManager {
     ACLManager aclManager = new ACLManager(currentUser, conf);
 
     Map<ApplicationAccessType, String> yarnAcls = aclManager.toYARNACls();
-    Assert.assertTrue(yarnAcls.containsKey(ApplicationAccessType.VIEW_APP));
-    Assert.assertEquals("c1,user1,user4 grp3,grp4",
+    assertTrue(yarnAcls.containsKey(ApplicationAccessType.VIEW_APP));
+    assertEquals("c1,user1,user4 grp3,grp4",
         yarnAcls.get(ApplicationAccessType.VIEW_APP));
-    Assert.assertTrue(yarnAcls.containsKey(ApplicationAccessType.MODIFY_APP));
-    Assert.assertEquals("*",
+    assertTrue(yarnAcls.containsKey(ApplicationAccessType.MODIFY_APP));
+    assertEquals("*",
         yarnAcls.get(ApplicationAccessType.MODIFY_APP));
 
     viewACLs = "   grp3,grp4  ";
     conf.set(TezConfiguration.TEZ_AM_VIEW_ACLS, viewACLs);
     ACLManager aclManager1 = new ACLManager(currentUser, conf);
     yarnAcls = aclManager1.toYARNACls();
-    Assert.assertEquals("c1 grp3,grp4",
+    assertEquals("c1 grp3,grp4",
         yarnAcls.get(ApplicationAccessType.VIEW_APP));
 
   }

--- a/tez-api/src/test/java/org/apache/tez/common/security/TestACLManager.java
+++ b/tez-api/src/test/java/org/apache/tez/common/security/TestACLManager.java
@@ -36,7 +36,6 @@ import org.apache.tez.dag.api.records.DAGProtos.ACLInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-
 public class TestACLManager {
 
   private static final String[] noGroups = new String[0];

--- a/tez-api/src/test/java/org/apache/tez/common/security/TestDAGAccessControls.java
+++ b/tez-api/src/test/java/org/apache/tez/common/security/TestDAGAccessControls.java
@@ -18,33 +18,40 @@
  */
 package org.apache.tez.common.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.dag.api.TezConfiguration;
 
 import com.google.common.collect.Sets;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestDAGAccessControls {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testStringBasedConstructor() {
     DAGAccessControls dagAccessControls = new DAGAccessControls("u1 g1", "u2 g2");
 
-    Assert.assertEquals(1, dagAccessControls.getUsersWithViewACLs().size());
-    Assert.assertEquals(1, dagAccessControls.getUsersWithModifyACLs().size());
-    Assert.assertEquals(1, dagAccessControls.getGroupsWithViewACLs().size());
-    Assert.assertEquals(1, dagAccessControls.getGroupsWithModifyACLs().size());
+    assertEquals(1, dagAccessControls.getUsersWithViewACLs().size());
+    assertEquals(1, dagAccessControls.getUsersWithModifyACLs().size());
+    assertEquals(1, dagAccessControls.getGroupsWithViewACLs().size());
+    assertEquals(1, dagAccessControls.getGroupsWithModifyACLs().size());
 
-    Assert.assertTrue(dagAccessControls.getUsersWithViewACLs().contains("u1"));
-    Assert.assertTrue(dagAccessControls.getUsersWithModifyACLs().contains("u2"));
-    Assert.assertTrue(dagAccessControls.getGroupsWithViewACLs().contains("g1"));
-    Assert.assertTrue(dagAccessControls.getGroupsWithModifyACLs().contains("g2"));
+    assertTrue(dagAccessControls.getUsersWithViewACLs().contains("u1"));
+    assertTrue(dagAccessControls.getUsersWithModifyACLs().contains("u2"));
+    assertTrue(dagAccessControls.getGroupsWithViewACLs().contains("g1"));
+    assertTrue(dagAccessControls.getGroupsWithModifyACLs().contains("g2"));
   }
 
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMergeIntoAmAcls() {
     DAGAccessControls dagAccessControls = new DAGAccessControls("u1 g1", "u2 g2");
     Configuration conf = new Configuration(false);
@@ -133,15 +140,15 @@ public class TestDAGAccessControls {
     String [] parts1 = expected.split(" ");
     String [] parts2 = obtained.split(" ");
 
-    Assert.assertEquals(parts1.length, parts2.length);
+    assertEquals(parts1.length, parts2.length);
 
-    Assert.assertEquals(
+    assertEquals(
         Sets.newHashSet(parts1[0].split(",")), Sets.newHashSet(parts2[0].split(",")));
 
     if (parts1.length < 2) {
       return;
     }
-    Assert.assertEquals(
+    assertEquals(
         Sets.newHashSet(parts1[1].split(",")), Sets.newHashSet(parts2[1].split(",")));
   }
 }

--- a/tez-api/src/test/java/org/apache/tez/common/security/TestTokenCache.java
+++ b/tez-api/src/test/java/org/apache/tez/common/security/TestTokenCache.java
@@ -18,6 +18,9 @@
  */
 package org.apache.tez.common.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -28,6 +31,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -40,9 +44,9 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -52,7 +56,7 @@ public class TestTokenCache {
 
   private static String renewer;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     conf = new Configuration();
     conf.set(YarnConfiguration.RM_PRINCIPAL, "mapred/host@REALM");
@@ -61,7 +65,8 @@ public class TestTokenCache {
     renewer = Master.getMasterPrincipal(conf);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   @SuppressWarnings("deprecation")
   public void testBinaryCredentials() throws Exception {
     String binaryTokenFile = null;
@@ -85,7 +90,7 @@ public class TestTokenCache {
       Credentials newCreds = new Credentials();
       TokenCache.mergeBinaryTokens(newCreds, conf, binaryTokenFile);
 
-      Assert.assertTrue(newCreds.getAllTokens().size() > 0);
+      assertTrue(newCreds.getAllTokens().size() > 0);
       checkTokens(creds, newCreds);
     } finally {
       if (binaryTokenFile != null) {
@@ -98,7 +103,8 @@ public class TestTokenCache {
     }
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testObtainTokensForFileSystems() throws Exception {
     Path[] paths = makePaths(100, "test://dir/file");
     Credentials creds = new Credentials();
@@ -171,12 +177,12 @@ public class TestTokenCache {
   }
 
   private void checkTokens(Credentials creds, Credentials newCreds) {
-    Assert.assertEquals(creds.getAllTokens().size(),
+    assertEquals(creds.getAllTokens().size(),
         newCreds.getAllTokens().size());
     for (Token<?> token : newCreds.getAllTokens()) {
       Token<?> credsToken = creds.getToken(token.getService());
-      Assert.assertTrue(credsToken != null);
-      Assert.assertEquals(token, credsToken);
+      assertNotNull(credsToken);
+      assertEquals(token, credsToken);
     }
   }
 

--- a/tez-api/src/test/java/org/apache/tez/dag/api/TestDAG.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/TestDAG.java
@@ -18,8 +18,15 @@
  */
 package org.apache.tez.dag.api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.LocalResourceType;
@@ -34,15 +41,16 @@ import org.apache.tez.dag.api.records.DAGProtos.ConfigurationProto;
 import org.apache.tez.dag.api.records.DAGProtos.DAGPlan;
 import org.apache.tez.dag.api.records.DAGProtos.DAGPlan.Builder;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestDAG {
 
   private final int dummyTaskCount = 2;
   private final Resource dummyTaskResource = Resource.newInstance(1, 1);
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDuplicatedVertices() {
     Vertex v1 = Vertex.create("v1", ProcessorDescriptor.create("Processor"),
         dummyTaskCount, dummyTaskResource);
@@ -52,14 +60,15 @@ public class TestDAG {
     dag.addVertex(v1);
     try {
       dag.addVertex(v2);
-      Assert.fail("should fail it due to duplicated vertices");
+      fail("should fail it due to duplicated vertices");
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.assertEquals("Vertex v1 already defined!", e.getMessage());
+      assertEquals("Vertex v1 already defined!", e.getMessage());
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDuplicatedEdges() {
     Vertex v1 = Vertex.create("v1", ProcessorDescriptor.create("Processor"),
         dummyTaskCount, dummyTaskResource);
@@ -81,14 +90,15 @@ public class TestDAG {
     dag.addEdge(edge1);
     try {
       dag.addEdge(edge2);
-      Assert.fail("should fail it due to duplicated edges");
+      fail("should fail it due to duplicated edges");
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.assertTrue(e.getMessage().contains("already defined!"));
+      assertTrue(e.getMessage().contains("already defined!"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDuplicatedVertexGroup() {
     Vertex v1 = Vertex.create("v1", ProcessorDescriptor.create("Processor"),
         dummyTaskCount, dummyTaskResource);
@@ -102,17 +112,18 @@ public class TestDAG {
 
     try {
       dag.createVertexGroup("group_1", v2, v3);
-      Assert.fail("should fail it due to duplicated VertexGroups");
+      fail("should fail it due to duplicated VertexGroups");
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.assertEquals("VertexGroup group_1 already defined!", e.getMessage());
+      assertEquals("VertexGroup group_1 already defined!", e.getMessage());
     }
     // it is possible to create vertex group with same member but different group name
     dag.createVertexGroup("group_2", v1, v2);
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDuplicatedGroupInputEdge() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create("Processor"),
@@ -148,14 +159,15 @@ public class TestDAG {
     dag.addEdge(e1);
     try {
       dag.addEdge(e2);
-      Assert.fail("should fail it due to duplicated GroupInputEdge");
+      fail("should fail it due to duplicated GroupInputEdge");
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.assertTrue(e.getMessage().contains("already defined"));
+      assertTrue(e.getMessage().contains("already defined"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGConf() {
     DAG dag = DAG.create("DAG-testDAGConf");
     // it's OK to set custom configuration
@@ -164,9 +176,9 @@ public class TestDAG {
     // set invalid AM level configuration
     try {
       dag.setConf(TezConfiguration.TEZ_AM_SESSION_MODE, true+"");
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertEquals("tez.am.mode.session is set at the scope of DAG,"
+      assertEquals("tez.am.mode.session is set at the scope of DAG,"
           + " but it is only valid in the scope of AM",
           e.getMessage());
     }
@@ -176,7 +188,8 @@ public class TestDAG {
     dag.setConf(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS, 3 + "");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexConf() {
     Vertex v1 = Vertex.create("v1", ProcessorDescriptor.create("dummyProcessor"));
     // it's OK to set custom property
@@ -185,9 +198,9 @@ public class TestDAG {
     // set invalid AM level configuration
     try {
       v1.setConf(TezConfiguration.TEZ_AM_SESSION_MODE, true+"");
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertEquals("tez.am.mode.session is set at the scope of VERTEX,"
+      assertEquals("tez.am.mode.session is set at the scope of VERTEX,"
           + " but it is only valid in the scope of AM",
           e.getMessage());
     }
@@ -195,9 +208,9 @@ public class TestDAG {
     // set invalid DAG level configuration
     try {
       v1.setConf(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS, false + "");
-      Assert.fail("should fail due to invalid configuration set");
+      fail("should fail due to invalid configuration set");
     } catch (IllegalStateException e) {
-      Assert.assertEquals("tez.am.commit-all-outputs-on-dag-success is set at the scope of VERTEX,"
+      assertEquals("tez.am.commit-all-outputs-on-dag-success is set at the scope of VERTEX,"
           + " but it is only valid in the scope of DAG",
           e.getMessage());
     }
@@ -205,30 +218,31 @@ public class TestDAG {
     v1.setConf(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS, 3 + "");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDuplicatedInput() {
     Vertex v1 = Vertex.create("v1", ProcessorDescriptor.create("dummyProcessor"));
     DataSourceDescriptor dataSource =
         DataSourceDescriptor.create(InputDescriptor.create("dummyInput"), null, null);
     try {
       v1.addDataSource(null, dataSource);
-      Assert.fail("Should fail due to invalid inputName");
+      fail("Should fail due to invalid inputName");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .contains("InputName should not be null, empty or white space only,"));
     }
     try {
       v1.addDataSource("", dataSource);
-      Assert.fail("Should fail due to invalid inputName");
+      fail("Should fail due to invalid inputName");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .contains("InputName should not be null, empty or white space only,"));
     }
     try {
       v1.addDataSource(" ", dataSource);
-      Assert.fail("Should fail due to invalid inputName");
+      fail("Should fail due to invalid inputName");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .contains("InputName should not be null, empty or white space only,"));
     }
 
@@ -236,36 +250,37 @@ public class TestDAG {
     try {
       v1.addDataSource("input_1",
           DataSourceDescriptor.create(InputDescriptor.create("dummyInput"), null, null));
-      Assert.fail("Should fail due to duplicated input");
+      fail("Should fail due to duplicated input");
     } catch (IllegalArgumentException e) {
-      Assert.assertEquals("Duplicated input:input_1, vertexName=v1", e.getMessage());
+      assertEquals("Duplicated input:input_1, vertexName=v1", e.getMessage());
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDuplicatedOutput_1() {
     Vertex v1 = Vertex.create("v1", ProcessorDescriptor.create("dummyProcessor"));
     DataSinkDescriptor dataSink =
         DataSinkDescriptor.create(OutputDescriptor.create("dummyOutput"), null, null);
     try {
       v1.addDataSink(null, dataSink);
-      Assert.fail("Should fail due to invalid outputName");
+      fail("Should fail due to invalid outputName");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .contains("OutputName should not be null, empty or white space only,"));
     }
     try {
       v1.addDataSink("", dataSink);
-      Assert.fail("Should fail due to invalid outputName");
+      fail("Should fail due to invalid outputName");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .contains("OutputName should not be null, empty or white space only,"));
     }
     try {
       v1.addDataSink(" ", dataSink);
-      Assert.fail("Should fail due to invalid outputName");
+      fail("Should fail due to invalid outputName");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .contains("OutputName should not be null, empty or white space only,"));
     }
 
@@ -274,13 +289,14 @@ public class TestDAG {
     try {
       v1.addDataSink("output_1",
           DataSinkDescriptor.create(OutputDescriptor.create("dummyOutput"), null, null));
-      Assert.fail("Should fail due to duplicated output");
+      fail("Should fail due to duplicated output");
     } catch (IllegalArgumentException e) {
-      Assert.assertEquals("Duplicated output:output_1, vertexName=v1", e.getMessage());
+      assertEquals("Duplicated output:output_1, vertexName=v1", e.getMessage());
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDuplicatedOutput_2() {
     DAG dag = DAG.create("DAG-testDuplicatedOutput_2");
     Vertex v1 = Vertex.create("v1", ProcessorDescriptor.create("dummyProcessor"));
@@ -288,23 +304,23 @@ public class TestDAG {
         DataSinkDescriptor.create(OutputDescriptor.create("dummyOutput"), null, null);
     try {
       v1.addDataSink(null, dataSink);
-      Assert.fail("Should fail due to invalid outputName");
+      fail("Should fail due to invalid outputName");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .contains("OutputName should not be null, empty or white space only,"));
     }
     try {
       v1.addDataSink("", dataSink);
-      Assert.fail("Should fail due to invalid outputName");
+      fail("Should fail due to invalid outputName");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .contains("OutputName should not be null, empty or white space only,"));
     }
     try {
       v1.addDataSink(" ", dataSink);
-      Assert.fail("Should fail due to invalid outputName");
+      fail("Should fail due to invalid outputName");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .contains("OutputName should not be null, empty or white space only,"));
     }
 
@@ -314,9 +330,9 @@ public class TestDAG {
     try {
       vGroup.addDataSink("output_1",
           DataSinkDescriptor.create(OutputDescriptor.create("dummyOutput"), null, null));
-      Assert.fail("Should fail due to duplicated output");
+      fail("Should fail due to duplicated output");
     } catch (IllegalArgumentException e) {
-      Assert.assertEquals("Duplicated output:output_1, vertexName=v1", e.getMessage());
+      assertEquals("Duplicated output:output_1, vertexName=v1", e.getMessage());
     }
   }
 
@@ -324,13 +340,13 @@ public class TestDAG {
   public void testCallerContext() {
     try {
       CallerContext.create("ctxt", "", "", "desc");
-      Assert.fail("Expected failure for invalid args");
+      fail("Expected failure for invalid args");
     } catch (Exception e) {
       // Expected
     }
     try {
       CallerContext.create("", "desc");
-      Assert.fail("Expected failure for invalid args");
+      fail("Expected failure for invalid args");
     } catch (Exception e) {
       // Expected
     }
@@ -339,8 +355,8 @@ public class TestDAG {
     CallerContext.create("ctxt", null);
 
     CallerContext callerContext = CallerContext.create("ctxt", "desc");
-    Assert.assertTrue(callerContext.toString().contains("desc"));
-    Assert.assertFalse(callerContext.contextAsSimpleString().contains("desc"));
+    assertTrue(callerContext.toString().contains("desc"));
+    assertFalse(callerContext.contextAsSimpleString().contains("desc"));
 
   }
 
@@ -361,7 +377,7 @@ public class TestDAG {
     DAGPlan firstPlan = dag.createDag(tezConf, null, null, null, false);
     for (int i = 0; i < 3; ++i) {
         DAGPlan dagPlan = dag.createDag(tezConf, null, null, null, false);
-        Assert.assertEquals(dagPlan, firstPlan);
+        assertEquals(dagPlan, firstPlan);
     }
   }
 
@@ -383,43 +399,43 @@ public class TestDAG {
     // Expect null when history log level is not set in both dag and tezConf
     DAGPlan dagPlan = dag.createDag(tezConf, null, null, null, false);
     Builder builder = DAGPlan.newBuilder(dagPlan);
-    Assert.assertNull(findKVP(builder.getDagConf(), TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL));
+    assertNull(findKVP(builder.getDagConf(), TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL));
 
     // Set tezConf but not dag, expect value in tezConf.
     tezConf.set(TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL, "TASK");
     dagPlan = dag.createDag(tezConf, null, null, null, false);
-    Assert.assertEquals("TASK", findKVP(DAGPlan.newBuilder(dagPlan).getDagConf(),
+    assertEquals("TASK", findKVP(DAGPlan.newBuilder(dagPlan).getDagConf(),
         TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL));
 
     // Set invalid value in tezConf, expect exception.
     tezConf.set(TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL, "invalid");
     try {
       dagPlan = dag.createDag(tezConf, null, null, null, false);
-      Assert.fail("Expected illegal argument exception");
+      fail("Expected illegal argument exception");
     } catch (IllegalArgumentException e) {
-      Assert.assertEquals("Config: " + TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL +
+      assertEquals("Config: " + TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL +
             " is set to invalid value: invalid", e.getMessage());
     }
 
     // Set value in dag, should override tez conf value.
     dag.setHistoryLogLevel(HistoryLogLevel.VERTEX);
     dagPlan = dag.createDag(tezConf, null, null, null, false);
-    Assert.assertEquals("VERTEX", findKVP(DAGPlan.newBuilder(dagPlan).getDagConf(),
+    assertEquals("VERTEX", findKVP(DAGPlan.newBuilder(dagPlan).getDagConf(),
         TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL));
 
     // Set value directly into dagConf.
     dag.setConf(TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL, HistoryLogLevel.DAG.name());
     dagPlan = dag.createDag(tezConf, null, null, null, false);
-    Assert.assertEquals("DAG", findKVP(DAGPlan.newBuilder(dagPlan).getDagConf(),
+    assertEquals("DAG", findKVP(DAGPlan.newBuilder(dagPlan).getDagConf(),
         TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL));
 
     // Set value invalid directly into dagConf and expect exception.
     dag.setConf(TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL, "invalid");
     try {
       dagPlan = dag.createDag(tezConf, null, null, null, false);
-      Assert.fail("Expected illegal argument exception");
+      fail("Expected illegal argument exception");
     } catch (IllegalArgumentException e) {
-      Assert.assertEquals("Config: " + TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL +
+      assertEquals("Config: " + TezConfiguration.TEZ_HISTORY_LOGGING_LOGLEVEL +
             " is set to invalid value: invalid", e.getMessage());
     }
   }
@@ -431,7 +447,7 @@ public class TestDAG {
         if (foundValue == null) {
           foundValue = conf.getConfKeyValues(i).getValue();
         } else {
-          Assert.fail("Multiple values found: " + foundValue + ", " +
+          fail("Multiple values found: " + foundValue + ", " +
               conf.getConfKeyValues(i).getValue());
         }
       }

--- a/tez-api/src/test/java/org/apache/tez/dag/api/TestDAGPlan.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/TestDAGPlan.java
@@ -59,7 +59,7 @@ import org.apache.tez.serviceplugins.api.TaskSchedulerDescriptor;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.io.*;
+import org.junit.jupiter.api.io.TempDir;
 
 // based on TestDAGLocationHint
 public class TestDAGPlan {

--- a/tez-api/src/test/java/org/apache/tez/dag/api/TestDAGPlan.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/TestDAGPlan.java
@@ -18,15 +18,21 @@
  */
 package org.apache.tez.dag.api;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
+import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.Credentials;
@@ -51,17 +57,18 @@ import org.apache.tez.serviceplugins.api.ServicePluginsDescriptor;
 import org.apache.tez.serviceplugins.api.TaskCommunicatorDescriptor;
 import org.apache.tez.serviceplugins.api.TaskSchedulerDescriptor;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.*;
 
 // based on TestDAGLocationHint
 public class TestDAGPlan {
-  @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder(); //TODO: doesn't seem to be deleting this folder automatically as expected.
 
-  @Test(timeout = 5000)
+  @TempDir
+  public Path tempFolder;
+
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasicJobPlanSerde() throws IOException {
 
     DAGPlan job = DAGPlan.newBuilder()
@@ -81,7 +88,7 @@ public class TestDAGPlan {
                    .build())
              .build())
         .build();
-   File file = tempFolder.newFile("jobPlan");
+   File file = tempFolder.resolve("jobPlan").toFile();
    FileOutputStream outStream = null;
    try {
      outStream = new FileOutputStream(file);
@@ -103,10 +110,11 @@ public class TestDAGPlan {
      outStream.close();
    }
 
-   Assert.assertEquals(job, inJob);
+   assertEquals(job, inJob);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEdgeManagerSerde() {
     DAG dag = DAG.create("DAG-testEdgeManagerSerde");
     ProcessorDescriptor pd1 = ProcessorDescriptor.create("processor1")
@@ -137,13 +145,13 @@ public class TestDAGPlan {
         .getEdgeList().get(0));
 
     EdgeManagerPluginDescriptor emDesc = edgeProperty.getEdgeManagerDescriptor();
-    Assert.assertNotNull(emDesc);
-    Assert.assertEquals("emClass", emDesc.getClassName());
-    Assert.assertTrue(
-        Arrays.equals("emPayload".getBytes(), emDesc.getUserPayload().deepCopyAsArray()));
+    assertNotNull(emDesc);
+    assertEquals("emClass", emDesc.getClassName());
+    assertArrayEquals("emPayload".getBytes(), emDesc.getUserPayload().deepCopyAsArray());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testUserPayloadSerde() {
     DAG dag = DAG.create("DAG-testUserPayloadSerde");
     ProcessorDescriptor pd1 = ProcessorDescriptor.create("processor1").
@@ -204,7 +212,8 @@ public class TestDAGPlan {
     assertEquals("output", edgeProperty.getEdgeSource().getClassName());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void userVertexOrderingIsMaintained() {
     DAG dag = DAG.create("DAG-userVertexOrderingIsMaintained");
     ProcessorDescriptor pd1 = ProcessorDescriptor.create("processor1").
@@ -277,7 +286,8 @@ public class TestDAGPlan {
     assertEquals("output", edgeProperty.getEdgeSource().getClassName());
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCredentialsSerde() {
     DAG dag = DAG.create("DAG-testCredentialsSerde");
     ProcessorDescriptor pd1 = ProcessorDescriptor.create("processor1").
@@ -321,7 +331,8 @@ public class TestDAGPlan {
     assertNotNull(fetchedCredentials.getToken(new Text("Token2")));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidExecContext_1() {
     DAG dag = DAG.create("DAG-testInvalidExecContext_1");
     dag.setExecutionContext(VertexExecutionContext.createExecuteInAm(true));
@@ -346,7 +357,8 @@ public class TestDAGPlan {
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidExecContext_2() {
 
     ServicePluginsDescriptor servicePluginsDescriptor = ServicePluginsDescriptor
@@ -428,7 +440,8 @@ public class TestDAGPlan {
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testServiceDescriptorPropagation() {
     DAG dag = DAG.create("DAG-testServiceDescriptorPropagation");
     ProcessorDescriptor pd1 = ProcessorDescriptor.create("processor1").
@@ -491,7 +504,8 @@ public class TestDAGPlan {
     assertFalse(v2Proto.hasExecutionContext());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidJavaOpts() {
     DAG dag = DAG.create("DAG-testInvalidJavaOpts");
     ProcessorDescriptor pd1 = ProcessorDescriptor.create("processor1")
@@ -507,7 +521,7 @@ public class TestDAGPlan {
       dag.createDag(conf, null, null, null, true, null, new JavaOptsChecker());
       fail("Expected dag creation to fail for invalid java opts");
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains("Invalid/conflicting GC options"));
+      assertTrue(e.getMessage().contains("Invalid/conflicting GC options"));
     }
 
     // Should not fail as java opts valid

--- a/tez-api/src/test/java/org/apache/tez/dag/api/TestDAGVerify.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/TestDAGVerify.java
@@ -18,6 +18,14 @@
  */
 package org.apache.tez.dag.api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.LocalResource;
@@ -45,8 +54,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestDAGVerify {
 
@@ -61,7 +70,8 @@ public class TestDAGVerify {
   //    v1
   //    |
   //    v2
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVerifyScatterGather() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create(dummyProcessorClassName),
@@ -81,7 +91,8 @@ public class TestDAGVerify {
     dag.verify();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVerifyCustomEdge() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create(dummyProcessorClassName),
@@ -102,7 +113,8 @@ public class TestDAGVerify {
     dag.verify();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVerifyOneToOne() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create(dummyProcessorClassName),
@@ -122,7 +134,8 @@ public class TestDAGVerify {
     dag.verify();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // v1 (known) -> v2 (-1) -> v3 (-1)
   public void testVerifyOneToOneInferParallelism() {
     Vertex v1 = Vertex.create("v1",
@@ -151,11 +164,12 @@ public class TestDAGVerify {
     dag.addEdge(e1);
     dag.addEdge(e2);
     dag.verify();
-    Assert.assertEquals(dummyTaskCount, v2.getParallelism());
-    Assert.assertEquals(dummyTaskCount, v3.getParallelism());
+    assertEquals(dummyTaskCount, v2.getParallelism());
+    assertEquals(dummyTaskCount, v3.getParallelism());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // v1 (known) -> v2 (-1) -> v3 (-1)
   // The test checks resiliency to ordering of the vertices/edges
   public void testVerifyOneToOneInferParallelismReverseOrder() {
@@ -185,11 +199,12 @@ public class TestDAGVerify {
     dag.addEdge(e2);
     dag.addEdge(e1);
     dag.verify();
-    Assert.assertEquals(dummyTaskCount, v2.getParallelism());
-    Assert.assertEquals(dummyTaskCount, v3.getParallelism());
+    assertEquals(dummyTaskCount, v2.getParallelism());
+    assertEquals(dummyTaskCount, v3.getParallelism());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVerifyOneToOneNoInferParallelism() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create(dummyProcessorClassName),
@@ -210,10 +225,11 @@ public class TestDAGVerify {
     dag.addVertex(v2);
     dag.addEdge(e1);
     dag.verify();
-    Assert.assertEquals(-1, v2.getParallelism());
+    assertEquals(-1, v2.getParallelism());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // v1 (-1) -> v2 (known) -> v3 (-1)
   public void testVerifyOneToOneIncorrectParallelism1() {
     Vertex v1 = Vertex.create("v1",
@@ -243,14 +259,15 @@ public class TestDAGVerify {
     dag.addEdge(e2);
     try {
       dag.verify();
-      Assert.assertTrue(false);
+      fail();
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "1-1 Edge. Destination vertex parallelism must match source vertex"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // v1 (-1) -> v3 (-1), v2 (known) -> v3 (-1)
   // order of edges should not matter
   public void testVerifyOneToOneIncorrectParallelism2() {
@@ -291,14 +308,15 @@ public class TestDAGVerify {
     dag.addEdge(e3);
     try {
       dag.verify();
-      Assert.fail();
+      fail();
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "1-1 Edge. Destination vertex parallelism must match source vertex"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVerifyBroadcast() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create(dummyProcessorClassName),
@@ -318,7 +336,8 @@ public class TestDAGVerify {
     dag.verify();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVerify3() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create(dummyProcessorClassName),
@@ -338,7 +357,8 @@ public class TestDAGVerify {
     dag.verify();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVerify4() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create(dummyProcessorClassName),
@@ -363,7 +383,8 @@ public class TestDAGVerify {
   //       v2   ^
   //      |  |  ^
   //    v3    v4
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCycle1() {
     IllegalStateException ex=null;
     Vertex v1 = Vertex.create("v1",
@@ -413,9 +434,9 @@ public class TestDAGVerify {
     catch (IllegalStateException e){
       ex = e;
     }
-    Assert.assertNotNull(ex);
+    assertNotNull(ex);
     System.out.println(ex.getMessage());
-    Assert.assertTrue(ex.getMessage().startsWith("DAG contains a cycle"));
+    assertTrue(ex.getMessage().startsWith("DAG contains a cycle"));
   }
 
   //     v1
@@ -423,7 +444,8 @@ public class TestDAGVerify {
   //    -> v2
   //    ^  | |
   //    v3    v4
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCycle2() {
     IllegalStateException ex=null;
     Vertex v1 = Vertex.create("v1",
@@ -473,13 +495,14 @@ public class TestDAGVerify {
     catch (IllegalStateException e){
       ex = e;
     }
-    Assert.assertNotNull(ex);
+    assertNotNull(ex);
     System.out.println(ex.getMessage());
-    Assert.assertTrue(ex.getMessage().startsWith("DAG contains a cycle"));
+    assertTrue(ex.getMessage().startsWith("DAG contains a cycle"));
   }
 
   // v1 -> v1
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSelfCycle(){
     IllegalStateException ex=null;
     Vertex v1 = Vertex.create("v1",
@@ -499,12 +522,13 @@ public class TestDAGVerify {
     catch (IllegalStateException e){
       ex = e;
     }
-    Assert.assertNotNull(ex);
+    assertNotNull(ex);
     System.out.println(ex.getMessage());
-    Assert.assertTrue(ex.getMessage().startsWith("DAG contains a self-cycle"));
+    assertTrue(ex.getMessage().startsWith("DAG contains a self-cycle"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void repeatedVertexName() {
     IllegalStateException ex=null;
     Vertex v1 = Vertex.create("v1",
@@ -522,12 +546,13 @@ public class TestDAGVerify {
     catch (IllegalStateException e){
       ex = e;
     }
-    Assert.assertNotNull(ex);
+    assertNotNull(ex);
     System.out.println(ex.getMessage());
-    Assert.assertTrue(ex.getMessage().startsWith("Vertex v1 already defined"));
+    assertTrue(ex.getMessage().startsWith("Vertex v1 already defined"));
   }
 
-  @Test(expected = IllegalStateException.class, timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInputAndInputVertexNameCollision() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create("MapProcessor"),
@@ -548,10 +573,11 @@ public class TestDAGVerify {
     dag.addVertex(v1);
     dag.addVertex(v2);
     dag.addEdge(e1);
-    dag.verify();
+    assertThrows(IllegalStateException.class, dag::verify);
   }
 
-  @Test(expected = IllegalStateException.class, timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOutputAndOutputVertexNameCollision() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create("MapProcessor"),
@@ -572,10 +598,11 @@ public class TestDAGVerify {
     dag.addVertex(v1);
     dag.addVertex(v2);
     dag.addEdge(e1);
-    dag.verify();
+    assertThrows(IllegalStateException.class, dag::verify);
   }
 
-  @Test(expected = IllegalStateException.class, timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOutputAndVertexNameCollision() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create("MapProcessor"),
@@ -589,10 +616,11 @@ public class TestDAGVerify {
     DAG dag = DAG.create("DAG-testOutputAndVertexNameCollision");
     dag.addVertex(v1);
     dag.addVertex(v2);
-    dag.verify();
+    assertThrows(IllegalStateException.class, dag::verify);
   }
 
-  @Test(expected = IllegalStateException.class, timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInputAndVertexNameCollision() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create("MapProcessor"),
@@ -606,13 +634,14 @@ public class TestDAGVerify {
     DAG dag = DAG.create("DAG-testInputAndVertexNameCollision");
     dag.addVertex(v1);
     dag.addVertex(v2);
-    dag.verify();
+    assertThrows(IllegalStateException.class, dag::verify);
   }
 
   //  v1  v2
   //   |  |
   //    v3
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void BinaryInputAllowed() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create("MapProcessor"),
@@ -642,7 +671,8 @@ public class TestDAGVerify {
     dag.verify();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexGroupWithMultipleOutputEdges() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create("Processor"),
@@ -687,15 +717,16 @@ public class TestDAGVerify {
       dag.verify();  // should be OK when called multiple times
     }
 
-    Assert.assertEquals(2, v1.getOutputVertices().size());
-    Assert.assertEquals(2, v2.getOutputVertices().size());
-    Assert.assertTrue(v1.getOutputVertices().contains(v3));
-    Assert.assertTrue(v1.getOutputVertices().contains(v4));
-    Assert.assertTrue(v2.getOutputVertices().contains(v3));
-    Assert.assertTrue(v2.getOutputVertices().contains(v4));
+    assertEquals(2, v1.getOutputVertices().size());
+    assertEquals(2, v2.getOutputVertices().size());
+    assertTrue(v1.getOutputVertices().contains(v3));
+    assertTrue(v1.getOutputVertices().contains(v4));
+    assertTrue(v2.getOutputVertices().contains(v3));
+    assertTrue(v2.getOutputVertices().contains(v4));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexGroup() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create("Processor"),
@@ -749,35 +780,36 @@ public class TestDAGVerify {
     // for the first Group v1 and v2 should get connected to v4 and also have 1 output
     // for the second Group v2 and v3 should get connected to v5
     // the Group place holders should disappear
-    Assert.assertNull(dag.getVertex(uv12.getGroupName()));
-    Assert.assertNull(dag.getVertex(uv23.getGroupName()));
-    Assert.assertFalse(dag.edges.contains(e1));
-    Assert.assertFalse(dag.edges.contains(e2));
-    Assert.assertEquals(1, v1.getOutputs().size());
-    Assert.assertEquals(1, v2.getOutputs().size());
-    Assert.assertEquals(outDesc, v1.getOutputs().get(0).getIODescriptor());
-    Assert.assertEquals(outDesc, v2.getOutputs().get(0).getIODescriptor());
-    Assert.assertEquals(1, v1.getOutputVertices().size());
-    Assert.assertEquals(1, v3.getOutputVertices().size());
-    Assert.assertEquals(2, v2.getOutputVertices().size());
-    Assert.assertTrue(v1.getOutputVertices().contains(v4));
-    Assert.assertTrue(v3.getOutputVertices().contains(v5));
-    Assert.assertTrue(v2.getOutputVertices().contains(v4));
-    Assert.assertTrue(v2.getOutputVertices().contains(v5));
-    Assert.assertEquals(2, v4.getInputVertices().size());
-    Assert.assertTrue(v4.getInputVertices().contains(v1));
-    Assert.assertTrue(v4.getInputVertices().contains(v2));
-    Assert.assertEquals(2, v5.getInputVertices().size());
-    Assert.assertTrue(v5.getInputVertices().contains(v2));
-    Assert.assertTrue(v5.getInputVertices().contains(v3));
-    Assert.assertEquals(1, v4.getGroupInputs().size());
-    Assert.assertTrue(v4.getGroupInputs().containsKey(groupName1));
-    Assert.assertEquals(1, v5.getGroupInputs().size());
-    Assert.assertTrue(v5.getGroupInputs().containsKey(groupName2));
-    Assert.assertEquals(2, dag.vertexGroups.size());
+    assertNull(dag.getVertex(uv12.getGroupName()));
+    assertNull(dag.getVertex(uv23.getGroupName()));
+    assertFalse(dag.edges.contains(e1));
+    assertFalse(dag.edges.contains(e2));
+    assertEquals(1, v1.getOutputs().size());
+    assertEquals(1, v2.getOutputs().size());
+    assertEquals(outDesc, v1.getOutputs().get(0).getIODescriptor());
+    assertEquals(outDesc, v2.getOutputs().get(0).getIODescriptor());
+    assertEquals(1, v1.getOutputVertices().size());
+    assertEquals(1, v3.getOutputVertices().size());
+    assertEquals(2, v2.getOutputVertices().size());
+    assertTrue(v1.getOutputVertices().contains(v4));
+    assertTrue(v3.getOutputVertices().contains(v5));
+    assertTrue(v2.getOutputVertices().contains(v4));
+    assertTrue(v2.getOutputVertices().contains(v5));
+    assertEquals(2, v4.getInputVertices().size());
+    assertTrue(v4.getInputVertices().contains(v1));
+    assertTrue(v4.getInputVertices().contains(v2));
+    assertEquals(2, v5.getInputVertices().size());
+    assertTrue(v5.getInputVertices().contains(v2));
+    assertTrue(v5.getInputVertices().contains(v3));
+    assertEquals(1, v4.getGroupInputs().size());
+    assertTrue(v4.getGroupInputs().containsKey(groupName1));
+    assertEquals(1, v5.getGroupInputs().size());
+    assertTrue(v5.getGroupInputs().containsKey(groupName2));
+    assertEquals(2, dag.vertexGroups.size());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexGroupOneToOne() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create("Processor"),
@@ -828,13 +860,14 @@ public class TestDAGVerify {
       dag.verify();  // should be OK when called multiple times
     }
 
-    Assert.assertEquals(dummyTaskCount, v5.getParallelism());
+    assertEquals(dummyTaskCount, v5.getParallelism());
   }
 
   //   v1
   //  |  |
   //  v2  v3
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void BinaryOutput() {
     IllegalStateException ex = null;
     try {
@@ -868,10 +901,11 @@ public class TestDAGVerify {
     catch (IllegalStateException e){
       ex = e;
     }
-    Assert.assertNull(ex);
+    assertNull(ex);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDagWithNoVertices() {
     IllegalStateException ex=null;
     try {
@@ -881,14 +915,15 @@ public class TestDAGVerify {
     catch (IllegalStateException e){
       ex = e;
     }
-    Assert.assertNotNull(ex);
+    assertNotNull(ex);
     System.out.println(ex.getMessage());
-    Assert.assertTrue(ex.getMessage()
+    assertTrue(ex.getMessage()
         .startsWith("Invalid dag containing 0 vertices"));
   }
 
   @SuppressWarnings("unused")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidVertexConstruction() {
     {
       Vertex v1 = Vertex.create("v1",
@@ -902,11 +937,10 @@ public class TestDAGVerify {
       Vertex v1 = Vertex.create("v1",
           ProcessorDescriptor.create("MapProcessor"),
           -2, dummyTaskResource);
-      Assert.fail("Expected exception for 0 parallelism");
+      fail("Expected exception for 0 parallelism");
     } catch (IllegalArgumentException e) {
-      Assert
-          .assertTrue(e
-              .getMessage()
+      assertTrue(
+          e.getMessage()
               .startsWith(
                   "Parallelism should be -1 if determined by the AM, otherwise should be >= 0"));
     }
@@ -914,13 +948,14 @@ public class TestDAGVerify {
       Vertex v1 = Vertex.create("v1",
           ProcessorDescriptor.create("MapProcessor"),
           1, null);
-      Assert.fail("Expected exception for 0 parallelism");
+      fail("Expected exception for 0 parallelism");
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().startsWith("Resource cannot be null"));
+      assertTrue(e.getMessage().startsWith("Resource cannot be null"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleRootInputsAllowed() {
     DAG dag = DAG.create("DAG-testMultipleRootInputsAllowed");
     ProcessorDescriptor pd1 = ProcessorDescriptor.create("processor1")
@@ -944,7 +979,8 @@ public class TestDAGVerify {
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCreateDataInference() {
     Vertex v1 = Vertex.create("v1", ProcessorDescriptor.create(dummyProcessorClassName));
     Map<String, LocalResource> lrs1 = Maps.newHashMap();
@@ -971,16 +1007,17 @@ public class TestDAGVerify {
     dag.addVertex(v1);
     dag.addTaskLocalFiles(lrs1);
     DAGPlan dagPlan = dag.createDag(new TezConfiguration(), null, null, null, true);
-    Assert.assertEquals(lrName1, dagPlan.getLocalResource(0).getName());
+    assertEquals(lrName1, dagPlan.getLocalResource(0).getName());
     VertexPlan vPlan = dagPlan.getVertex(0);
     PlanTaskConfiguration taskPlan = vPlan.getTaskConfig();
-    Assert.assertEquals(dummyTaskCount, taskPlan.getNumTasks());
-    Assert.assertEquals(TezConfiguration.TEZ_TASK_RESOURCE_MEMORY_MB_DEFAULT, taskPlan.getMemoryMb());
-    Assert.assertEquals(lrName2, taskPlan.getLocalResource(0).getName());
-    Assert.assertEquals(dummyTaskCount, vPlan.getTaskLocationHintCount());
+    assertEquals(dummyTaskCount, taskPlan.getNumTasks());
+    assertEquals(TezConfiguration.TEZ_TASK_RESOURCE_MEMORY_MB_DEFAULT, taskPlan.getMemoryMb());
+    assertEquals(lrName2, taskPlan.getLocalResource(0).getName());
+    assertEquals(dummyTaskCount, vPlan.getTaskLocationHintCount());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInferredFilesFail() {
     Vertex v1 = Vertex.create("v1",
         ProcessorDescriptor.create(dummyProcessorClassName),
@@ -999,9 +1036,9 @@ public class TestDAGVerify {
     // Allowed since the LR is the same.
     try {
       v1.addTaskLocalFiles(lrs2);
-      Assert.fail();
+      fail();
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains("Duplicate Resources found with different size"));
+      assertTrue(e.getMessage().contains("Duplicate Resources found with different size"));
     }
 
     DataSourceDescriptor ds = DataSourceDescriptor.create(InputDescriptor.create("I.class"),
@@ -1013,20 +1050,21 @@ public class TestDAGVerify {
     dag.addTaskLocalFiles(lrs);
     try {
       dag.addTaskLocalFiles(lrs2);
-      Assert.fail();
+      fail();
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains("Duplicate Resources found with different size"));
+      assertTrue(e.getMessage().contains("Duplicate Resources found with different size"));
     }
     try {
       // data source will add duplicate common files to vertex
       dag.createDag(new TezConfiguration(), null, null, null, true);
-      Assert.fail();
+      fail();
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains("Duplicate Resources found with different size"));
+      assertTrue(e.getMessage().contains("Duplicate Resources found with different size"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGAccessControls() {
     DAG dag = DAG.create("DAG-testDAGAccessControls");
     ProcessorDescriptor pd1 = ProcessorDescriptor.create("processor1")
@@ -1043,27 +1081,28 @@ public class TestDAGVerify {
 
     Configuration conf = new Configuration(false);
     DAGPlan dagPlan = dag.createDag(conf, null, null, null, true);
-    Assert.assertNull(conf.get(TezConstants.TEZ_DAG_VIEW_ACLS));
-    Assert.assertNull(conf.get(TezConstants.TEZ_DAG_MODIFY_ACLS));
+    assertNull(conf.get(TezConstants.TEZ_DAG_VIEW_ACLS));
+    assertNull(conf.get(TezConstants.TEZ_DAG_MODIFY_ACLS));
 
     ACLInfo aclInfo = dagPlan.getAclInfo();
-    Assert.assertEquals(Collections.singletonList("u1"), aclInfo.getUsersWithViewAccessList());
-    Assert.assertEquals(Collections.singletonList("g1"), aclInfo.getGroupsWithViewAccessList());
-    Assert.assertEquals(Collections.singletonList("*"), aclInfo.getUsersWithModifyAccessList());
-    Assert.assertEquals(Collections.singletonList("g2"), aclInfo.getGroupsWithModifyAccessList());
+    assertEquals(Collections.singletonList("u1"), aclInfo.getUsersWithViewAccessList());
+    assertEquals(Collections.singletonList("g1"), aclInfo.getGroupsWithViewAccessList());
+    assertEquals(Collections.singletonList("*"), aclInfo.getUsersWithModifyAccessList());
+    assertEquals(Collections.singletonList("g2"), aclInfo.getGroupsWithModifyAccessList());
   }
 
   // v1 has input initializer
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGInvalidParallelism1() {
     DAG dag = DAG.create("DAG-testDAGInvalidParallelism1");
     Vertex v1 = Vertex.create("v1", ProcessorDescriptor.create(dummyProcessorClassName));
     dag.addVertex(v1);
     try {
       dag.verify();
-      Assert.fail();
+      fail();
     } catch (Exception e) {
-      Assert.assertEquals(
+      assertEquals(
           "v1 has -1 tasks but does not have input initializers, 1-1 uninited sources or custom vertex manager to set it at runtime",
           e.getMessage());
     }
@@ -1075,16 +1114,17 @@ public class TestDAGVerify {
   }
 
   // v1 has custom vertex manager
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGInvalidParallelism2() {
     DAG dag = DAG.create("DAG-testDAGInvalidParallelism2");
     Vertex v1 = Vertex.create("v1", ProcessorDescriptor.create(dummyProcessorClassName));
     dag.addVertex(v1);
     try {
       dag.verify();
-      Assert.fail();
+      fail();
     } catch (Exception e) {
-      Assert.assertEquals(
+      assertEquals(
           "v1 has -1 tasks but does not have input initializers, 1-1 uninited sources or custom vertex manager to set it at runtime",
           e.getMessage());
     }
@@ -1094,16 +1134,17 @@ public class TestDAGVerify {
   }
 
   // v1 has 1-1 united source vertex v0 which has input initializer
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGInvalidParallelism3() {
     DAG dag = DAG.create("DAG-testDAGInvalidParallelism3");
     Vertex v1 = Vertex.create("v1", ProcessorDescriptor.create(dummyProcessorClassName));
     dag.addVertex(v1);
     try {
       dag.verify();
-      Assert.fail();
+      fail();
     } catch (Exception e) {
-      Assert.assertEquals(
+      assertEquals(
           "v1 has -1 tasks but does not have input initializers, 1-1 uninited sources or custom vertex manager to set it at runtime",
           e.getMessage());
     }
@@ -1128,9 +1169,9 @@ public class TestDAGVerify {
     dag.addVertex(v1);
     try {
       dag.verify();
-      Assert.fail();
+      fail();
     } catch (Exception e) {
-      Assert.assertEquals(
+      assertEquals(
           "v1 has -1 tasks but does not have input initializers, 1-1 uninited sources or custom vertex manager to set it at runtime",
           e.getMessage());
     }
@@ -1169,7 +1210,8 @@ public class TestDAGVerify {
   }
 
   // Verifies failure in case of a file size difference. Does not verify sha differences.
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGWithConflictingResource() {
     DAG dag = DAG.create("DAG-testDAGWithConflictingResource");
     Map<String, LocalResource> localResourceMap = new HashMap<>();
@@ -1188,9 +1230,9 @@ public class TestDAGVerify {
 
     try {
       dag.verifyLocalResources(new TezConfiguration());
-      Assert.fail("should report failure on conflict resources");
+      fail("should report failure on conflict resources");
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("There is conflicting local resource"));
+      assertTrue(e.getMessage().contains("There is conflicting local resource"));
     }
   }
 }

--- a/tez-api/src/test/java/org/apache/tez/dag/api/TestDAGVerify.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/TestDAGVerify.java
@@ -1103,8 +1103,8 @@ public class TestDAGVerify {
       fail();
     } catch (Exception e) {
       assertEquals(
-          "v1 has -1 tasks but does not have input initializers, 1-1 uninited sources or custom vertex manager to set it at runtime",
-          e.getMessage());
+          "v1 has -1 tasks but does not have input initializers, 1-1 uninited sources or custom vertex manager to set" +
+          " it at runtime", e.getMessage());
     }
 
     DataSourceDescriptor dsDesc = DataSourceDescriptor.create(InputDescriptor.create(dummyInputClassName),
@@ -1125,8 +1125,8 @@ public class TestDAGVerify {
       fail();
     } catch (Exception e) {
       assertEquals(
-          "v1 has -1 tasks but does not have input initializers, 1-1 uninited sources or custom vertex manager to set it at runtime",
-          e.getMessage());
+          "v1 has -1 tasks but does not have input initializers, 1-1 uninited sources or custom vertex manager to set" +
+          " it at runtime", e.getMessage());
     }
 
     v1.setVertexManagerPlugin(VertexManagerPluginDescriptor.create(dummyVMPluginClassName));
@@ -1145,8 +1145,8 @@ public class TestDAGVerify {
       fail();
     } catch (Exception e) {
       assertEquals(
-          "v1 has -1 tasks but does not have input initializers, 1-1 uninited sources or custom vertex manager to set it at runtime",
-          e.getMessage());
+          "v1 has -1 tasks but does not have input initializers, 1-1 uninited sources or custom vertex manager to set" +
+          " it at runtime", e.getMessage());
     }
 
     Vertex v0 = Vertex.create("v0", ProcessorDescriptor.create(dummyProcessorClassName));
@@ -1172,8 +1172,8 @@ public class TestDAGVerify {
       fail();
     } catch (Exception e) {
       assertEquals(
-          "v1 has -1 tasks but does not have input initializers, 1-1 uninited sources or custom vertex manager to set it at runtime",
-          e.getMessage());
+          "v1 has -1 tasks but does not have input initializers, 1-1 uninited sources or custom vertex manager to set" +
+          " it at runtime", e.getMessage());
     }
 
     Vertex v0 = Vertex.create("v2", ProcessorDescriptor.create(dummyProcessorClassName));

--- a/tez-api/src/test/java/org/apache/tez/dag/api/TestDagTypeConverters.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/TestDagTypeConverters.java
@@ -18,14 +18,19 @@
  */
 package org.apache.tez.dag.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.URL;
@@ -47,12 +52,13 @@ import org.apache.tez.serviceplugins.api.TaskSchedulerDescriptor;
 
 import com.google.common.collect.Sets;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestDagTypeConverters {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTezEntityDescriptorSerialization() throws IOException {
     UserPayload payload = UserPayload.create(ByteBuffer.wrap(new String("Foobar").getBytes()), 100);
     String historytext = "Bar123";
@@ -61,24 +67,25 @@ public class TestDagTypeConverters {
         .setHistoryText(historytext);
     TezEntityDescriptorProto proto =
         DagTypeConverters.convertToDAGPlan(entityDescriptor);
-    Assert.assertEquals(payload.getVersion(), proto.getTezUserPayload().getVersion());
-    Assert.assertArrayEquals(payload.deepCopyAsArray(), proto.getTezUserPayload().getUserPayload().toByteArray());
+    assertEquals(payload.getVersion(), proto.getTezUserPayload().getVersion());
+    assertArrayEquals(payload.deepCopyAsArray(), proto.getTezUserPayload().getUserPayload().toByteArray());
     assertTrue(proto.hasHistoryText());
-    Assert.assertNotEquals(historytext, proto.getHistoryText());
-    Assert.assertEquals(historytext, new String(
+    assertNotEquals(historytext, proto.getHistoryText());
+    assertEquals(historytext, new String(
         TezCommonUtils.decompressByteStringToByteArray(proto.getHistoryText())));
 
     // Ensure that the history text is not deserialized
     InputDescriptor inputDescriptor =
         DagTypeConverters.convertInputDescriptorFromDAGPlan(proto);
-    Assert.assertNull(inputDescriptor.getHistoryText());
+    assertNull(inputDescriptor.getHistoryText());
 
     // Check history text value
     String actualHistoryText = DagTypeConverters.getHistoryTextFromProto(proto, TezCommonUtils.newInflater());
-    Assert.assertEquals(historytext, actualHistoryText);
+    assertEquals(historytext, actualHistoryText);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testYarnPathTranslation() {
     // Without port
     String p1String = "hdfs://mycluster/file";
@@ -89,9 +96,9 @@ public class TestDagTypeConverters {
     String p1StringSerialized = DagTypeConverters.convertToDAGPlan(lr1Url);
     // Deserialize
     URL lr1UrlDeserialized = DagTypeConverters.convertToYarnURL(p1StringSerialized);
-    Assert.assertEquals("mycluster", lr1UrlDeserialized.getHost());
-    Assert.assertEquals("/file", lr1UrlDeserialized.getFile());
-    Assert.assertEquals("hdfs", lr1UrlDeserialized.getScheme());
+    assertEquals("mycluster", lr1UrlDeserialized.getHost());
+    assertEquals("/file", lr1UrlDeserialized.getFile());
+    assertEquals("hdfs", lr1UrlDeserialized.getScheme());
 
 
     // With port
@@ -103,14 +110,15 @@ public class TestDagTypeConverters {
     String p2StringSerialized = DagTypeConverters.convertToDAGPlan(lr2Url);
     // Deserialize
     URL lr2UrlDeserialized = DagTypeConverters.convertToYarnURL(p2StringSerialized);
-    Assert.assertEquals("mycluster", lr2UrlDeserialized.getHost());
-    Assert.assertEquals("/file", lr2UrlDeserialized.getFile());
-    Assert.assertEquals("hdfs", lr2UrlDeserialized.getScheme());
-    Assert.assertEquals(2311, lr2UrlDeserialized.getPort());
+    assertEquals("mycluster", lr2UrlDeserialized.getHost());
+    assertEquals("/file", lr2UrlDeserialized.getFile());
+    assertEquals("hdfs", lr2UrlDeserialized.getScheme());
+    assertEquals(2311, lr2UrlDeserialized.getPort());
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexExecutionContextTranslation() {
     VertexExecutionContext originalContext;
     VertexExecutionContextProto contextProto;
@@ -142,7 +150,8 @@ public class TestDagTypeConverters {
   static final String testComm = "testComm";
   static final String classSuffix = "_class";
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testServiceDescriptorTranslation() {
 
 

--- a/tez-api/src/test/java/org/apache/tez/dag/api/TestEntityDescriptor.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/TestEntityDescriptor.java
@@ -18,6 +18,9 @@
  */
 package org.apache.tez.dag.api;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
@@ -28,25 +31,26 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.tez.common.TezUtils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestEntityDescriptor {
 
   public void verifyResults(InputDescriptor entityDescriptor, InputDescriptor deserialized, UserPayload payload,
                              String confVal) throws IOException {
-    Assert.assertEquals(entityDescriptor.getClassName(), deserialized.getClassName());
+    assertEquals(entityDescriptor.getClassName(), deserialized.getClassName());
     // History text is not serialized when sending to tasks
-    Assert.assertNull(deserialized.getHistoryText());
-    Assert.assertArrayEquals(payload.deepCopyAsArray(), deserialized.getUserPayload().deepCopyAsArray());
+    assertNull(deserialized.getHistoryText());
+    assertArrayEquals(payload.deepCopyAsArray(), deserialized.getUserPayload().deepCopyAsArray());
     Configuration deserializedConf = TezUtils.createConfFromUserPayload(deserialized.getUserPayload());
-    Assert.assertEquals(confVal, deserializedConf.get("testKey"));
+    assertEquals(confVal, deserializedConf.get("testKey"));
   }
 
   public void testSingularWrite(InputDescriptor entityDescriptor, InputDescriptor deserialized, UserPayload payload,
@@ -74,7 +78,8 @@ public class TestEntityDescriptor {
     verifyResults(entityDescriptor, deserialized, payload, confVal);
   }
 
-  @Test (timeout=3000)
+  @Test
+  @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
   public void testEntityDescriptorHadoopSerialization() throws IOException {
      /* This tests the alternate serialization code path
      * if the DataOutput is not DataOutputBuffer

--- a/tez-api/src/test/java/org/apache/tez/dag/api/TestHistoryLogLevel.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/TestHistoryLogLevel.java
@@ -18,15 +18,16 @@
  */
 package org.apache.tez.dag.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.hadoop.conf.Configuration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 public class TestHistoryLogLevel {
 

--- a/tez-api/src/test/java/org/apache/tez/dag/api/TestTaskLocationHint.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/TestTaskLocationHint.java
@@ -18,14 +18,20 @@
  */
 package org.apache.tez.dag.api;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.concurrent.TimeUnit;
+
 import com.google.common.collect.Sets;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTaskLocationHint {
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEquality() {
     TaskLocationHint t1 = TaskLocationHint.createTaskLocationHint("v1", 0);
     TaskLocationHint t2 = TaskLocationHint.createTaskLocationHint("v1", 0);
@@ -42,21 +48,21 @@ public class TestTaskLocationHint {
     TaskLocationHint t10 = TaskLocationHint.createTaskLocationHint(
         Sets.newHashSet(new String[] {"n1"}), Sets.newHashSet(new String[] {"r1", "r2"}));
 
-    Assert.assertEquals(t1, t2);
-    Assert.assertEquals(t5, t6);
-    Assert.assertEquals(t7, t8);
-    Assert.assertEquals(t2, t1);
-    Assert.assertEquals(t6, t5);
-    Assert.assertEquals(t8, t7);
-    Assert.assertNotEquals(t1, t3);
-    Assert.assertNotEquals(t3, t1);
-    Assert.assertNotEquals(t1, t4);
-    Assert.assertNotEquals(t4, t1);
-    Assert.assertNotEquals(t1, t5);
-    Assert.assertNotEquals(t5, t1);
-    Assert.assertNotEquals(t8, t9);
-    Assert.assertNotEquals(t9, t8);
-    Assert.assertNotEquals(t9, t10);
-    Assert.assertNotEquals(t10, t9);
+    assertEquals(t1, t2);
+    assertEquals(t5, t6);
+    assertEquals(t7, t8);
+    assertEquals(t2, t1);
+    assertEquals(t6, t5);
+    assertEquals(t8, t7);
+    assertNotEquals(t1, t3);
+    assertNotEquals(t3, t1);
+    assertNotEquals(t1, t4);
+    assertNotEquals(t4, t1);
+    assertNotEquals(t1, t5);
+    assertNotEquals(t5, t1);
+    assertNotEquals(t8, t9);
+    assertNotEquals(t9, t8);
+    assertNotEquals(t9, t10);
+    assertNotEquals(t10, t9);
   }
 }

--- a/tez-api/src/test/java/org/apache/tez/dag/api/TestTezConfiguration.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/TestTezConfiguration.java
@@ -69,8 +69,7 @@ public class TestTezConfiguration {
         // not prefix
         if (!value.endsWith(".")) {
           expectedKeys.add((String) f.get(null));
-          assertNotNull(
-              f.getAnnotation(ConfigurationScope.class),
+          assertNotNull(f.getAnnotation(ConfigurationScope.class),
               "field " + f.getName() + " do not have annotation of ConfigurationScope.");
         }
       }

--- a/tez-api/src/test/java/org/apache/tez/dag/api/TestTezConfiguration.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/TestTezConfiguration.java
@@ -18,53 +18,60 @@
  */
 package org.apache.tez.dag.api;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTezConfiguration {
 
   private static final String expectedValue = "tez.tar.gz";
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConstruction() {
     TezConfiguration tezConf1 = new TezConfiguration();
-    Assert.assertEquals(expectedValue, tezConf1.get(TezConfiguration.TEZ_LIB_URIS));
+    assertEquals(expectedValue, tezConf1.get(TezConfiguration.TEZ_LIB_URIS));
 
     Configuration tezConf2 = new Configuration(true);
-    Assert.assertNull(tezConf2.get(TezConfiguration.TEZ_LIB_URIS));
+    assertNull(tezConf2.get(TezConfiguration.TEZ_LIB_URIS));
 
     TezConfiguration tezConf3 = new TezConfiguration(new Configuration());
-    Assert.assertEquals(expectedValue, tezConf3.get(TezConfiguration.TEZ_LIB_URIS));
+    assertEquals(expectedValue, tezConf3.get(TezConfiguration.TEZ_LIB_URIS));
 
     TezConfiguration tezConf4 = new TezConfiguration(false);
-    Assert.assertNull(tezConf4.get(TezConfiguration.TEZ_LIB_URIS));
+    assertNull(tezConf4.get(TezConfiguration.TEZ_LIB_URIS));
 
     Configuration tezConf5 = new Configuration(true);
-    Assert.assertNull(tezConf5.get(TezConfiguration.TEZ_LIB_URIS));
+    assertNull(tezConf5.get(TezConfiguration.TEZ_LIB_URIS));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testKeySet() throws IllegalAccessException {
     Class<?> c = TezConfiguration.class;
     Set<String> expectedKeys = new HashSet<String>();
     for (Field f : c.getFields()) {
-      if (!f.getName().endsWith("DEFAULT") && f.getType() == String.class
+      if (!f.getName().endsWith("DEFAULT")
+          && f.getType() == String.class
           && !f.getName().equals("TEZ_SITE_XML")) {
-        String value = (String)f.get(null);
+        String value = (String) f.get(null);
         // not prefix
         if (!value.endsWith(".")) {
           expectedKeys.add((String) f.get(null));
-          Assert.assertNotNull("field " + f.getName() + " do not have annotation of ConfigurationScope.",
-              f.getAnnotation(ConfigurationScope.class));
+          assertNotNull(
+              f.getAnnotation(ConfigurationScope.class),
+              "field " + f.getName() + " do not have annotation of ConfigurationScope.");
         }
       }
     }
@@ -75,6 +82,6 @@ public class TestTezConfiguration {
         fail("Found unexpected key: " + key + " in key set");
       }
     }
-    assertTrue("Missing keys in key set: " + expectedKeys, expectedKeys.size() == 0);
+    assertEquals(0, expectedKeys.size(), "Missing keys in key set: " + expectedKeys);
   }
 }

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/TestATSHttpClient.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/TestATSHttpClient.java
@@ -18,7 +18,10 @@
  */
 package org.apache.tez.dag.api.client;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -28,32 +31,34 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.common.counters.TezCounters;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.TezException;
+import org.apache.tez.dag.api.client.DAGStatus.State;
 
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestATSHttpClient {
 
-  @Before
-  public void setup() {
+  @BeforeAll
+  public static void setup() {
     // Disable tests if hadoop version is less than 2.4.0
     // as Timeline is not supported in 2.2.x or 2.3.x
     // If enabled with the lower versions, tests fail due to incompatible use of an API
     // YarnConfiguration::useHttps which only exists in versions 2.4 and higher
     String hadoopVersion = System.getProperty("tez.hadoop.version");
-    Assume.assumeFalse(hadoopVersion.startsWith("2.2.") || hadoopVersion.startsWith("2.3."));
+    assumeFalse(hadoopVersion.startsWith("2.2.") || hadoopVersion.startsWith("2.3."));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetDagStatusThrowsExceptionOnEmptyJson() throws TezException {
     ApplicationId mockAppId = mock(ApplicationId.class);
     DAGClientTimelineImpl httpClient = new DAGClientTimelineImpl(mockAppId, "EXAMPLE_DAG_ID",
@@ -73,11 +78,12 @@ public class TestATSHttpClient {
       fail("should not come here");
     }
 
-    Assert.assertTrue("Expected TezException but did not happen", exceptionHappened);
+    assertTrue(exceptionHappened, "Expected TezException but did not happen");
     verify(spyClient).getJsonRootEntity(expectedDagUrl);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetDagStatusSimple() throws TezException, JSONException, IOException {
     DAGClientTimelineImpl
         httpClient = new DAGClientTimelineImpl(mock(ApplicationId.class),"EXAMPLE_DAG_ID",
@@ -119,25 +125,24 @@ public class TestATSHttpClient {
 
     DAGStatus dagStatus = spyClient.getDAGStatus(statusOptions);
 
-    Assert.assertEquals("DAG State", DAGStatus.State.SUCCEEDED, dagStatus.getState());
-    Assert.assertEquals("DAG Diagnostics size", 1, dagStatus.getDiagnostics().size());
-    Assert.assertEquals("DAG diagnostics detail", "SAMPLE_DIAGNOSTICS",
-        dagStatus.getDiagnostics().get(0));
-    Assert.assertEquals("Counters Size", 2, dagStatus.getDAGCounters().countCounters());
-    Assert.assertEquals("Counter Value", 1,
-        dagStatus.getDAGCounters().getGroup("CG1").findCounter("C1").getValue());
-    Assert.assertEquals("total tasks", 15, dagStatus.getDAGProgress().getTotalTaskCount());
-    Assert.assertEquals("failed tasks", 2, dagStatus.getDAGProgress().getFailedTaskCount());
-    Assert.assertEquals("killed tasks", 6, dagStatus.getDAGProgress().getKilledTaskCount());
-    Assert.assertEquals("succeeded tasks", 7, dagStatus.getDAGProgress().getSucceededTaskCount());
-    Assert.assertEquals("running tasks", 8, dagStatus.getDAGProgress().getRunningTaskCount());
+    assertEquals(State.SUCCEEDED, dagStatus.getState(), "DAG State");
+    assertEquals(1, dagStatus.getDiagnostics().size(), "DAG Diagnostics size");
+    assertEquals("SAMPLE_DIAGNOSTICS", dagStatus.getDiagnostics().get(0), "DAG diagnostics detail");
+    assertEquals(2, dagStatus.getDAGCounters().countCounters(), "Counters Size");
+    assertEquals(1, dagStatus.getDAGCounters().getGroup("CG1").findCounter("C1").getValue(), "Counter Value");
+    assertEquals(15, dagStatus.getDAGProgress().getTotalTaskCount(), "total tasks");
+    assertEquals(2, dagStatus.getDAGProgress().getFailedTaskCount(), "failed tasks");
+    assertEquals(6, dagStatus.getDAGProgress().getKilledTaskCount(), "killed tasks");
+    assertEquals(7, dagStatus.getDAGProgress().getSucceededTaskCount(), "succeeded tasks");
+    assertEquals(8, dagStatus.getDAGProgress().getRunningTaskCount(), "running tasks");
     final Map<String, Progress> vertexProgress = dagStatus.getVertexProgress();
-    Assert.assertEquals("vertex progress count", 2, vertexProgress.size());
-    Assert.assertTrue("vertex name1", vertexProgress.containsKey("v1"));
-    Assert.assertTrue("vertex name2", vertexProgress.containsKey("v2"));
+    assertEquals(2, vertexProgress.size(), "vertex progress count");
+    assertTrue(vertexProgress.containsKey("v1"), "vertex name1");
+    assertTrue(vertexProgress.containsKey("v2"), "vertex name2");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetVertexStatusSimple() throws JSONException, TezException, IOException {
     DAGClientTimelineImpl
         httpClient = new DAGClientTimelineImpl(mock(ApplicationId.class), "EXAMPLE_DAG_ID",
@@ -165,16 +170,15 @@ public class TestATSHttpClient {
     doReturn(new JSONObject(jsonData)).when(spyClient).getJsonRootEntity(expectedVertexUrl);
 
     VertexStatus vertexStatus = spyClient.getVertexStatus("vertex1name", statusOptions);
-    Assert.assertEquals("status check", VertexStatus.State.SUCCEEDED, vertexStatus.getState());
-    Assert.assertEquals("diagnostics", "diagnostics1", vertexStatus.getDiagnostics().get(0));
+    assertEquals(VertexStatus.State.SUCCEEDED, vertexStatus.getState(), "status check");
+    assertEquals("diagnostics1", vertexStatus.getDiagnostics().get(0), "diagnostics");
     final Progress progress = vertexStatus.getProgress();
     final TezCounters vertexCounters = vertexStatus.getVertexCounters();
-    Assert.assertEquals("failed task count", 1, progress.getFailedTaskCount());
-    Assert.assertEquals("suceeded task count", 2, progress.getSucceededTaskCount());
-    Assert.assertEquals("killed task count", 3, progress.getKilledTaskCount());
-    Assert.assertEquals("total task count", 4, progress.getTotalTaskCount());
-    Assert.assertEquals("Counters Size", 2, vertexCounters.countCounters());
-    Assert.assertEquals("Counter Value", 1,
-        vertexCounters.getGroup("CG1").findCounter("C1").getValue());
+    assertEquals(1, progress.getFailedTaskCount(), "failed task count");
+    assertEquals(2, progress.getSucceededTaskCount(), "suceeded task count");
+    assertEquals(3, progress.getKilledTaskCount(), "killed task count");
+    assertEquals(4, progress.getTotalTaskCount(), "total task count");
+    assertEquals(2, vertexCounters.countCounters(), "Counters Size");
+    assertEquals(1, vertexCounters.getGroup("CG1").findCounter("C1").getValue(), "Counter Value");
   }
 }

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/TestTimelineReaderFactory.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/TestTimelineReaderFactory.java
@@ -17,11 +17,12 @@
  * under the License.
  */
 package org.apache.tez.dag.api.client;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -29,25 +30,28 @@ import org.apache.hadoop.security.authentication.client.ConnectionConfigurator;
 import org.apache.tez.dag.api.TezException;
 import org.apache.tez.dag.api.client.TimelineReaderFactory.TimelineReaderPseudoAuthenticatedStrategy;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTimelineReaderFactory {
 
-  // ensure TimelineReaderTokenAuthenticatedStrategy is used.
-  @Test(timeout = 5000)
+  // ensure on hadoop 2.6+ TimelineReaderTokenAuthenticatedStrategy is used.
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testShouldUseTokenDelegationAuthStrategy() throws TezException {
 
     String returnedClassName =
         TimelineReaderFactory.getTimelineReaderStrategy(mock(Configuration.class), false, 0)
             .getClass()
             .getCanonicalName();
-    Assert.assertEquals("should use token delegation auth",
+    assertEquals(
         "org.apache.tez.dag.api.client.TimelineReaderFactory.TimelineReaderTokenAuthenticatedStrategy",
-        returnedClassName);
+        returnedClassName,
+        "should use token delegation auth");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPseudoAuthenticatorConnectionUrlShouldHaveUserName() throws Exception {
     ConnectionConfigurator connConf = mock(ConnectionConfigurator.class);
     TimelineReaderPseudoAuthenticatedStrategy.PseudoAuthenticatedURLConnectionFactory
@@ -56,7 +60,7 @@ public class TestTimelineReaderFactory {
     String inputUrl = "http://host:8080/path";
     String expectedUrl = inputUrl + "?user.name=" + UserGroupInformation.getCurrentUser().getShortUserName();
     HttpURLConnection httpURLConnection = connectionFactory.getConnection(URI.create(inputUrl).toURL());
-    Assert.assertEquals(expectedUrl, httpURLConnection.getURL().toString());
+    assertEquals(expectedUrl, httpURLConnection.getURL().toString());
   }
 
 }

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/TestTimelineReaderFactory.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/TestTimelineReaderFactory.java
@@ -44,10 +44,8 @@ public class TestTimelineReaderFactory {
         TimelineReaderFactory.getTimelineReaderStrategy(mock(Configuration.class), false, 0)
             .getClass()
             .getCanonicalName();
-    assertEquals(
-        "org.apache.tez.dag.api.client.TimelineReaderFactory.TimelineReaderTokenAuthenticatedStrategy",
-        returnedClassName,
-        "should use token delegation auth");
+    assertEquals("org.apache.tez.dag.api.client.TimelineReaderFactory.TimelineReaderTokenAuthenticatedStrategy",
+        returnedClassName, "should use token delegation auth");
   }
 
   @Test

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClient.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClient.java
@@ -18,8 +18,14 @@
  */
 package org.apache.tez.dag.api.client.rpc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doAnswer;
@@ -34,6 +40,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nullable;
@@ -77,9 +84,9 @@ import org.apache.tez.dag.api.records.DAGProtos.VertexStatusStateProto;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.util.collections.Sets;
@@ -187,7 +194,7 @@ public class TestDAGClient {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws YarnException, IOException, TezException, ServiceException{
 
     setUpData();
@@ -216,7 +223,8 @@ public class TestDAGClient {
     realClient.proxy = mockProxy;
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testApp() throws IOException, TezException, ServiceException{
     assertTrue(dagClient.getExecutionContext().contains(mockAppId.toString()));
     assertEquals(mockAppId.toString(), dagClient.getSessionIdentifierString());
@@ -225,7 +233,8 @@ public class TestDAGClient {
     assertEquals(mockAppReport, realClient.getApplicationReportInternal());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGStatus() throws Exception{
     DAGStatus resultDagStatus = dagClient.getDAGStatus(null);
     verify(mockProxy, times(1)).getDAGStatus(null, GetDAGStatusRequestProto.newBuilder()
@@ -240,7 +249,8 @@ public class TestDAGClient {
     System.out.println("DAGStatusWithCounter:" + resultDagStatus);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexStatus() throws Exception{
     VertexStatus resultVertexStatus = dagClient.getVertexStatus("v1", null);
     verify(mockProxy).getVertexStatus(null, GetVertexStatusRequestProto.newBuilder()
@@ -256,14 +266,16 @@ public class TestDAGClient {
     System.out.println("VertexWithCounter:" + resultVertexStatus);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTryKillDAG() throws Exception{
     dagClient.tryKillDAG();
     verify(mockProxy, times(1)).tryKillDAG(null, TryKillDAGRequestProto.newBuilder()
         .setDagId(dagIdStr).build());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWaitForCompletion() throws Exception{
     // first time return DAG_RUNNING, second time return DAG_SUCCEEDED
     when(mockProxy.getDAGStatus(isNull(), any()))
@@ -283,7 +295,8 @@ public class TestDAGClient {
         .getDAGStatus(rpcControllerArgumentCaptor.capture(), argumentCaptor.capture());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWaitForCompletionWithStatusUpdates() throws Exception{
 
     // first time and second time return DAG_RUNNING, third time return DAG_SUCCEEDED
@@ -338,7 +351,8 @@ public class TestDAGClient {
         .getDAGStatus(rpcControllerArgumentCaptor.capture(), argumentCaptor.capture());
   }
 
-  @Test(timeout = 50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testGetDagStatusWithTimeout() throws Exception {
     long startTime;
     long endTime;
@@ -412,7 +426,8 @@ public class TestDAGClient {
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDagClientTimelineEnabledCondition() throws IOException {
     String historyLoggingClass = "org.apache.tez.dag.history.logging.ats.ATSHistoryLoggingService";
 
@@ -591,7 +606,7 @@ public class TestDAGClient {
         reloaderThread = thread;
       }
     }
-    Assert.assertTrue("Reloader is not alive", reloaderThread.isAlive());
+    assertTrue(reloaderThread.isAlive(), "Reloader is not alive");
 
     dagClient.close();
     boolean reloaderStillAlive = true;
@@ -602,10 +617,11 @@ public class TestDAGClient {
       }
       Thread.sleep(1000);
     }
-    Assert.assertFalse("Reloader is still alive", reloaderStillAlive);
+    assertFalse(reloaderStillAlive, "Reloader is still alive");
   }
 
-  @Test(timeout = 50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testGetDagStatusWithCachedStatusExpiration() throws Exception {
     long startTime;
     long endTime;
@@ -625,8 +641,8 @@ public class TestDAGClient {
 
       // Fetch from AM. RUNNING
       rmDagStatus =
-          new DAGStatus(constructDagStatusProto(DAGStatusStateProto.DAG_RUNNING),
-              DagStatusSource.RM);
+          new DAGStatus(
+              constructDagStatusProto(DAGStatusStateProto.DAG_RUNNING), DagStatusSource.RM);
       dagClientImpl.setRmDagStatus(rmDagStatus);
       dagClientRpc.setAMProxy(createMockProxy(DAGStatusStateProto.DAG_RUNNING, -1));
 
@@ -639,14 +655,14 @@ public class TestDAGClient {
       assertEquals(0, dagClientImpl.numGetStatusViaRmInvocations);
       // Directly from AM - one refresh. One with timeout.
       assertEquals(2, dagClientRpc.numGetStatusViaAmInvocations);
-      assertEquals(DAGStatus.State.RUNNING, dagStatus.getState());
+      assertEquals(State.RUNNING, dagStatus.getState());
 
       // Fetch from AM. Success.
       dagClientImpl.resetCounters();
       dagClientRpc.resetCounters();
       rmDagStatus =
-          new DAGStatus(constructDagStatusProto(DAGStatusStateProto.DAG_RUNNING),
-              DagStatusSource.RM);
+          new DAGStatus(
+              constructDagStatusProto(DAGStatusStateProto.DAG_RUNNING), DagStatusSource.RM);
       dagClientImpl.setRmDagStatus(rmDagStatus);
       dagClientRpc.setAMProxy(createMockProxy(DAGStatusStateProto.DAG_SUCCEEDED, 1000L));
 
@@ -654,17 +670,17 @@ public class TestDAGClient {
       dagStatus = dagClientImpl.getDAGStatus(EnumSet.noneOf(StatusGetOpts.class), 2000L);
       endTime = System.currentTimeMillis();
       diff = endTime - startTime;
-      assertTrue("diff is " + diff, diff > 500L && diff < 1500L);
+      assertTrue(diff > 500L && diff < 1500L, "diff is " + diff);
       // Directly from AM
       assertEquals(0, dagClientImpl.numGetStatusViaRmInvocations);
       // Directly from AM - previous request cached, so single invocation only.
       assertEquals(1, dagClientRpc.numGetStatusViaAmInvocations);
-      assertEquals(DAGStatus.State.SUCCEEDED, dagStatus.getState());
+      assertEquals(State.SUCCEEDED, dagStatus.getState());
 
       // verify that the cachedDAGStatus is correct
       DAGStatus cachedDagStatus = dagClientImpl.getCachedDAGStatus();
-      Assert.assertNotNull(cachedDagStatus);
-      Assert.assertSame(dagStatus, cachedDagStatus);
+      assertNotNull(cachedDagStatus);
+      assertSame(dagStatus, cachedDagStatus);
 
       // When AM proxy throws an exception, the cachedDAGStatus should be returned
       dagClientImpl.resetCounters();
@@ -675,8 +691,8 @@ public class TestDAGClient {
       assertEquals(0, dagClientImpl.numGetStatusViaRmInvocations);
       // Directly from AM - previous request cached, so single invocation only.
       assertEquals(1, dagClientRpc.numGetStatusViaAmInvocations);
-      assertEquals(DAGStatus.State.SUCCEEDED, dagStatus.getState());
-      Assert.assertSame(dagStatus, cachedDagStatus);
+      assertEquals(State.SUCCEEDED, dagStatus.getState());
+      assertSame(dagStatus, cachedDagStatus);
 
       // test that RM is invoked when the cacheExpires and the AM fails.
       dagClientRpc.setAMProxy(createMockProxy(DAGStatusStateProto.DAG_SUCCEEDED, 1000L));
@@ -689,13 +705,13 @@ public class TestDAGClient {
       assertEquals(1, dagClientImpl.numGetStatusViaRmInvocations);
       assertEquals(1, dagClientRpc.numGetStatusViaAmInvocations);
       assertEquals(State.RUNNING, dagStatus.getState());
-      Assert.assertNotSame(dagStatus, cachedDagStatus);
+      assertNotSame(dagStatus, cachedDagStatus);
 
       // verify that the cachedDAGStatus is null because AM threw exception before setting the
       // cache.
       cachedDagStatus = dagClientImpl.getCachedDAGStatus();
-      Assert.assertNull(cachedDagStatus);
-      Assert.assertNotNull(dagStatus);
+      assertNull(cachedDagStatus);
+      assertNotNull(dagStatus);
 
       // inject fault in RM too. getDAGStatus should return null;
       dagClientImpl.resetCounters();
@@ -704,9 +720,9 @@ public class TestDAGClient {
       dagClientImpl.injectFault();
       try {
         dagClientImpl.getDAGStatus(EnumSet.noneOf(StatusGetOpts.class));
-        Assert.fail("The RM should throw IOException");
+        fail("The RM should throw IOException");
       } catch (IOException ioException) {
-        Assert.assertEquals(ioException.getMessage(), "Fault Injected for RM");
+        assertEquals(ioException.getMessage(), "Fault Injected for RM");
         assertEquals(1, dagClientImpl.numGetStatusViaRmInvocations);
         assertEquals(1, dagClientRpc.numGetStatusViaAmInvocations);
       }

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClient.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClient.java
@@ -640,9 +640,7 @@ public class TestDAGClient {
       DAGStatus rmDagStatus;
 
       // Fetch from AM. RUNNING
-      rmDagStatus =
-          new DAGStatus(
-              constructDagStatusProto(DAGStatusStateProto.DAG_RUNNING), DagStatusSource.RM);
+      rmDagStatus = new DAGStatus(constructDagStatusProto(DAGStatusStateProto.DAG_RUNNING), DagStatusSource.RM);
       dagClientImpl.setRmDagStatus(rmDagStatus);
       dagClientRpc.setAMProxy(createMockProxy(DAGStatusStateProto.DAG_RUNNING, -1));
 
@@ -660,9 +658,7 @@ public class TestDAGClient {
       // Fetch from AM. Success.
       dagClientImpl.resetCounters();
       dagClientRpc.resetCounters();
-      rmDagStatus =
-          new DAGStatus(
-              constructDagStatusProto(DAGStatusStateProto.DAG_RUNNING), DagStatusSource.RM);
+      rmDagStatus = new DAGStatus(constructDagStatusProto(DAGStatusStateProto.DAG_RUNNING), DagStatusSource.RM);
       dagClientImpl.setRmDagStatus(rmDagStatus);
       dagClientRpc.setAMProxy(createMockProxy(DAGStatusStateProto.DAG_SUCCEEDED, 1000L));
 

--- a/tez-api/src/test/java/org/apache/tez/runtime/api/events/TestCompositeDataMovementEvent.java
+++ b/tez-api/src/test/java/org/apache/tez/runtime/api/events/TestCompositeDataMovementEvent.java
@@ -18,25 +18,30 @@
  */
 package org.apache.tez.runtime.api.events;
 
-import java.nio.ByteBuffer;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Assert;
-import org.junit.Test;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestCompositeDataMovementEvent {
   ByteBuffer userPayload = ByteBuffer.wrap("Dummy userPayLoad".getBytes());
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetCount(){
     int numPartitions = 2;
     int startIndex = 2;
     CompositeDataMovementEvent cdme1 =
         CompositeDataMovementEvent.create(startIndex, numPartitions, userPayload);
-    Assert.assertEquals(numPartitions, cdme1.getCount());
-    Assert.assertEquals(startIndex, cdme1.getSourceIndexStart());
+    assertEquals(numPartitions, cdme1.getCount());
+    assertEquals(startIndex, cdme1.getSourceIndexStart());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetEvents(){
     int numOutputs = 0;
     int startIndex = 1;
@@ -45,7 +50,7 @@ public class TestCompositeDataMovementEvent {
     for(DataMovementEvent dme: cdme2.getEvents()){
       numOutputs++;
     }
-    Assert.assertEquals(numOutputs, cdme2.getCount());
+    assertEquals(numOutputs, cdme2.getCount());
   }
 
 }

--- a/tez-api/src/test/java/org/apache/tez/runtime/api/events/TestInputDataInformationEvent.java
+++ b/tez-api/src/test/java/org/apache/tez/runtime/api/events/TestInputDataInformationEvent.java
@@ -18,11 +18,13 @@
  */
 package org.apache.tez.runtime.api.events;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestInputDataInformationEvent {
 
@@ -32,24 +34,24 @@ public class TestInputDataInformationEvent {
         InputDataInformationEvent.createWithSerializedPayload(0, ByteBuffer.wrap("payload1".getBytes()));
     // event created by createWithSerializedPayload should contain serialized payload
     // but not a path or a deserialized payload
-    Assert.assertEquals(
+    assertEquals(
         "payload1",
         StandardCharsets.UTF_8.decode(eventWithSerializedPayload.getUserPayload()).toString());
-    Assert.assertNull(eventWithSerializedPayload.getSerializedPath());
-    Assert.assertNull(eventWithSerializedPayload.getDeserializedUserPayload());
+    assertNull(eventWithSerializedPayload.getSerializedPath());
+    assertNull(eventWithSerializedPayload.getDeserializedUserPayload());
 
     InputDataInformationEvent eventWithObjectPayload = InputDataInformationEvent.createWithObjectPayload(0, "payload2");
     // event created by eventWithObjectPayload should contain a deserialized payload
     // but not a path or serialized payload
-    Assert.assertEquals("payload2", eventWithObjectPayload.getDeserializedUserPayload());
-    Assert.assertNull(eventWithObjectPayload.getSerializedPath());
-    Assert.assertNull(eventWithObjectPayload.getUserPayload());
+    assertEquals("payload2", eventWithObjectPayload.getDeserializedUserPayload());
+    assertNull(eventWithObjectPayload.getSerializedPath());
+    assertNull(eventWithObjectPayload.getUserPayload());
 
     InputDataInformationEvent eventWithPath = InputDataInformationEvent.createWithSerializedPath(0, "file://hello");
     // event created by createWithSerializedPath should contain a path
     // but neither serialized nor deserialized payload
-    Assert.assertEquals("file://hello", eventWithPath.getSerializedPath());
-    Assert.assertNull(eventWithPath.getUserPayload());
-    Assert.assertNull(eventWithPath.getDeserializedUserPayload());
+    assertEquals("file://hello", eventWithPath.getSerializedPath());
+    assertNull(eventWithPath.getUserPayload());
+    assertNull(eventWithPath.getDeserializedUserPayload());
   }
 }

--- a/tez-common/pom.xml
+++ b/tez-common/pom.xml
@@ -71,9 +71,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
   </dependencies>
 

--- a/tez-common/src/test/java/org/apache/tez/common/TestAsyncDispatcher.java
+++ b/tez-common/src/test/java/org/apache/tez/common/TestAsyncDispatcher.java
@@ -18,14 +18,18 @@
  */
 package org.apache.tez.common;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.event.AbstractEvent;
 import org.apache.hadoop.yarn.event.EventHandler;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestAsyncDispatcher {
 
@@ -79,7 +83,8 @@ public class TestAsyncDispatcher {
   }
 
   @SuppressWarnings("unchecked")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasic() throws Exception {
     CountDownLatch latch = new CountDownLatch(4);
     CountDownEventHandler.latch = latch;
@@ -99,15 +104,16 @@ public class TestAsyncDispatcher {
     central.close();
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleRegisterFail() throws Exception {
     AsyncDispatcher central = new AsyncDispatcher("Type1");
     try {
       central.register(TestEventType1.class, new TestEventHandler1());
       central.registerAndCreateDispatcher(TestEventType1.class, new TestEventHandler2(), "Type2");
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("Cannot register same event on multiple dispatchers"));
+      assertTrue(e.getMessage().contains("Cannot register same event on multiple dispatchers"));
     } finally {
       central.close();
     }
@@ -116,9 +122,9 @@ public class TestAsyncDispatcher {
     try {
       central.registerAndCreateDispatcher(TestEventType1.class, new TestEventHandler2(), "Type2");
       central.register(TestEventType1.class, new TestEventHandler1());
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("Multiple dispatchers cannot be registered for"));
+      assertTrue(e.getMessage().contains("Multiple dispatchers cannot be registered for"));
     } finally {
       central.close();
     }

--- a/tez-common/src/test/java/org/apache/tez/common/TestAsyncDispatcherConcurrent.java
+++ b/tez-common/src/test/java/org/apache/tez/common/TestAsyncDispatcherConcurrent.java
@@ -18,13 +18,17 @@
  */
 package org.apache.tez.common;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.event.EventHandler;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 @SuppressWarnings("unchecked")
 public class TestAsyncDispatcherConcurrent {
@@ -94,7 +98,8 @@ public class TestAsyncDispatcherConcurrent {
     }
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasic() throws Exception {
     CountDownLatch latch = new CountDownLatch(4);
     CountDownEventHandler.init(latch);
@@ -115,7 +120,8 @@ public class TestAsyncDispatcherConcurrent {
     central.close();
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultiThreads() throws Exception {
     CountDownLatch latch = new CountDownLatch(4);
     CountDownEventHandler.init(latch);
@@ -134,15 +140,16 @@ public class TestAsyncDispatcherConcurrent {
     central.close();
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleRegisterFail() throws Exception {
     AsyncDispatcher central = new AsyncDispatcher("Type1");
     try {
       central.register(TestEventType1.class, new TestEventHandler1());
       central.registerAndCreateDispatcher(TestEventType1.class, new TestEventHandler2(), "Type2", 1);
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("Cannot register same event on multiple dispatchers"));
+      assertTrue(e.getMessage().contains("Cannot register same event on multiple dispatchers"));
     } finally {
       central.close();
     }
@@ -151,9 +158,9 @@ public class TestAsyncDispatcherConcurrent {
     try {
       central.registerAndCreateDispatcher(TestEventType1.class, new TestEventHandler2(), "Type2", 1);
       central.register(TestEventType1.class, new TestEventHandler1());
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("Multiple concurrent dispatchers cannot be registered"));
+      assertTrue(e.getMessage().contains("Multiple concurrent dispatchers cannot be registered"));
     } finally {
       central.close();
     }
@@ -162,9 +169,9 @@ public class TestAsyncDispatcherConcurrent {
     try {
       central.registerAndCreateDispatcher(TestEventType1.class, new TestEventHandler2(), "Type2", 1);
       central.registerAndCreateDispatcher(TestEventType1.class, new TestEventHandler2(), "Type2", 1);
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("Multiple concurrent dispatchers cannot be registered"));
+      assertTrue(e.getMessage().contains("Multiple concurrent dispatchers cannot be registered"));
     } finally {
       central.close();
     }
@@ -173,9 +180,9 @@ public class TestAsyncDispatcherConcurrent {
     try {
       central.registerAndCreateDispatcher(TestEventType1.class, new TestEventHandler2(), "Type2");
       central.registerAndCreateDispatcher(TestEventType1.class, new TestEventHandler2(), "Type2");
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("Multiple dispatchers cannot be registered for"));
+      assertTrue(e.getMessage().contains("Multiple dispatchers cannot be registered for"));
     } finally {
       central.close();
     }
@@ -186,9 +193,9 @@ public class TestAsyncDispatcherConcurrent {
           TestEventType1.class, new TestEventHandler2(), "Type2", 1);
       central.registerWithExistingDispatcher(TestEventType1.class, new TestEventHandler1(),
           concDispatcher);
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("Multiple concurrent dispatchers cannot be registered"));
+      assertTrue(e.getMessage().contains("Multiple concurrent dispatchers cannot be registered"));
     } finally {
       central.close();
     }

--- a/tez-common/src/test/java/org/apache/tez/common/TestTezSharedExecutor.java
+++ b/tez-common/src/test/java/org/apache/tez/common/TestTezSharedExecutor.java
@@ -18,6 +18,11 @@
  */
 package org.apache.tez.common;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -34,10 +39,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.conf.Configuration;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTezSharedExecutor {
 
@@ -113,18 +118,19 @@ public class TestTezSharedExecutor {
 
   private TezSharedExecutor sharedExecutor;
 
-  @Before
+  @BeforeEach
   public void setup() {
     sharedExecutor = new TezSharedExecutor(new Configuration());
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     sharedExecutor.shutdownNow();
     sharedExecutor = null;
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleExecution() throws Exception {
     ConcurrentHashMap<String, AtomicInteger> map = new ConcurrentHashMap<>();
 
@@ -132,13 +138,13 @@ public class TestTezSharedExecutor {
 
     // Test runnable
     service.submit(new Counter(map, "test")).get();
-    Assert.assertEquals(1, map.get("test").get());
+    assertEquals(1, map.get("test").get());
 
     // Test runnable with a result
     final Object expected = new Object();
     Object val = service.submit(new Counter(map, "test"), expected).get();
-    Assert.assertEquals(expected, val);
-    Assert.assertEquals(2, map.get("test").get());
+    assertEquals(expected, val);
+    assertEquals(2, map.get("test").get());
 
     // Test callable.
     val = service.submit(new Callable<Object>() {
@@ -147,19 +153,20 @@ public class TestTezSharedExecutor {
         return expected;
       }
     }).get();
-    Assert.assertEquals(expected, val);
+    assertEquals(expected, val);
 
     // Tasks should be rejected after a shutdown.
     service.shutdown();
 
     try {
       service.submit(new Counter(map, "test"));
-      Assert.fail("Expected rejected execution exception.");
+      fail("Expected rejected execution exception.");
     } catch (RejectedExecutionException e) {
     }
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testAwaitTermination() throws Exception {
     ExecutorService service = sharedExecutor.createExecutorService(1, "await-termination");
     CountDownLatch latch = new CountDownLatch(1);
@@ -169,18 +176,19 @@ public class TestTezSharedExecutor {
     service.shutdown();
 
     // Task stuck on latch hence it should fail to terminate.
-    Assert.assertFalse(service.awaitTermination(100, TimeUnit.MILLISECONDS));
-    Assert.assertFalse(service.isTerminated());
-    Assert.assertTrue(service.isShutdown());
+    assertFalse(service.awaitTermination(100, TimeUnit.MILLISECONDS));
+    assertFalse(service.isTerminated());
+    assertTrue(service.isShutdown());
 
     latch.countDown();
 
-    Assert.assertTrue(service.awaitTermination(5, TimeUnit.SECONDS));
-    Assert.assertTrue(service.isTerminated());
-    Assert.assertTrue(service.isShutdown());
+    assertTrue(service.awaitTermination(5, TimeUnit.SECONDS));
+    assertTrue(service.isTerminated());
+    assertTrue(service.isShutdown());
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSerialExecution() throws Exception {
     ExecutorService service = sharedExecutor.createExecutorService(1, "serial-test");
     CountDownLatch latch = new CountDownLatch(1);
@@ -197,7 +205,7 @@ public class TestTezSharedExecutor {
     service.shutdown();
 
     // Until we release the task from the latch nothing moves forward.
-    Assert.assertEquals(0, list.size());
+    assertEquals(0, list.size());
     latch.countDown();
     f1.get();
 
@@ -205,11 +213,12 @@ public class TestTezSharedExecutor {
     for (Future<?> f : futures) {
       f.get();
     }
-    Assert.assertEquals(10, list.size());
-    Assert.assertEquals(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), list);
+    assertEquals(10, list.size());
+    assertEquals(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9), list);
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testParallelExecution() throws Exception {
     ConcurrentHashMap<String, AtomicInteger> map = new ConcurrentHashMap<>();
 
@@ -229,13 +238,13 @@ public class TestTezSharedExecutor {
     for (Future<?> future : futures) {
       future.get();
     }
-    Assert.assertEquals(expectedCounts[0], map.get("test0").get());
-    Assert.assertEquals(expectedCounts[1], map.get("test1").get());
+    assertEquals(expectedCounts[0], map.get("test0").get());
+    assertEquals(expectedCounts[1], map.get("test1").get());
 
     // Even if one service is shutdown the other should work.
     services[0].shutdown();
     services[1].submit(new Counter(map, "test1")).get();
-    Assert.assertEquals(expectedCounts[1] + 1, map.get("test1").get());
+    assertEquals(expectedCounts[1] + 1, map.get("test1").get());
   }
 
 }

--- a/tez-common/src/test/java/org/apache/tez/common/TestTezUtils.java
+++ b/tez-common/src/test/java/org/apache/tez/common/TestTezUtils.java
@@ -18,10 +18,11 @@
  */
 package org.apache.tez.common;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -29,6 +30,7 @@ import java.util.BitSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.client.TezClientUtils;
@@ -45,20 +47,21 @@ import com.google.protobuf.ByteString;
 
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTezUtils {
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testByteStringToAndFromConf() throws IOException {
     Configuration conf = getConf();
-    Assert.assertEquals(conf.size(), 6);
+    assertEquals(conf.size(), 6);
     ByteString bsConf = TezUtils.createByteStringFromConf(conf);
     conf.clear();
-    Assert.assertEquals(conf.size(), 0);
+    assertEquals(conf.size(), 0);
     conf = TezUtils.createConfFromByteString(bsConf);
-    Assert.assertEquals(conf.size(), 6);
+    assertEquals(conf.size(), 6);
     checkConf(conf);
   }
 
@@ -75,104 +78,111 @@ public class TestTezUtils {
     }
 
     String largeValue = sb.toString();
-    Assert.assertEquals(largeSize, largeValue.length());
+    assertEquals(largeSize, largeValue.length());
     return largeValue;
   }
 
   private ByteString createByteString(Configuration conf, String largeValue) throws IOException {
     conf.set("testLargeValue", largeValue);
-    Assert.assertEquals(conf.size(), 7);
+    assertEquals(conf.size(), 7);
     return TezUtils.createByteStringFromConf(conf);
   }
 
-  @Test (timeout=20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testByteStringToAndFromLargeConf() throws IOException {
     Configuration conf = getConf();
     String largeValue = constructLargeValue();
     ByteString bsConf = createByteString(conf, largeValue);
     conf.clear();
-    Assert.assertEquals(conf.size(), 0);
+    assertEquals(conf.size(), 0);
     conf = TezUtils.createConfFromByteString(bsConf);
-    Assert.assertEquals(conf.size(), 7);
+    assertEquals(conf.size(), 7);
     checkConf(conf);
-    Assert.assertEquals(conf.get("testLargeValue"), largeValue);
+    assertEquals(conf.get("testLargeValue"), largeValue);
   }
 
-  @Test (timeout=20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testByteStringAddToLargeConf() throws IOException {
     Configuration conf = getConf();
     String largeValue = constructLargeValue();
     ByteString bsConf = createByteString(conf, largeValue);
     conf.clear();
-    Assert.assertEquals(conf.size(), 0);
+    assertEquals(conf.size(), 0);
     TezUtils.addToConfFromByteString(conf, bsConf);
-    Assert.assertEquals(conf.size(), 7);
+    assertEquals(conf.size(), 7);
     checkConf(conf);
-    Assert.assertEquals(conf.get("testLargeValue"), largeValue);
+    assertEquals(conf.get("testLargeValue"), largeValue);
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testPayloadToAndFromConf() throws IOException {
     Configuration conf = getConf();
-    Assert.assertEquals(conf.size(), 6);
+    assertEquals(conf.size(), 6);
     UserPayload bConf = TezUtils.createUserPayloadFromConf(conf);
     conf.clear();
-    Assert.assertEquals(conf.size(), 0);
+    assertEquals(conf.size(), 0);
     conf = TezUtils.createConfFromUserPayload(bConf);
-    Assert.assertEquals(conf.size(), 6);
+    assertEquals(conf.size(), 6);
     checkConf(conf);
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testCleanVertexName() {
     String testString = "special characters & spaces and longer than "
         + TezUtilsInternal.MAX_VERTEX_NAME_LENGTH + " characters";
-    Assert.assertTrue(testString.length() > TezUtilsInternal.MAX_VERTEX_NAME_LENGTH);
+    assertTrue(testString.length() > TezUtilsInternal.MAX_VERTEX_NAME_LENGTH);
     String cleaned = TezUtilsInternal.cleanVertexName(testString);
-    Assert.assertTrue(cleaned.length() <= TezUtilsInternal.MAX_VERTEX_NAME_LENGTH);
-    Assert.assertFalse(cleaned.contains("\\s+"));
-    Assert.assertTrue(cleaned.matches("\\w+"));
+    assertTrue(cleaned.length() <= TezUtilsInternal.MAX_VERTEX_NAME_LENGTH);
+    assertFalse(cleaned.contains("\\s+"));
+    assertTrue(cleaned.matches("\\w+"));
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testBitSetToByteArray() {
     BitSet bitSet = createBitSet(0);
     byte[] bytes = TezUtilsInternal.toByteArray(bitSet);
-    Assert.assertEquals(bytes.length, (bitSet.length() + 7) / 8);
+    assertEquals(bytes.length, (bitSet.length() + 7) / 8);
 
     bitSet = createBitSet(1000);
     bytes = TezUtilsInternal.toByteArray(bitSet);
-    Assert.assertEquals(bytes.length, (bitSet.length() + 7) / 8);
+    assertEquals(bytes.length, (bitSet.length() + 7) / 8);
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testBitSetFromByteArray() {
     BitSet bitSet = createBitSet(0);
     byte[] bytes = TezUtilsInternal.toByteArray(bitSet);
-    Assert.assertEquals(TezUtilsInternal.fromByteArray(bytes).cardinality(), bitSet.cardinality());
-    Assert.assertTrue(TezUtilsInternal.fromByteArray(bytes).equals(bitSet));
+    assertEquals(TezUtilsInternal.fromByteArray(bytes).cardinality(), bitSet.cardinality());
+    assertEquals(TezUtilsInternal.fromByteArray(bytes), bitSet);
 
     bitSet = createBitSet(1);
     bytes = TezUtilsInternal.toByteArray(bitSet);
-    Assert.assertEquals(TezUtilsInternal.fromByteArray(bytes).cardinality(), bitSet.cardinality());
-    Assert.assertTrue(TezUtilsInternal.fromByteArray(bytes).equals(bitSet));
+    assertEquals(TezUtilsInternal.fromByteArray(bytes).cardinality(), bitSet.cardinality());
+    assertEquals(TezUtilsInternal.fromByteArray(bytes), bitSet);
 
     bitSet = createBitSet(1000);
     bytes = TezUtilsInternal.toByteArray(bitSet);
-    Assert.assertEquals(TezUtilsInternal.fromByteArray(bytes).cardinality(), bitSet.cardinality());
-    Assert.assertTrue(TezUtilsInternal.fromByteArray(bytes).equals(bitSet));
+    assertEquals(TezUtilsInternal.fromByteArray(bytes).cardinality(), bitSet.cardinality());
+    assertEquals(TezUtilsInternal.fromByteArray(bytes), bitSet);
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testBitSetConversion() {
     for (int i = 0 ; i < 16 ; i++) {
       BitSet bitSet = createBitSetWithSingleEntry(i);
       byte[] bytes = TezUtilsInternal.toByteArray(bitSet);
 
       BitSet deseraialized = TezUtilsInternal.fromByteArray(bytes);
-      Assert.assertEquals(bitSet, deseraialized);
-      Assert.assertEquals(bitSet.cardinality(), deseraialized.cardinality());
-      Assert.assertEquals(1, deseraialized.cardinality());
+      assertEquals(bitSet, deseraialized);
+      assertEquals(bitSet.cardinality(), deseraialized.cardinality());
+      assertEquals(1, deseraialized.cardinality());
     }
   }
 
@@ -204,30 +214,31 @@ public class TestTezUtils {
   }
 
   private void checkConf(Configuration conf) {
-    Assert.assertEquals(conf.get("test1"), "value1");
-    Assert.assertTrue(conf.getBoolean("test2", false));
-    Assert.assertEquals(conf.getDouble("test3", 0), 1.2345, 1e-15);
-    Assert.assertEquals(conf.getInt("test4", 0), 34567);
-    Assert.assertEquals(conf.getLong("test5", 0), 1234567890L);
+    assertEquals(conf.get("test1"), "value1");
+    assertTrue(conf.getBoolean("test2", false));
+    assertEquals(conf.getDouble("test3", 0), 1.2345, 1e-15);
+    assertEquals(conf.getInt("test4", 0), 34567);
+    assertEquals(conf.getLong("test5", 0), 1234567890L);
     String tmp[] = conf.getStrings("test6");
-    Assert.assertEquals(tmp.length, 3);
-    Assert.assertEquals(tmp[0], "S1");
-    Assert.assertEquals(tmp[1], "S2");
-    Assert.assertEquals(tmp[2], "S3");
+    assertEquals(tmp.length, 3);
+    assertEquals(tmp[0], "S1");
+    assertEquals(tmp[1], "S2");
+    assertEquals(tmp[2], "S3");
 
   }
 
   private void checkJSONConfigObj(JSONObject confObject) throws JSONException {
-    Assert.assertNotNull(confObject);
-    Assert.assertEquals("value1", confObject.getString("test1"));
-    Assert.assertEquals("true", confObject.getString("test2"));
-    Assert.assertEquals("1.2345", confObject.getString("test3"));
-    Assert.assertEquals("34567", confObject.getString("test4"));
-    Assert.assertEquals("1234567890", confObject.getString("test5"));
-    Assert.assertEquals("S1,S2,S3", confObject.getString("test6"));
+    assertNotNull(confObject);
+    assertEquals("value1", confObject.getString("test1"));
+    assertEquals("true", confObject.getString("test2"));
+    assertEquals("1.2345", confObject.getString("test3"));
+    assertEquals("34567", confObject.getString("test4"));
+    assertEquals("1234567890", confObject.getString("test5"));
+    assertEquals("S1,S2,S3", confObject.getString("test6"));
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testConvertToHistoryText() throws JSONException {
     Configuration conf = getConf();
 
@@ -235,8 +246,8 @@ public class TestTezUtils {
 
     JSONObject jsonObject = new JSONObject(confToJson);
 
-    Assert.assertFalse(jsonObject.has(ATSConstants.DESC));
-    Assert.assertTrue(jsonObject.has(ATSConstants.CONFIG));
+    assertFalse(jsonObject.has(ATSConstants.DESC));
+    assertTrue(jsonObject.has(ATSConstants.CONFIG));
 
     JSONObject confObject = jsonObject.getJSONObject(ATSConstants.CONFIG);
     checkJSONConfigObj(confObject);
@@ -245,54 +256,56 @@ public class TestTezUtils {
     confToJson = TezUtils.convertToHistoryText(desc, conf);
     jsonObject = new JSONObject(confToJson);
 
-    Assert.assertTrue(jsonObject.has(ATSConstants.DESC));
+    assertTrue(jsonObject.has(ATSConstants.DESC));
     String descFromJson = jsonObject.getString(ATSConstants.DESC);
-    Assert.assertEquals(desc, descFromJson);
+    assertEquals(desc, descFromJson);
 
-    Assert.assertTrue(jsonObject.has(ATSConstants.CONFIG));
+    assertTrue(jsonObject.has(ATSConstants.CONFIG));
     confObject = jsonObject.getJSONObject("config");
     checkJSONConfigObj(confObject);
 
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testConvertToHistoryTextWithReplaceVars() throws JSONException {
     Configuration conf = getConf();
     conf.set("user", "user1");
     conf.set("location", "/tmp/${user}/");
 
     String location = "/tmp/user1/";
-    Assert.assertEquals(location, conf.get("location"));
+    assertEquals(location, conf.get("location"));
 
     String confToJson = TezUtils.convertToHistoryText(conf);
 
     JSONObject jsonObject = new JSONObject(confToJson);
 
-    Assert.assertFalse(jsonObject.has(ATSConstants.DESC));
-    Assert.assertTrue(jsonObject.has(ATSConstants.CONFIG));
+    assertFalse(jsonObject.has(ATSConstants.DESC));
+    assertTrue(jsonObject.has(ATSConstants.CONFIG));
 
     JSONObject confObject = jsonObject.getJSONObject(ATSConstants.CONFIG);
     checkJSONConfigObj(confObject);
-    Assert.assertEquals("user1", confObject.getString("user"));
-    Assert.assertEquals(location, confObject.getString("location"));
+    assertEquals("user1", confObject.getString("user"));
+    assertEquals(location, confObject.getString("location"));
 
     String desc = "desc123";
     confToJson = TezUtils.convertToHistoryText(desc, conf);
     jsonObject = new JSONObject(confToJson);
 
-    Assert.assertTrue(jsonObject.has(ATSConstants.DESC));
+    assertTrue(jsonObject.has(ATSConstants.DESC));
     String descFromJson = jsonObject.getString(ATSConstants.DESC);
-    Assert.assertEquals(desc, descFromJson);
+    assertEquals(desc, descFromJson);
 
-    Assert.assertTrue(jsonObject.has(ATSConstants.CONFIG));
+    assertTrue(jsonObject.has(ATSConstants.CONFIG));
     confObject = jsonObject.getJSONObject("config");
     checkJSONConfigObj(confObject);
-    Assert.assertEquals("user1", confObject.getString("user"));
-    Assert.assertEquals(location, confObject.getString("location"));
+    assertEquals("user1", confObject.getString("user"));
+    assertEquals(location, confObject.getString("location"));
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPopulateConfProtoFromEntries() {
       Map<String, String> map = new HashMap<>();
       map.put("nonNullKey", "value");
@@ -302,14 +315,16 @@ public class TestTezUtils {
       assertEquals(confBuilder.getConfKeyValuesList().size(), 1);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testReadTezConfigurationXmlFromClasspath() throws IOException {
     InputStream is = ClassLoader.getSystemResourceAsStream(TezConfiguration.TEZ_SITE_XML);
     Configuration conf = TezUtilsInternal.readTezConfigurationXml(is);
     assertEquals("tez.tar.gz", conf.get("tez.lib.uris"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPluginsDescriptorFromJSON() throws IOException {
     InputStream is = ClassLoader.getSystemResourceAsStream(TezConstants.SERVICE_PLUGINS_DESCRIPTOR_JSON);
     ServicePluginsDescriptor spd = TezClientUtils.createPluginsDescriptorFromJSON(is);

--- a/tez-common/src/test/java/org/apache/tez/dag/records/TestTezIds.java
+++ b/tez-common/src/test/java/org/apache/tez/dag/records/TestTezIds.java
@@ -18,11 +18,17 @@
  */
 package org.apache.tez.dag.records;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,57 +37,58 @@ public class TestTezIds {
   private static final Logger LOG = LoggerFactory.getLogger(TestTezIds.class);
 
   private void verifyDagInfo(String[] splits, TezDAGID dagId) {
-    Assert.assertEquals(dagId.getApplicationId().getClusterTimestamp(),
+    assertEquals(dagId.getApplicationId().getClusterTimestamp(),
         Long.valueOf(splits[1]).longValue());
-    Assert.assertEquals(dagId.getApplicationId().getId(),
+    assertEquals(dagId.getApplicationId().getId(),
         Integer.valueOf(splits[2]).intValue());
-    Assert.assertEquals(dagId.getId(),
+    assertEquals(dagId.getId(),
         Integer.valueOf(splits[3]).intValue());
   }
 
   private void verifyVertexInfo(String[] splits, TezVertexID vId) {
     verifyDagInfo(splits, vId.getDAGID());
-    Assert.assertEquals(vId.getId(),
+    assertEquals(vId.getId(),
         Integer.valueOf(splits[4]).intValue());
   }
 
   private void verifyTaskInfo(String[] splits, TezTaskID tId) {
     verifyVertexInfo(splits, tId.getVertexID());
-    Assert.assertEquals(tId.getId(),
+    assertEquals(tId.getId(),
         Integer.valueOf(splits[5]).intValue());
   }
 
   private void verifyAttemptInfo(String[] splits, TezTaskAttemptID taId) {
     verifyTaskInfo(splits, taId.getTaskID());
-    Assert.assertEquals(taId.getId(),
+    assertEquals(taId.getId(),
         Integer.valueOf(splits[6]).intValue());
   }
 
   private void verifyDagId(String dagIdStr, TezDAGID dagId) {
     String[] splits = dagIdStr.split("_");
-    Assert.assertEquals(4, splits.length);
+    assertEquals(4, splits.length);
     verifyDagInfo(splits, dagId);
   }
 
   private void verifyVertexId(String vIdStr, TezVertexID vId) {
     String[] splits = vIdStr.split("_");
-    Assert.assertEquals(5, splits.length);
+    assertEquals(5, splits.length);
     verifyVertexInfo(splits, vId);
   }
 
   private void verifyTaskId(String tIdStr, TezTaskID tId) {
     String[] splits = tIdStr.split("_");
-    Assert.assertEquals(6, splits.length);
+    assertEquals(6, splits.length);
     verifyTaskInfo(splits, tId);
   }
 
   private void verifyAttemptId(String taIdStr, TezTaskAttemptID taId) {
     String[] splits = taIdStr.split("_");
-    Assert.assertEquals(7, splits.length);
+    assertEquals(7, splits.length);
     verifyAttemptInfo(splits, taId);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testIdStringify() {
     ApplicationId appId = ApplicationId.newInstance(9999, 72);
     TezDAGID dagId = TezDAGID.getInstance(appId, 1);
@@ -99,10 +106,10 @@ public class TestTezIds {
     LOG.info("Task ID:" + tIdStr);
     LOG.info("Attempt ID:" + taIdStr);
 
-    Assert.assertTrue(dagIdStr.startsWith("dag"));
-    Assert.assertTrue(vIdStr.startsWith("vertex"));
-    Assert.assertTrue(tIdStr.startsWith("task"));
-    Assert.assertTrue(taIdStr.startsWith("attempt"));
+    assertTrue(dagIdStr.startsWith("dag"));
+    assertTrue(vIdStr.startsWith("vertex"));
+    assertTrue(tIdStr.startsWith("task"));
+    assertTrue(taIdStr.startsWith("attempt"));
 
     verifyDagId(dagIdStr, dagId);
     verifyVertexId(vIdStr, vId);
@@ -110,39 +117,40 @@ public class TestTezIds {
     verifyAttemptId(taIdStr, taId);
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidDagIds() {
     String dagIdStr = "aaa_111_1_1";
     TezDAGID dagId;
     try {
       dagId = TezDAGID.fromString(dagIdStr);
-      Assert.fail("Expected failure for invalid dagId=" + dagIdStr);
+      fail("Expected failure for invalid dagId=" + dagIdStr);
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("Invalid DAG Id format"));
+      assertTrue(e.getMessage().contains("Invalid DAG Id format"));
     }
 
     dagIdStr = "dag_111_11";
     try {
       dagId = TezDAGID.fromString(dagIdStr);
-      Assert.fail("Expected failure for invalid dagId=" + dagIdStr);
+      fail("Expected failure for invalid dagId=" + dagIdStr);
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("Invalid DAG Id format"));
+      assertTrue(e.getMessage().contains("Invalid DAG Id format"));
     }
 
     dagIdStr = "dag_111_11_aa";
     try {
       dagId = TezDAGID.fromString(dagIdStr);
-      Assert.fail("Expected failure for invalid dagId=" + dagIdStr);
+      fail("Expected failure for invalid dagId=" + dagIdStr);
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("Error while parsing"));
+      assertTrue(e.getMessage().contains("Error while parsing"));
     }
 
     dagIdStr = "dag_111_aa_1";
     try {
       dagId = TezDAGID.fromString(dagIdStr);
-      Assert.fail("Expected failure for invalid dagId=" + dagIdStr);
+      fail("Expected failure for invalid dagId=" + dagIdStr);
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains("Error while parsing"));
+      assertTrue(e.getMessage().contains("Error while parsing"));
     }
 
   }
@@ -156,18 +164,18 @@ public class TestTezIds {
     // All dags within one group should have same id.
     String groupId1 = dagId.getGroupId(numDagsPerGroup);
     for (int i = 0; i < numDagsPerGroup; ++i) {
-      Assert.assertEquals(TezDAGID.getInstance(appId, i + 1).getGroupId(numDagsPerGroup), groupId1);
+      assertEquals(TezDAGID.getInstance(appId, i + 1).getGroupId(numDagsPerGroup), groupId1);
     }
 
     // Assert different id across groups.
-    Assert.assertNotEquals(
+    assertNotEquals(
         TezDAGID.getInstance(appId, numDagsPerGroup + 1).getGroupId(numDagsPerGroup), groupId1);
 
     // Invalid values -1, 0, 1 should throw IllegalArgumentException.
     for (int i = -1; i < 2; ++i) {
       try {
         dagId.getGroupId(i);
-        Assert.fail("Expected IllegalArgumentException for numDagsPerGroup: " + i);
+        fail("Expected IllegalArgumentException for numDagsPerGroup: " + i);
       } catch (IllegalArgumentException e) {
       }
     }

--- a/tez-common/src/test/java/org/apache/tez/util/TestNumberFormat.java
+++ b/tez-common/src/test/java/org/apache/tez/util/TestNumberFormat.java
@@ -18,14 +18,18 @@
  */
 package org.apache.tez.util;
 
-import java.text.NumberFormat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Assert;
-import org.junit.Test;
+import java.text.NumberFormat;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestNumberFormat {
 
-  @Test(timeout = 1000)
+  @Test
+  @Timeout(value = 1000, unit = TimeUnit.MILLISECONDS)
   public void testLongWithPadding() throws Exception {
     FastNumberFormat fastNumberFormat = FastNumberFormat.getInstance();
     fastNumberFormat.setMinimumIntegerDigits(6);
@@ -33,8 +37,9 @@ public class TestNumberFormat {
     numberFormat.setGroupingUsed(false);
     numberFormat.setMinimumIntegerDigits(6);
     long[] testLongs = {1, 23, 456, 7890, 12345, 678901, 2345689, 0, -0, -1, -23, -456, -7890, -12345, -678901, -2345689};
-    for (long l: testLongs) {
-      Assert.assertEquals("Number formats should be equal", numberFormat.format(l), fastNumberFormat.format(l));
+    for (long l : testLongs) {
+      assertEquals(
+          numberFormat.format(l), fastNumberFormat.format(l), "Number formats should be equal");
     }
   }
 }

--- a/tez-common/src/test/java/org/apache/tez/util/TestNumberFormat.java
+++ b/tez-common/src/test/java/org/apache/tez/util/TestNumberFormat.java
@@ -38,8 +38,7 @@ public class TestNumberFormat {
     numberFormat.setMinimumIntegerDigits(6);
     long[] testLongs = {1, 23, 456, 7890, 12345, 678901, 2345689, 0, -0, -1, -23, -456, -7890, -12345, -678901, -2345689};
     for (long l : testLongs) {
-      assertEquals(
-          numberFormat.format(l), fastNumberFormat.format(l), "Number formats should be equal");
+      assertEquals(numberFormat.format(l), fastNumberFormat.format(l), "Number formats should be equal");
     }
   }
 }

--- a/tez-common/src/test/java/org/apache/tez/util/TestStopWatch.java
+++ b/tez-common/src/test/java/org/apache/tez/util/TestStopWatch.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 
-
 public class TestStopWatch {
 
   @Test

--- a/tez-common/src/test/java/org/apache/tez/util/TestStopWatch.java
+++ b/tez-common/src/test/java/org/apache/tez/util/TestStopWatch.java
@@ -18,8 +18,13 @@
  */
 package org.apache.tez.util;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
 
 public class TestStopWatch {
 
@@ -27,13 +32,13 @@ public class TestStopWatch {
   public void testStartAndStop() throws Exception {
     try {
       StopWatch sw = new StopWatch();
-      Assert.assertFalse(sw.isRunning());
+      assertFalse(sw.isRunning());
       sw.start();
-      Assert.assertTrue(sw.isRunning());
+      assertTrue(sw.isRunning());
       sw.stop();
-      Assert.assertFalse(sw.isRunning());
+      assertFalse(sw.isRunning());
     } catch (Exception e) {
-      Assert.fail("StopWatch should not fail with normal usage");
+      fail("StopWatch should not fail with normal usage");
     }
   }
 
@@ -43,16 +48,14 @@ public class TestStopWatch {
     try {
       sw.stop();
     } catch (Exception e) {
-      Assert.assertTrue("IllegalStateException is expected",
-          e instanceof IllegalStateException);
+      assertInstanceOf(IllegalStateException.class, e, "IllegalStateException is expected");
     }
     sw.reset();
     sw.start();
     try {
       sw.start();
     } catch (Exception e) {
-      Assert.assertTrue("IllegalStateException is expected",
-          e instanceof IllegalStateException);
+      assertInstanceOf(IllegalStateException.class, e, "IllegalStateException is expected");
     }
   }
 

--- a/tez-common/src/test/java/org/apache/tez/util/TestTezMxBeanResourceCalculator.java
+++ b/tez-common/src/test/java/org/apache/tez/util/TestTezMxBeanResourceCalculator.java
@@ -18,20 +18,26 @@
  */
 package org.apache.tez.util;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.util.ResourceCalculatorProcessTree;
 import org.apache.tez.dag.api.TezConfiguration;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTezMxBeanResourceCalculator {
 
   private ResourceCalculatorProcessTree resourceCalculator;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Configuration conf = new TezConfiguration();
     conf.set(TezConfiguration.TEZ_TASK_RESOURCE_CALCULATOR_PROCESS_TREE_CLASS,
@@ -44,19 +50,20 @@ public class TestTezMxBeanResourceCalculator {
         "", clazz, conf);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     resourceCalculator = null;
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testResourceCalculator() {
-    Assert.assertTrue(resourceCalculator instanceof TezMxBeanResourceCalculator);
-    Assert.assertTrue(resourceCalculator.getCumulativeCpuTime() > 0);
-    Assert.assertTrue(resourceCalculator.getVirtualMemorySize() > 0);
-    Assert.assertTrue(resourceCalculator.getRssMemorySize() > 0);
-    Assert.assertTrue(resourceCalculator.getProcessTreeDump().equals(""));
-    Assert.assertTrue(resourceCalculator.checkPidPgrpidForMatch());
+    assertInstanceOf(TezMxBeanResourceCalculator.class, resourceCalculator);
+    assertTrue(resourceCalculator.getCumulativeCpuTime() > 0);
+    assertTrue(resourceCalculator.getVirtualMemorySize() > 0);
+    assertTrue(resourceCalculator.getRssMemorySize() > 0);
+    assertEquals("", resourceCalculator.getProcessTreeDump());
+    assertTrue(resourceCalculator.checkPidPgrpidForMatch());
   }
 
 }

--- a/tez-dag/pom.xml
+++ b/tez-dag/pom.xml
@@ -134,10 +134,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
@@ -163,8 +159,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
   </dependencies>
 

--- a/tez-dag/src/test/java/org/apache/tez/client/registry/zookeeper/TestZkAMRegistryClient.java
+++ b/tez-dag/src/test/java/org/apache/tez/client/registry/zookeeper/TestZkAMRegistryClient.java
@@ -141,22 +141,21 @@ public class TestZkAMRegistryClient {
 
     // Create and start the ZkAMRegistryClient
     registryClient = ZkAMRegistryClient.getClient(tezConf);
-    registryClient.addListener(
-        new AMRegistryClientListener() {
-          @Override
-          public void onAdd(AMRecord amRecord) {
-            LOG.info("AM added to registry: {}", amRecord);
-            if (amRecord.getApplicationId().equals(appId)) {
-              amDiscovered.set(true);
-              amRegisteredLatch.countDown();
-            }
-          }
+    registryClient.addListener(new AMRegistryClientListener() {
+      @Override
+      public void onAdd(AMRecord amRecord) {
+        LOG.info("AM added to registry: {}", amRecord);
+        if (amRecord.getApplicationId().equals(appId)) {
+          amDiscovered.set(true);
+          amRegisteredLatch.countDown();
+        }
+      }
 
-          @Override
-          public void onRemove(AMRecord amRecord) {
-            LOG.info("AM removed from registry: {}", amRecord);
-          }
-        });
+      @Override
+      public void onRemove(AMRecord amRecord) {
+        LOG.info("AM removed from registry: {}", amRecord);
+      }
+    });
     registryClient.start();
 
     String workingDir = TEST_DIR.toString();
@@ -165,22 +164,8 @@ public class TestZkAMRegistryClient {
     String jobUserName = UserGroupInformation.getCurrentUser().getShortUserName();
 
     dagAppMaster =
-        new MockDAGAppMaster(
-            attemptId,
-            containerId,
-            SystemClock.getInstance(),
-            System.currentTimeMillis(),
-            true,
-            workingDir,
-            localDirs,
-            logDirs,
-            new AtomicBoolean(true),
-            false,
-            false,
-            new Credentials(),
-            jobUserName,
-            1,
-            1,
+        new MockDAGAppMaster(attemptId, containerId, SystemClock.getInstance(), System.currentTimeMillis(), true,
+            workingDir, localDirs, logDirs, new AtomicBoolean(true), false, false, new Credentials(), jobUserName, 1, 1,
             new LocalNodeContext("localhost", 0, 0));
 
     dagAppMaster.init(tezConf);

--- a/tez-dag/src/test/java/org/apache/tez/client/registry/zookeeper/TestZkAMRegistryClient.java
+++ b/tez-dag/src/test/java/org/apache/tez/client/registry/zookeeper/TestZkAMRegistryClient.java
@@ -18,12 +18,11 @@
  */
 package org.apache.tez.client.registry.zookeeper;
 
-
 import static org.apache.tez.frameworkplugins.FrameworkMode.STANDALONE_ZOOKEEPER;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.List;
@@ -46,9 +45,11 @@ import org.apache.tez.dag.app.DAGAppMaster;
 import org.apache.tez.dag.app.LocalNodeContext;
 import org.apache.tez.dag.app.MockDAGAppMaster;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,7 +74,7 @@ public class TestZkAMRegistryClient {
    * Embedded ZooKeeper server for testing. Uses Apache Curator's {@link TestingServer}
    * to provide an in-memory ZooKeeper instance.
    */
-  private TestingServer zkServer;
+  private static TestingServer zkServer;
 
   /**
    * ZooKeeper-based AM registry client used to discover and retrieve AM records.
@@ -85,19 +86,23 @@ public class TestZkAMRegistryClient {
    */
   private DAGAppMaster dagAppMaster;
 
-  @Before
-  public void setup() throws Exception {
+  @BeforeAll
+  public static void setup() throws Exception {
     zkServer = new TestingServer();
     zkServer.start();
     LOG.info("Started ZooKeeper test server on port: {}", zkServer.getPort());
   }
 
-  @After
-  public void teardown() throws Exception {
+  @AfterEach
+  public void teardownEach() throws Exception {
     if (dagAppMaster != null) {
       dagAppMaster.stop();
     }
     IOUtils.closeQuietly(registryClient);
+  }
+
+  @AfterAll
+  public static void teardown() throws Exception {
     IOUtils.closeQuietly(zkServer);
   }
 
@@ -122,7 +127,8 @@ public class TestZkAMRegistryClient {
    *
    * @throws Exception if any part of the test fails
    */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testZkAmRegistryDiscovery() throws Exception {
     TezConfiguration tezConf = getTezConfForZkDiscovery();
 
@@ -135,51 +141,67 @@ public class TestZkAMRegistryClient {
 
     // Create and start the ZkAMRegistryClient
     registryClient = ZkAMRegistryClient.getClient(tezConf);
-    registryClient.addListener(new AMRegistryClientListener() {
-      @Override
-      public void onAdd(AMRecord amRecord) {
-        LOG.info("AM added to registry: {}", amRecord);
-        if (amRecord.getApplicationId().equals(appId)) {
-          amDiscovered.set(true);
-          amRegisteredLatch.countDown();
-        }
-      }
+    registryClient.addListener(
+        new AMRegistryClientListener() {
+          @Override
+          public void onAdd(AMRecord amRecord) {
+            LOG.info("AM added to registry: {}", amRecord);
+            if (amRecord.getApplicationId().equals(appId)) {
+              amDiscovered.set(true);
+              amRegisteredLatch.countDown();
+            }
+          }
 
-      @Override
-      public void onRemove(AMRecord amRecord) {
-        LOG.info("AM removed from registry: {}", amRecord);
-      }
-    });
+          @Override
+          public void onRemove(AMRecord amRecord) {
+            LOG.info("AM removed from registry: {}", amRecord);
+          }
+        });
     registryClient.start();
 
     String workingDir = TEST_DIR.toString();
-    String[] localDirs = new String[]{TEST_DIR.toString()};
-    String[] logDirs = new String[]{TEST_DIR + "/logs"};
+    String[] localDirs = new String[] {TEST_DIR.toString()};
+    String[] logDirs = new String[] {TEST_DIR + "/logs"};
     String jobUserName = UserGroupInformation.getCurrentUser().getShortUserName();
 
-    dagAppMaster = new MockDAGAppMaster(attemptId, containerId, SystemClock.getInstance(),
-        System.currentTimeMillis(), true, workingDir, localDirs, logDirs, new AtomicBoolean(true), false, false,
-        new Credentials(), jobUserName, 1, 1, new LocalNodeContext("localhost", 0, 0));
+    dagAppMaster =
+        new MockDAGAppMaster(
+            attemptId,
+            containerId,
+            SystemClock.getInstance(),
+            System.currentTimeMillis(),
+            true,
+            workingDir,
+            localDirs,
+            logDirs,
+            new AtomicBoolean(true),
+            false,
+            false,
+            new Credentials(),
+            jobUserName,
+            1,
+            1,
+            new LocalNodeContext("localhost", 0, 0));
 
     dagAppMaster.init(tezConf);
     dagAppMaster.start();
 
     // Wait for AM to be registered in ZooKeeper
     boolean registered = amRegisteredLatch.await(30, TimeUnit.SECONDS);
-    assertTrue("AM was not registered in ZooKeeper within timeout", registered);
-    assertTrue("AM was not discovered by registry client", amDiscovered.get());
+    assertTrue(registered, "AM was not registered in ZooKeeper within timeout");
+    assertTrue(amDiscovered.get(), "AM was not discovered by registry client");
 
     // Verify the AM record is available through the registry client
     AMRecord amRecord = registryClient.getRecord(appId);
-    assertNotNull("AM record should be retrievable from registry", amRecord);
-    assertEquals("Application ID should match", appId, amRecord.getApplicationId());
-    assertNotNull("Host should be set", amRecord.getHostName());
-    assertTrue("Port should be positive", amRecord.getPort() > 0);
+    assertNotNull(amRecord, "AM record should be retrievable from registry");
+    assertEquals(appId, amRecord.getApplicationId(), "Application ID should match");
+    assertNotNull(amRecord.getHostName(), "Host should be set");
+    assertTrue(amRecord.getPort() > 0, "Port should be positive");
 
     // Verify getAllRecords also returns the AM
     List<AMRecord> allRecords = registryClient.getAllRecords();
-    assertNotNull("getAllRecords should not return null", allRecords);
-    assertFalse("getAllRecords should contain at least one record", allRecords.isEmpty());
+    assertNotNull(allRecords, "getAllRecords should not return null");
+    assertFalse(allRecords.isEmpty(), "getAllRecords should contain at least one record");
 
     boolean found = false;
     for (AMRecord record : allRecords) {
@@ -188,7 +210,7 @@ public class TestZkAMRegistryClient {
         break;
       }
     }
-    assertTrue("AM record should be in getAllRecords", found);
+    assertTrue(found, "AM record should be in getAllRecords");
   }
 
   private TezConfiguration getTezConfForZkDiscovery() {

--- a/tez-dag/src/test/java/org/apache/tez/dag/api/client/TestDAGClientHandler.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/api/client/TestDAGClientHandler.java
@@ -18,11 +18,16 @@
  */
 package org.apache.tez.dag.api.client;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.util.SystemClock;
@@ -36,14 +41,16 @@ import org.apache.tez.dag.app.DAGAppMasterState;
 import org.apache.tez.dag.app.dag.DAG;
 import org.apache.tez.dag.records.TezDAGID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.internal.util.collections.Sets;
 
 
 public class TestDAGClientHandler {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGClientHandler() throws TezException {
 
     TezDAGID mockTezDAGId = mock(TezDAGID.class);
@@ -116,7 +123,7 @@ public class TestDAGClientHandler {
     verify(mockDagAM, times(1)).tryKillDAG(eventCaptor.capture(),
         contains("Sending client kill from"));
     assertEquals(1, eventCaptor.getAllValues().size());
-    assertTrue(eventCaptor.getAllValues().get(0) instanceof DAG);
+    assertInstanceOf(DAG.class, eventCaptor.getAllValues().get(0));
     assertEquals("dag_9999_0001_1",  ((DAG)eventCaptor.getAllValues().get(0)).getID().toString());
 
     // submitDAG
@@ -148,7 +155,7 @@ public class TestDAGClientHandler {
     assertEquals("dag_9999_0001_1", dagClientHandler.getDAG("dag_9999_0001_1").getID().toString());
   }
 
-  @Test(expected = NoCurrentDAGException.class)
+  @Test
   public void testNoCurrentDAGException() throws TezException {
     DAGAppMaster mockDagAM = getMockAm();
 
@@ -156,7 +163,9 @@ public class TestDAGClientHandler {
     when(mockDagAM.getContext().getCurrentDAG()).thenReturn(null);
 
     // so this should throw NoCurrentDAGException
-    new DAGClientHandler(mockDagAM).getDAG("dag_0000_0000_0");
+    assertThrows(NoCurrentDAGException.class, () -> {
+        new DAGClientHandler(mockDagAM).getDAG("dag_0000_0000_0");
+    });
   }
 
   private DAGAppMaster getMockAm() {

--- a/tez-dag/src/test/java/org/apache/tez/dag/api/client/TestDAGClientHandler.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/api/client/TestDAGClientHandler.java
@@ -163,9 +163,7 @@ public class TestDAGClientHandler {
     when(mockDagAM.getContext().getCurrentDAG()).thenReturn(null);
 
     // so this should throw NoCurrentDAGException
-    assertThrows(NoCurrentDAGException.class, () -> {
-        new DAGClientHandler(mockDagAM).getDAG("dag_0000_0000_0");
-    });
+    assertThrows(NoCurrentDAGException.class, () -> new DAGClientHandler(mockDagAM).getDAG("dag_0000_0000_0"));
   }
 
   private DAGAppMaster getMockAm() {

--- a/tez-dag/src/test/java/org/apache/tez/dag/api/client/TestDAGClientServer.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/api/client/TestDAGClientServer.java
@@ -18,11 +18,14 @@
  */
 package org.apache.tez.dag.api.client;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -30,12 +33,14 @@ import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.TezUncheckedException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestDAGClientServer {
 
   // try 10 times to allocate random port, fail it if no one is succeed.
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPortRange() {
     boolean succeedToAllocate = false;
     Random rand = new Random();

--- a/tez-dag/src/test/java/org/apache/tez/dag/api/client/TestVertexStatusBuilder.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/api/client/TestVertexStatusBuilder.java
@@ -18,22 +18,27 @@
  */
 package org.apache.tez.dag.api.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+
 import org.apache.tez.dag.api.records.DAGProtos;
 import org.apache.tez.dag.app.dag.VertexState;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestVertexStatusBuilder {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexStateConversion() {
     for (VertexState state : VertexState.values()) {
       DAGProtos.VertexStatusStateProto stateProto =
           VertexStatusBuilder.getProtoState(state);
       VertexStatus.State clientState =
           VertexStatus.getState(stateProto);
-      Assert.assertEquals(state.name(), clientState.name());
+      assertEquals(state.name(), clientState.name());
     }
   }
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/api/client/registry/zookeeper/TestZkAMRegistry.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/api/client/registry/zookeeper/TestZkAMRegistry.java
@@ -18,9 +18,9 @@
  */
 package org.apache.tez.dag.api.client.registry.zookeeper;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.test.TestingServer;
@@ -43,9 +44,10 @@ import org.apache.tez.client.registry.AMRegistryUtils;
 import org.apache.tez.client.registry.zookeeper.ZkConfig;
 import org.apache.tez.dag.api.TezConfiguration;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Unit tests for {@link ZkAMRegistry}.
@@ -59,16 +61,16 @@ import org.junit.Test;
  */
 public class TestZkAMRegistry {
 
-  private TestingServer zkServer;
+  private static TestingServer zkServer;
 
-  @Before
-  public void setup() throws Exception {
+  @BeforeAll
+  public static void setup() throws Exception {
     zkServer = new TestingServer();
     zkServer.start();
   }
 
-  @After
-  public void teardown() throws Exception {
+  @AfterAll
+  public static void teardown() throws Exception {
     if (zkServer != null) {
       zkServer.close();
     }
@@ -86,12 +88,13 @@ public class TestZkAMRegistry {
 
       assertNotNull(first);
       assertNotNull(second);
-      assertEquals("Cluster timestamps should match", first.getClusterTimestamp(), second.getClusterTimestamp());
-      assertEquals("Second id should be first id + 1", first.getId() + 1, second.getId());
+      assertEquals(first.getClusterTimestamp(), second.getClusterTimestamp(), "Cluster timestamps should match");
+      assertEquals(first.getId() + 1, second.getId(), "Second id should be first id + 1");
     }
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testGenerateNewIdFromParallelThreads() throws Exception {
     final int threadCount = 50;
 
@@ -138,12 +141,12 @@ public class TestZkAMRegistry {
       } finally {
         executor.shutdown();
       }
-      assertEquals(String.format("All generated ids should be unique, ids found: %s", ids), threadCount, ids.size());
+      assertEquals(threadCount, ids.size(), String.format("All generated ids should be unique, ids found: %s", ids));
 
       // additionally ensure cluster timestamp is the same for all IDs
       long clusterTs = ids.iterator().next().getClusterTimestamp();
       for (ApplicationId id : ids) {
-        assertEquals("Cluster timestamps should match for all generated ids", clusterTs, id.getClusterTimestamp());
+        assertEquals(clusterTs, id.getClusterTimestamp(), "Cluster timestamps should match for all generated ids");
       }
     }
   }
@@ -172,14 +175,14 @@ public class TestZkAMRegistry {
       String path = zkConfig.getZkNamespace() + "/" + appId.toString();
       byte[] data = checkClient.getData().forPath(path);
 
-      assertNotNull("Data should be written to ZooKeeper for AMRecord", data);
+      assertNotNull(data, "Data should be written to ZooKeeper for AMRecord");
       String json = new String(data, StandardCharsets.UTF_8);
       String expectedJson = AMRegistryUtils.recordToJsonString(record);
-      assertEquals("Stored AMRecord JSON should match expected", expectedJson, json);
+      assertEquals(expectedJson, json, "Stored AMRecord JSON should match expected");
 
       // Remove record and ensure node is deleted
       registry.remove(record);
-      assertNull("Node should be removed from ZooKeeper after remove()", checkClient.checkExists().forPath(path));
+      assertNull(checkClient.checkExists().forPath(path), "Node should be removed from ZooKeeper after remove()");
     }
   }
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClientAMProtocolBlockingPBServerImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClientAMProtocolBlockingPBServerImpl.java
@@ -18,9 +18,9 @@
  */
 package org.apache.tez.dag.api.client.rpc;
 
-import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -33,6 +33,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.fs.FileSystem;
@@ -52,32 +53,33 @@ import org.apache.tez.dag.api.client.DAGClientHandler;
 import org.apache.tez.dag.api.client.rpc.DAGClientAMProtocolRPC.SubmitDAGRequestProto;
 import org.apache.tez.dag.api.records.DAGProtos.DAGPlan;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.*;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
 
 public class TestDAGClientAMProtocolBlockingPBServerImpl {
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder(new File("target"));
+  @TempDir
+  public java.nio.file.Path tmpFolder;
 
   @Captor
   private ArgumentCaptor<Map<String, LocalResource>> localResourcesCaptor;
 
-  @Before
+  @BeforeEach
   public void init() {
     MockitoAnnotations.initMocks(this);
   }
 
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100000, unit = TimeUnit.MILLISECONDS)
   @SuppressWarnings("unchecked")
   public void testSubmitDagInSessionWithLargeDagPlan() throws Exception {
     int maxIPCMsgSize = 1024;
     String dagPlanName = "DAG-testSubmitDagInSessionWithLargeDagPlan";
-    File requestFile = tmpFolder.newFile("request-file");
+    File requestFile = java.nio.file.Files.createFile(tmpFolder.resolve("request-file")).toFile();
     TezConfiguration conf = new TezConfiguration();
     conf.setInt(CommonConfigurationKeys.IPC_MAXIMUM_DATA_LENGTH, maxIPCMsgSize);
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClientAMProtocolBlockingPBServerImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClientAMProtocolBlockingPBServerImpl.java
@@ -56,7 +56,7 @@ import org.apache.tez.dag.api.records.DAGProtos.DAGPlan;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.io.*;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/MockClock.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/MockClock.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 
 import org.apache.hadoop.yarn.util.Clock;
 
+
 public class MockClock implements Clock {
 
   long time;

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/MockClock.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/MockClock.java
@@ -23,7 +23,6 @@ import java.util.LinkedList;
 
 import org.apache.hadoop.yarn.util.Clock;
 
-
 public class MockClock implements Clock {
 
   long time;

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/MockLocalClient.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/MockLocalClient.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.tez.client.LocalClient;
 
+
 public class MockLocalClient extends LocalClient {
   MockDAGAppMaster mockApp;
   AtomicBoolean mockAppLauncherGoFlag;

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/MockLocalClient.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/MockLocalClient.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.util.Clock;
 import org.apache.tez.client.LocalClient;
 
-
 public class MockLocalClient extends LocalClient {
   MockDAGAppMaster mockApp;
   AtomicBoolean mockAppLauncherGoFlag;

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/MockTezClient.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/MockTezClient.java
@@ -28,6 +28,7 @@ import org.apache.tez.client.FrameworkClient;
 import org.apache.tez.client.TezClient;
 import org.apache.tez.dag.api.TezConfiguration;
 
+
 public class MockTezClient extends TezClient {
   MockLocalClient client;
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/MockTezClient.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/MockTezClient.java
@@ -28,7 +28,6 @@ import org.apache.tez.client.FrameworkClient;
 import org.apache.tez.client.TezClient;
 import org.apache.tez.dag.api.TezConfiguration;
 
-
 public class MockTezClient extends TezClient {
   MockLocalClient client;
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/PluginWrapperTestHelpers.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/PluginWrapperTestHelpers.java
@@ -18,7 +18,9 @@
  */
 package org.apache.tez.dag.app;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Constructor;
@@ -69,8 +71,7 @@ public final class PluginWrapperTestHelpers {
         if (answer.compareAsPrimitive) {
           assertEquals(answer.lastRetValue, result);
         } else {
-          assertSame("Expected: " + System.identityHashCode(answer.lastRetValue) + ", actual=" +
-                  System.identityHashCode(result), answer.lastRetValue, result);
+          assertSame(answer.lastRetValue, result, "Expected: " + System.identityHashCode(answer.lastRetValue) + ", actual=" + System.identityHashCode(result));
         }
       }
     }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/PluginWrapperTestHelpers.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/PluginWrapperTestHelpers.java
@@ -33,7 +33,6 @@ import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public final class PluginWrapperTestHelpers {
 
   private static final Logger LOG = LoggerFactory.getLogger(PluginWrapperTestHelpers.class);
@@ -71,7 +70,9 @@ public final class PluginWrapperTestHelpers {
         if (answer.compareAsPrimitive) {
           assertEquals(answer.lastRetValue, result);
         } else {
-          assertSame(answer.lastRetValue, result, "Expected: " + System.identityHashCode(answer.lastRetValue) + ", actual=" + System.identityHashCode(result));
+          assertSame(answer.lastRetValue, result,
+              "Expected: " + System.identityHashCode(answer.lastRetValue) + ", actual=" +
+              System.identityHashCode(result));
         }
       }
     }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestDAGAppMaster.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestDAGAppMaster.java
@@ -18,10 +18,12 @@
  */
 package org.apache.tez.dag.app;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -44,6 +46,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -56,7 +59,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
-import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.Time;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -93,10 +95,10 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -111,18 +113,19 @@ public class TestDAGAppMaster {
   private static final File TEST_DIR = new File(System.getProperty("test.build.data"),
       TestDAGAppMaster.class.getName()).getAbsoluteFile();
 
-  @Before
-  public void setup() {
+  @BeforeAll
+  public static void setup() {
     FileUtil.fullyDelete(TEST_DIR);
     TEST_DIR.mkdirs();
   }
 
-  @After
-  public void teardown() {
+  @AfterAll
+  public static void teardown() {
     FileUtil.fullyDelete(TEST_DIR);
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidSession() throws Exception {
     // AM should fail if not the first attempt and in session mode and
     // DAG recovery is disabled, otherwise the app can succeed without
@@ -144,11 +147,12 @@ public class TestDAGAppMaster {
         break;
       }
     }
-    Assert.assertTrue("Missing invalid session diagnostics", found);
+    assertTrue(found, "Missing invalid session diagnostics");
     dam.stop();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPluginParsing() throws IOException {
     BiMap<String, Integer> pluginMap = HashBiMap.create();
     Configuration conf = new Configuration(false);
@@ -165,7 +169,7 @@ public class TestDAGAppMaster {
     assertEquals(1, pluginMap.size());
     assertEquals(1, entities.size());
     assertTrue(pluginMap.containsKey(TezConstants.getTezYarnServicePluginName()));
-    assertTrue(0 == pluginMap.get(TezConstants.getTezYarnServicePluginName()));
+    assertEquals(0, (int) pluginMap.get(TezConstants.getTezYarnServicePluginName()));
     assertEquals("testval",
         TezUtils.createConfFromUserPayload(entities.get(0).getUserPayload()).get("testkey"));
 
@@ -176,7 +180,7 @@ public class TestDAGAppMaster {
     assertEquals(1, pluginMap.size());
     assertEquals(1, entities.size());
     assertTrue(pluginMap.containsKey(TezConstants.getTezUberServicePluginName()));
-    assertTrue(0 == pluginMap.get(TezConstants.getTezUberServicePluginName()));
+    assertEquals(0, (int) pluginMap.get(TezConstants.getTezUberServicePluginName()));
     assertEquals("testval",
         TezUtils.createConfFromUserPayload(entities.get(0).getUserPayload()).get("testkey"));
 
@@ -187,9 +191,9 @@ public class TestDAGAppMaster {
     assertEquals(2, pluginMap.size());
     assertEquals(2, entities.size());
     assertTrue(pluginMap.containsKey(TezConstants.getTezYarnServicePluginName()));
-    assertTrue(0 == pluginMap.get(TezConstants.getTezYarnServicePluginName()));
+    assertEquals(0, (int) pluginMap.get(TezConstants.getTezYarnServicePluginName()));
     assertTrue(pluginMap.containsKey(TezConstants.getTezUberServicePluginName()));
-    assertTrue(1 == pluginMap.get(TezConstants.getTezUberServicePluginName()));
+    assertEquals(1, (int) pluginMap.get(TezConstants.getTezUberServicePluginName()));
 
 
     String pluginName = "d1";
@@ -210,7 +214,7 @@ public class TestDAGAppMaster {
     assertEquals(1, pluginMap.size());
     assertEquals(1, entities.size());
     assertTrue(pluginMap.containsKey(pluginName));
-    assertTrue(0 == pluginMap.get(pluginName));
+    assertEquals(0, (int) pluginMap.get(pluginName));
 
     // Test descriptor, yarn and uber
     pluginMap.clear();
@@ -219,16 +223,17 @@ public class TestDAGAppMaster {
     assertEquals(3, pluginMap.size());
     assertEquals(3, entities.size());
     assertTrue(pluginMap.containsKey(TezConstants.getTezYarnServicePluginName()));
-    assertTrue(0 == pluginMap.get(TezConstants.getTezYarnServicePluginName()));
+    assertEquals(0, (int) pluginMap.get(TezConstants.getTezYarnServicePluginName()));
     assertTrue(pluginMap.containsKey(TezConstants.getTezUberServicePluginName()));
-    assertTrue(1 == pluginMap.get(TezConstants.getTezUberServicePluginName()));
+    assertEquals(1, (int) pluginMap.get(TezConstants.getTezUberServicePluginName()));
     assertTrue(pluginMap.containsKey(pluginName));
-    assertTrue(2 == pluginMap.get(pluginName));
+    assertEquals(2, (int) pluginMap.get(pluginName));
     entityDescriptors.clear();
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testParseAllPluginsNoneSpecified() throws IOException {
     PluginManager pluginManager = new PluginManager();
     Configuration conf = new Configuration(false);
@@ -263,7 +268,8 @@ public class TestDAGAppMaster {
         TezConstants.getTezUberServicePluginName());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testParseAllPluginsCustomAndYarnSpecified() throws IOException {
     Configuration conf = new Configuration(false);
     conf.set(TEST_KEY, TEST_VAL);
@@ -293,7 +299,8 @@ public class TestDAGAppMaster {
     assertEquals(TC_NAME + CLASS_SUFFIX, pluginDescriptors.getTaskCommunicatorDescriptors().get(1).getClassName());
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testShutdownTezAMWithMissingRecoveryAndFailureOnMissingData() throws Exception {
 
     TezConfiguration conf = new TezConfiguration();
@@ -327,8 +334,8 @@ public class TestDAGAppMaster {
     // This ensures that recovery data file system was called for getting summary files, and it will return false
     verify(mockFs, times(2)).exists(captor.capture());
 
-    Assert.assertTrue(captor.getAllValues().get(1).toString().contains("/recovery/1/summary"));
-    Assert.assertTrue(captor.getAllValues().get(0).toString().contains("/recovery/1/RecoveryFatalErrorOccurred"));
+    assertTrue(captor.getAllValues().get(1).toString().contains("/recovery/1/summary"));
+    assertTrue(captor.getAllValues().get(0).toString().contains("/recovery/1/RecoveryFatalErrorOccurred"));
 
     verify(dam.mockScheduler).setShouldUnregisterFlag();
     verify(dam.mockShutdown).shutdown();
@@ -371,8 +378,8 @@ public class TestDAGAppMaster {
     // This ensures that recovery data file system was called for getting summary files, and it will return false
     verify(mockFs, times(2)).exists(captor.capture());
 
-    Assert.assertTrue(captor.getAllValues().get(1).toString().contains("/recovery/1/summary"));
-    Assert.assertTrue(captor.getAllValues().get(0).toString().contains("/recovery/1/RecoveryFatalErrorOccurred"));
+    assertTrue(captor.getAllValues().get(1).toString().contains("/recovery/1/summary"));
+    assertTrue(captor.getAllValues().get(0).toString().contains("/recovery/1/RecoveryFatalErrorOccurred"));
 
     verify(dam.mockScheduler).setShouldUnregisterFlag();
     verify(dam.mockShutdown).shutdown();
@@ -397,8 +404,8 @@ public class TestDAGAppMaster {
         assertEquals(TEST_VAL,
             TezUtils.createConfFromUserPayload(descriptors.get(0).getUserPayload()).get(TEST_KEY));
       }
-      assertTrue(map.get(expectedNames[i]) == i);
-      assertTrue(map.inverse().get(i) == expectedNames[i]);
+      assertEquals((int) map.get(expectedNames[i]), i);
+      assertSame(map.inverse().get(i), expectedNames[i]);
     }
   }
 
@@ -453,16 +460,13 @@ public class TestDAGAppMaster {
     TezConfiguration conf = new TezConfiguration(false);
     conf.setBoolean(TezConfiguration.DAG_RECOVERY_ENABLED, false);
     dam.init(conf);
-    LambdaTestUtils.intercept(TezUncheckedException.class,
-        "Cannot get ApplicationACLs before all services have started, The current service state is INITED",
-        () -> dam.getContext().getApplicationACLs());
+    TezUncheckedException e1 = assertThrows(TezUncheckedException.class, () -> dam.getContext().getApplicationACLs());
+    assertTrue(e1.getMessage().contains("Cannot get ApplicationACLs before all services have started, The current service state is INITED"));
     dam.start();
     dam.stop();
     Mockito.when(dam.mockShutdown.getShutdownTime()).thenReturn(Date.from(Instant.ofEpochMilli(Time.now())));
-    LambdaTestUtils.intercept(TezUncheckedException.class,
-        " Cannot get ApplicationACLs before all services have started, "
-            + "The current service state is STOPPED. The shutdown hook started at "
-            + dam.mockShutdown.getShutdownTime(), () -> dam.getContext().getApplicationACLs());
+    TezUncheckedException e2 = assertThrows(TezUncheckedException.class, () -> dam.getContext().getApplicationACLs());
+    assertTrue(e2.getMessage().contains("Cannot get ApplicationACLs before all services have started, The current service state is STOPPED"));
   }
 
   @Test
@@ -530,20 +534,16 @@ public class TestDAGAppMaster {
     map.put(mockVertexID, mockVertex);
     when(dag.getVertices()).thenReturn(map);
     when(dag.getTotalVertices()).thenReturn(1);
-    Assert.assertEquals("Progress was NaN and should be reported as 0",
-        0, am.getProgress(), 0);
+    assertEquals(0, am.getProgress(), 0, "Progress was NaN and should be reported as 0");
     when(mockVertex.getProgress()).thenReturn(-10f);
-    Assert.assertEquals("Progress was negative and should be reported as 0",
-        0, am.getProgress(), 0);
+    assertEquals(0, am.getProgress(), 0, "Progress was negative and should be reported as 0");
     when(mockVertex.getProgress()).thenReturn(1.0000567f);
-    Assert.assertEquals(
+    assertEquals(1.0f, am.getProgress(), 0.0f,
         "Progress was greater than 1 by a small float precision "
-            + "1.0000567 and should be reported as 1",
-        1.0f, am.getProgress(), 0.0f);
+            + "1.0000567 and should be reported as 1");
     when(mockVertex.getProgress()).thenReturn(10f);
-    Assert.assertEquals(
-        "Progress was greater than 1 and should be reported as 1",
-        1.0f, am.getProgress(), 0.0f);
+    assertEquals(1.0f, am.getProgress(), 0.0f,
+        "Progress was greater than 1 and should be reported as 1");
   }
 
   @SuppressWarnings("deprecation")
@@ -614,22 +614,21 @@ public class TestDAGAppMaster {
     Token<? extends TokenIdentifier> fetchedToken1 =
         fetchedDagCreds.getToken(tokenAlias1);
     if (doMerge) {
-      assertNotNull("AM creds missing from DAG creds", fetchedToken1);
+      assertNotNull(fetchedToken1, "AM creds missing from DAG creds");
       compareTestTokens(amToken1, fetchedDagCreds.getToken(tokenAlias1));
     } else {
-      assertNull("AM creds leaked to DAG creds", fetchedToken1);
+      assertNull(fetchedToken1, "AM creds leaked to DAG creds");
     }
     compareTestTokens(dagToken1, fetchedDagCreds.getToken(tokenAlias2));
     compareTestTokens(dagToken2, fetchedDagCreds.getToken(tokenAlias3));
   }
 
   private static void compareTestTokens(
-      Token<? extends TokenIdentifier> expected,
-      Token<? extends TokenIdentifier> actual) throws IOException {
+      Token<? extends TokenIdentifier> expected, Token<? extends TokenIdentifier> actual)
+      throws IOException {
     TestTokenIdentifier expectedId = getTestTokenIdentifier(expected);
     TestTokenIdentifier actualId = getTestTokenIdentifier(actual);
-    assertEquals("Token id not preserved", expectedId.getTestId(),
-        actualId.getTestId());
+    assertEquals(expectedId.getTestId(), actualId.getTestId(), "Token id not preserved");
   }
 
   private static TestTokenIdentifier getTestTokenIdentifier(

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestDAGAppMaster.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestDAGAppMaster.java
@@ -461,12 +461,14 @@ public class TestDAGAppMaster {
     conf.setBoolean(TezConfiguration.DAG_RECOVERY_ENABLED, false);
     dam.init(conf);
     TezUncheckedException e1 = assertThrows(TezUncheckedException.class, () -> dam.getContext().getApplicationACLs());
-    assertTrue(e1.getMessage().contains("Cannot get ApplicationACLs before all services have started, The current service state is INITED"));
+    assertTrue(e1.getMessage()
+        .contains("Cannot get ApplicationACLs before all services have started, The current service state is INITED"));
     dam.start();
     dam.stop();
     Mockito.when(dam.mockShutdown.getShutdownTime()).thenReturn(Date.from(Instant.ofEpochMilli(Time.now())));
     TezUncheckedException e2 = assertThrows(TezUncheckedException.class, () -> dam.getContext().getApplicationACLs());
-    assertTrue(e2.getMessage().contains("Cannot get ApplicationACLs before all services have started, The current service state is STOPPED"));
+    assertTrue(e2.getMessage()
+        .contains("Cannot get ApplicationACLs before all services have started, The current service state is STOPPED"));
   }
 
   @Test
@@ -539,11 +541,9 @@ public class TestDAGAppMaster {
     assertEquals(0, am.getProgress(), 0, "Progress was negative and should be reported as 0");
     when(mockVertex.getProgress()).thenReturn(1.0000567f);
     assertEquals(1.0f, am.getProgress(), 0.0f,
-        "Progress was greater than 1 by a small float precision "
-            + "1.0000567 and should be reported as 1");
+        "Progress was greater than 1 by a small float precision " + "1.0000567 and should be reported as 1");
     when(mockVertex.getProgress()).thenReturn(10f);
-    assertEquals(1.0f, am.getProgress(), 0.0f,
-        "Progress was greater than 1 and should be reported as 1");
+    assertEquals(1.0f, am.getProgress(), 0.0f, "Progress was greater than 1 and should be reported as 1");
   }
 
   @SuppressWarnings("deprecation")
@@ -624,8 +624,8 @@ public class TestDAGAppMaster {
   }
 
   private static void compareTestTokens(
-      Token<? extends TokenIdentifier> expected, Token<? extends TokenIdentifier> actual)
-      throws IOException {
+      Token<? extends TokenIdentifier> expected,
+      Token<? extends TokenIdentifier> actual) throws IOException {
     TestTokenIdentifier expectedId = getTestTokenIdentifier(expected);
     TestTokenIdentifier actualId = getTestTokenIdentifier(actual);
     assertEquals(expectedId.getTestId(), actualId.getTestId(), "Token id not preserved");

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestMemoryWithEvents.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestMemoryWithEvents.java
@@ -18,6 +18,8 @@
  */
 package org.apache.tez.dag.app;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -52,9 +54,9 @@ import org.apache.tez.util.StopWatch;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 // The objective of these tests is to make sure the large job simulations pass
 // within the memory limits set by the junit tests (1GB)
@@ -136,7 +138,7 @@ public class TestMemoryWithEvents {
     mockLauncher.waitTillContainersLaunched();
     mockLauncher.startScheduling(true);
     DAGStatus status = dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
     checkMemory(dag.getName(), mockApp);
     stopwatch.stop();
     System.out.println("Time taken(ms): " + stopwatch.now(TimeUnit.MILLISECONDS));
@@ -163,8 +165,9 @@ public class TestMemoryWithEvents {
     }
   }
 
-  @Ignore
-  @Test (timeout = 600000)
+  @Disabled
+  @Test
+  @Timeout(value = 600000, unit = TimeUnit.MILLISECONDS)
   public void testMemoryRootInputEvents() throws Exception {
     DAG dag = DAG.create("testMemoryRootInputEvents");
     Vertex vA = Vertex.create("A", ProcessorDescriptor.create("Proc.class"), numTasks);
@@ -177,8 +180,9 @@ public class TestMemoryWithEvents {
     testMemory(dag, false);
   }
 
-  @Ignore
-  @Test (timeout = 600000)
+  @Disabled
+  @Test
+  @Timeout(value = 600000, unit = TimeUnit.MILLISECONDS)
   public void testMemoryOneToOne() throws Exception {
     DAG dag = DAG.create("testMemoryOneToOne");
     Vertex vA = Vertex.create("A", ProcessorDescriptor.create("Proc.class"), numTasks);
@@ -192,8 +196,9 @@ public class TestMemoryWithEvents {
     testMemory(dag, true);
   }
 
-  @Ignore
-  @Test (timeout = 600000)
+  @Disabled
+  @Test
+  @Timeout(value = 600000, unit = TimeUnit.MILLISECONDS)
   public void testMemoryBroadcast() throws Exception {
     DAG dag = DAG.create("testMemoryBroadcast");
     Vertex vA = Vertex.create("A", ProcessorDescriptor.create("Proc.class"), numTasks);
@@ -207,8 +212,9 @@ public class TestMemoryWithEvents {
     testMemory(dag, true);
   }
 
-  @Ignore
-  @Test (timeout = 600000)
+  @Disabled
+  @Test
+  @Timeout(value = 600000, unit = TimeUnit.MILLISECONDS)
   public void testMemoryScatterGather() throws Exception {
     DAG dag = DAG.create("testMemoryScatterGather");
     Vertex vA = Vertex.create("A", ProcessorDescriptor.create("Proc.class"), numTasks);

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestMockDAGAppMaster.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestMockDAGAppMaster.java
@@ -225,7 +225,8 @@ public class TestMockDAGAppMaster {
     TezTaskAttemptID killedTaId = TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexId, 0), 0);
     TaskAttempt killedTa = dagImpl.getVertex(vA.getName()).getTask(0).getAttempt(killedTaId);
     //Refer to TEZ-3950
-    assertTrue(killedTa.getState().equals(TaskAttemptState.KILLED) || killedTa.getState().equals(TaskAttemptState.FAILED));
+    assertTrue(
+        killedTa.getState().equals(TaskAttemptState.KILLED) || killedTa.getState().equals(TaskAttemptState.FAILED));
     tezClient.stop();
   }
 
@@ -234,8 +235,7 @@ public class TestMockDAGAppMaster {
   public void testBasicEvents() throws Exception {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
 
-    MockTezClient tezClient =
-        new MockTezClient("testMockAM", tezconf, true, null, null, null, null);
+    MockTezClient tezClient = new MockTezClient("testMockAM", tezconf, true, null, null, null, null);
     tezClient.start();
 
     MockDAGAppMaster mockApp = tezClient.getLocalClient().getMockApp();
@@ -247,40 +247,13 @@ public class TestMockDAGAppMaster {
     Vertex vB = Vertex.create("B", ProcessorDescriptor.create("Proc.class"), 2);
     Vertex vC = Vertex.create("C", ProcessorDescriptor.create("Proc.class"), 2);
     Vertex vD = Vertex.create("D", ProcessorDescriptor.create("Proc.class"), 2);
-    dag.addVertex(vA)
-        .addVertex(vB)
-        .addVertex(vC)
-        .addVertex(vD)
-        .addEdge(
-            Edge.create(
-                vA,
-                vB,
-                EdgeProperty.create(
-                    DataMovementType.BROADCAST,
-                    DataSourceType.PERSISTED,
-                    SchedulingType.SEQUENTIAL,
-                    OutputDescriptor.create("Out"),
-                    InputDescriptor.create("In"))))
-        .addEdge(
-            Edge.create(
-                vA,
-                vC,
-                EdgeProperty.create(
-                    DataMovementType.SCATTER_GATHER,
-                    DataSourceType.PERSISTED,
-                    SchedulingType.SEQUENTIAL,
-                    OutputDescriptor.create("Out"),
-                    InputDescriptor.create("In"))))
-        .addEdge(
-            Edge.create(
-                vA,
-                vD,
-                EdgeProperty.create(
-                    DataMovementType.ONE_TO_ONE,
-                    DataSourceType.PERSISTED,
-                    SchedulingType.SEQUENTIAL,
-                    OutputDescriptor.create("Out"),
-                    InputDescriptor.create("In"))));
+    dag.addVertex(vA).addVertex(vB).addVertex(vC).addVertex(vD).addEdge(Edge.create(vA, vB,
+        EdgeProperty.create(DataMovementType.BROADCAST, DataSourceType.PERSISTED, SchedulingType.SEQUENTIAL,
+            OutputDescriptor.create("Out"), InputDescriptor.create("In")))).addEdge(Edge.create(vA, vC,
+        EdgeProperty.create(DataMovementType.SCATTER_GATHER, DataSourceType.PERSISTED, SchedulingType.SEQUENTIAL,
+            OutputDescriptor.create("Out"), InputDescriptor.create("In")))).addEdge(Edge.create(vA, vD,
+        EdgeProperty.create(DataMovementType.ONE_TO_ONE, DataSourceType.PERSISTED, SchedulingType.SEQUENTIAL,
+            OutputDescriptor.create("Out"), InputDescriptor.create("In"))));
 
     DAGClient dagClient = tezClient.submitDAG(dag);
     mockLauncher.waitTillContainersLaunched();
@@ -300,8 +273,7 @@ public class TestMockDAGAppMaster {
     int targetIndex1 = ((DataMovementEvent) tEvents.get(0).getEvent()).getTargetIndex();
     int targetIndex2 = ((DataMovementEvent) tEvents.get(1).getEvent()).getTargetIndex();
     // order of vA task completion can change order of events
-    assertTrue(
-        (targetIndex1 == 0 && targetIndex2 == 1) || (targetIndex1 == 1 && targetIndex2 == 0),
+    assertTrue((targetIndex1 == 0 && targetIndex2 == 1) || (targetIndex1 == 1 && targetIndex2 == 0),
         "t1: " + targetIndex1 + " t2: " + targetIndex2);
     vImpl = (VertexImpl) dagImpl.getVertex(vC.getName());
     tImpl = (TaskImpl) vImpl.getTask(1);
@@ -309,25 +281,22 @@ public class TestMockDAGAppMaster {
     tEvents = vImpl.getTaskAttemptTezEvents(taId, 0, 0, 1000).getEvents();
     assertEquals(2, tEvents.size()); // 2 from vA
     assertEquals(vA.getName(), tEvents.get(0).getDestinationInfo().getEdgeVertexName());
-    assertEquals(
-        1, ((CompositeRoutedDataMovementEvent) tEvents.get(0).getEvent()).getSourceIndex());
+    assertEquals(1, ((CompositeRoutedDataMovementEvent) tEvents.get(0).getEvent()).getSourceIndex());
     assertEquals(vA.getName(), tEvents.get(1).getDestinationInfo().getEdgeVertexName());
-    assertEquals(
-        1, ((CompositeRoutedDataMovementEvent) tEvents.get(1).getEvent()).getSourceIndex());
+    assertEquals(1, ((CompositeRoutedDataMovementEvent) tEvents.get(1).getEvent()).getSourceIndex());
     targetIndex1 = ((CompositeRoutedDataMovementEvent) tEvents.get(0).getEvent()).getTargetIndex();
     targetIndex2 = ((CompositeRoutedDataMovementEvent) tEvents.get(1).getEvent()).getTargetIndex();
     // order of vA task completion can change order of events
-    assertTrue(
-        (targetIndex1 == 0 && targetIndex2 == 1) || (targetIndex1 == 1 && targetIndex2 == 0),
+    assertTrue((targetIndex1 == 0 && targetIndex2 == 1) || (targetIndex1 == 1 && targetIndex2 == 0),
         "t1: " + targetIndex1 + " t2: " + targetIndex2);
     vImpl = (VertexImpl) dagImpl.getVertex(vD.getName());
     tImpl = (TaskImpl) vImpl.getTask(1);
     taId = TezTaskAttemptID.getInstance(tImpl.getTaskID(), 0);
     tEvents = vImpl.getTaskAttemptTezEvents(taId, 0, 0, 1000).getEvents();
     assertEquals(1, tEvents.size()); // 1 from vA
-    assertEquals(vA.getName(), tEvents.get(0).getDestinationInfo().getEdgeVertexName());
-    assertEquals(0, ((DataMovementEvent) tEvents.get(0).getEvent()).getTargetIndex());
-    assertEquals(0, ((DataMovementEvent) tEvents.get(0).getEvent()).getSourceIndex());
+    assertEquals(vA.getName(), tEvents.getFirst().getDestinationInfo().getEdgeVertexName());
+    assertEquals(0, ((DataMovementEvent) tEvents.getFirst().getEvent()).getTargetIndex());
+    assertEquals(0, ((DataMovementEvent) tEvents.getFirst().getEvent()).getSourceIndex());
 
     tezClient.stop();
   }
@@ -1270,8 +1239,7 @@ public class TestMockDAGAppMaster {
     }
     assertEquals(DAGState.SUCCEEDED, mockApp.getContext().getCurrentDAG().getState());
     assertEquals(DAGAppMasterState.FAILED, mockApp.getState());
-    assertTrue(StringUtils.join(mockApp.getDiagnostics(),",")
-        .contains("Recovery had a fatal error, shutting down session after" +
-              " DAG completion"));
+    assertTrue(StringUtils.join(mockApp.getDiagnostics(), ",")
+        .contains("Recovery had a fatal error, shutting down session after" + " DAG completion"));
   }
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestMockDAGAppMaster.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestMockDAGAppMaster.java
@@ -18,6 +18,12 @@
  */
 package org.apache.tez.dag.app;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
@@ -27,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -110,9 +117,9 @@ import org.apache.tez.serviceplugins.api.ContainerStopRequest;
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Ints;
 
-import org.junit.Assert;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestMockDAGAppMaster {
   private static final Log LOG = LogFactory.getLog(TestMockDAGAppMaster.class);
@@ -149,7 +156,8 @@ public class TestMockDAGAppMaster {
     }
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLocalResourceSetup() throws Exception {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
 
@@ -179,16 +187,17 @@ public class TestMockDAGAppMaster {
     ContainerLaunchContext launchContext = cData.launchContext;
     Map<String, LocalResource> taskLR = launchContext.getLocalResources();
     // verify tasks are launched with both DAG and task resources.
-    Assert.assertTrue(taskLR.containsKey(lrName1));
-    Assert.assertTrue(taskLR.containsKey(lrName2));
+    assertTrue(taskLR.containsKey(lrName1));
+    assertTrue(taskLR.containsKey(lrName2));
 
     mockLauncher.startScheduling(true);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
     tezClient.stop();
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInternalPreemption() throws Exception {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
 
@@ -211,20 +220,22 @@ public class TestMockDAGAppMaster {
 
     mockLauncher.startScheduling(true);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
     TezVertexID vertexId = TezVertexID.getInstance(dagImpl.getID(), 0);
     TezTaskAttemptID killedTaId = TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexId, 0), 0);
     TaskAttempt killedTa = dagImpl.getVertex(vA.getName()).getTask(0).getAttempt(killedTaId);
     //Refer to TEZ-3950
-    Assert.assertTrue(killedTa.getState().equals(TaskAttemptState.KILLED) || killedTa.getState().equals(TaskAttemptState.FAILED));
+    assertTrue(killedTa.getState().equals(TaskAttemptState.KILLED) || killedTa.getState().equals(TaskAttemptState.FAILED));
     tezClient.stop();
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasicEvents() throws Exception {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
 
-    MockTezClient tezClient = new MockTezClient("testMockAM", tezconf, true, null, null, null, null);
+    MockTezClient tezClient =
+        new MockTezClient("testMockAM", tezconf, true, null, null, null, null);
     tezClient.start();
 
     MockDAGAppMaster mockApp = tezClient.getLocalClient().getMockApp();
@@ -241,60 +252,82 @@ public class TestMockDAGAppMaster {
         .addVertex(vC)
         .addVertex(vD)
         .addEdge(
-            Edge.create(vA, vB, EdgeProperty.create(DataMovementType.BROADCAST,
-                DataSourceType.PERSISTED, SchedulingType.SEQUENTIAL,
-                OutputDescriptor.create("Out"), InputDescriptor.create("In"))))
+            Edge.create(
+                vA,
+                vB,
+                EdgeProperty.create(
+                    DataMovementType.BROADCAST,
+                    DataSourceType.PERSISTED,
+                    SchedulingType.SEQUENTIAL,
+                    OutputDescriptor.create("Out"),
+                    InputDescriptor.create("In"))))
         .addEdge(
-            Edge.create(vA, vC, EdgeProperty.create(DataMovementType.SCATTER_GATHER,
-                DataSourceType.PERSISTED, SchedulingType.SEQUENTIAL,
-                OutputDescriptor.create("Out"), InputDescriptor.create("In"))))
+            Edge.create(
+                vA,
+                vC,
+                EdgeProperty.create(
+                    DataMovementType.SCATTER_GATHER,
+                    DataSourceType.PERSISTED,
+                    SchedulingType.SEQUENTIAL,
+                    OutputDescriptor.create("Out"),
+                    InputDescriptor.create("In"))))
         .addEdge(
-            Edge.create(vA, vD, EdgeProperty.create(DataMovementType.ONE_TO_ONE,
-                DataSourceType.PERSISTED, SchedulingType.SEQUENTIAL,
-                OutputDescriptor.create("Out"), InputDescriptor.create("In"))));
+            Edge.create(
+                vA,
+                vD,
+                EdgeProperty.create(
+                    DataMovementType.ONE_TO_ONE,
+                    DataSourceType.PERSISTED,
+                    SchedulingType.SEQUENTIAL,
+                    OutputDescriptor.create("Out"),
+                    InputDescriptor.create("In"))));
 
     DAGClient dagClient = tezClient.submitDAG(dag);
     mockLauncher.waitTillContainersLaunched();
     DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
     mockLauncher.startScheduling(true);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
     VertexImpl vImpl = (VertexImpl) dagImpl.getVertex(vB.getName());
     TaskImpl tImpl = (TaskImpl) vImpl.getTask(1);
     TezTaskAttemptID taId = TezTaskAttemptID.getInstance(tImpl.getTaskID(), 0);
     List<TezEvent> tEvents = vImpl.getTaskAttemptTezEvents(taId, 0, 0, 1000).getEvents();
-    Assert.assertEquals(2, tEvents.size()); // 2 from vA
-    Assert.assertEquals(vA.getName(), tEvents.get(0).getDestinationInfo().getEdgeVertexName());
-    Assert.assertEquals(0, ((DataMovementEvent)tEvents.get(0).getEvent()).getSourceIndex());
-    Assert.assertEquals(vA.getName(), tEvents.get(1).getDestinationInfo().getEdgeVertexName());
-    Assert.assertEquals(0, ((DataMovementEvent)tEvents.get(1).getEvent()).getSourceIndex());
-    int targetIndex1 = ((DataMovementEvent)tEvents.get(0).getEvent()).getTargetIndex();
-    int targetIndex2 = ((DataMovementEvent)tEvents.get(1).getEvent()).getTargetIndex();
+    assertEquals(2, tEvents.size()); // 2 from vA
+    assertEquals(vA.getName(), tEvents.get(0).getDestinationInfo().getEdgeVertexName());
+    assertEquals(0, ((DataMovementEvent) tEvents.get(0).getEvent()).getSourceIndex());
+    assertEquals(vA.getName(), tEvents.get(1).getDestinationInfo().getEdgeVertexName());
+    assertEquals(0, ((DataMovementEvent) tEvents.get(1).getEvent()).getSourceIndex());
+    int targetIndex1 = ((DataMovementEvent) tEvents.get(0).getEvent()).getTargetIndex();
+    int targetIndex2 = ((DataMovementEvent) tEvents.get(1).getEvent()).getTargetIndex();
     // order of vA task completion can change order of events
-    Assert.assertTrue("t1: " + targetIndex1 + " t2: " + targetIndex2,
-        (targetIndex1 == 0 && targetIndex2 == 1) || (targetIndex1 == 1 && targetIndex2 == 0));
+    assertTrue(
+        (targetIndex1 == 0 && targetIndex2 == 1) || (targetIndex1 == 1 && targetIndex2 == 0),
+        "t1: " + targetIndex1 + " t2: " + targetIndex2);
     vImpl = (VertexImpl) dagImpl.getVertex(vC.getName());
     tImpl = (TaskImpl) vImpl.getTask(1);
     taId = TezTaskAttemptID.getInstance(tImpl.getTaskID(), 0);
     tEvents = vImpl.getTaskAttemptTezEvents(taId, 0, 0, 1000).getEvents();
-    Assert.assertEquals(2, tEvents.size()); // 2 from vA
-    Assert.assertEquals(vA.getName(), tEvents.get(0).getDestinationInfo().getEdgeVertexName());
-    Assert.assertEquals(1, ((CompositeRoutedDataMovementEvent)tEvents.get(0).getEvent()).getSourceIndex());
-    Assert.assertEquals(vA.getName(), tEvents.get(1).getDestinationInfo().getEdgeVertexName());
-    Assert.assertEquals(1, ((CompositeRoutedDataMovementEvent)tEvents.get(1).getEvent()).getSourceIndex());
-    targetIndex1 = ((CompositeRoutedDataMovementEvent)tEvents.get(0).getEvent()).getTargetIndex();
-    targetIndex2 = ((CompositeRoutedDataMovementEvent)tEvents.get(1).getEvent()).getTargetIndex();
+    assertEquals(2, tEvents.size()); // 2 from vA
+    assertEquals(vA.getName(), tEvents.get(0).getDestinationInfo().getEdgeVertexName());
+    assertEquals(
+        1, ((CompositeRoutedDataMovementEvent) tEvents.get(0).getEvent()).getSourceIndex());
+    assertEquals(vA.getName(), tEvents.get(1).getDestinationInfo().getEdgeVertexName());
+    assertEquals(
+        1, ((CompositeRoutedDataMovementEvent) tEvents.get(1).getEvent()).getSourceIndex());
+    targetIndex1 = ((CompositeRoutedDataMovementEvent) tEvents.get(0).getEvent()).getTargetIndex();
+    targetIndex2 = ((CompositeRoutedDataMovementEvent) tEvents.get(1).getEvent()).getTargetIndex();
     // order of vA task completion can change order of events
-    Assert.assertTrue("t1: " + targetIndex1 + " t2: " + targetIndex2,
-        (targetIndex1 == 0 && targetIndex2 == 1) || (targetIndex1 == 1 && targetIndex2 == 0));
+    assertTrue(
+        (targetIndex1 == 0 && targetIndex2 == 1) || (targetIndex1 == 1 && targetIndex2 == 0),
+        "t1: " + targetIndex1 + " t2: " + targetIndex2);
     vImpl = (VertexImpl) dagImpl.getVertex(vD.getName());
     tImpl = (TaskImpl) vImpl.getTask(1);
     taId = TezTaskAttemptID.getInstance(tImpl.getTaskID(), 0);
     tEvents = vImpl.getTaskAttemptTezEvents(taId, 0, 0, 1000).getEvents();
-    Assert.assertEquals(1, tEvents.size()); // 1 from vA
-    Assert.assertEquals(vA.getName(), tEvents.get(0).getDestinationInfo().getEdgeVertexName());
-    Assert.assertEquals(0, ((DataMovementEvent)tEvents.get(0).getEvent()).getTargetIndex());
-    Assert.assertEquals(0, ((DataMovementEvent)tEvents.get(0).getEvent()).getSourceIndex());
+    assertEquals(1, tEvents.size()); // 1 from vA
+    assertEquals(vA.getName(), tEvents.get(0).getDestinationInfo().getEdgeVertexName());
+    assertEquals(0, ((DataMovementEvent) tEvents.get(0).getEvent()).getTargetIndex());
+    assertEquals(0, ((DataMovementEvent) tEvents.get(0).getEvent()).getSourceIndex());
 
     tezClient.stop();
   }
@@ -344,7 +377,8 @@ public class TestMockDAGAppMaster {
     }
   }
 
-  @Test (timeout = 100000)
+  @Test
+  @Timeout(value = 100000, unit = TimeUnit.MILLISECONDS)
   public void testMixedEdgeRouting() throws Exception {
    TezConfiguration tezconf = new TezConfiguration(defaultConf);
 
@@ -394,27 +428,28 @@ public class TestMockDAGAppMaster {
     DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
     mockLauncher.startScheduling(true);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
     // vC uses on demand routing and its task does not provide events
     VertexImpl vImpl = (VertexImpl) dagImpl.getVertex(vC.getName());
     TaskImpl tImpl = (TaskImpl) vImpl.getTask(0);
     TezTaskAttemptID taId = TezTaskAttemptID.getInstance(tImpl.getTaskID(), 0);
-    Assert.assertEquals(0, tImpl.getTaskAttemptTezEvents(taId, 0, 1000).size());
+    assertEquals(0, tImpl.getTaskAttemptTezEvents(taId, 0, 1000).size());
     // vD is mixed mode and only 1 out of 2 edges does legacy routing with task providing events
     vImpl = (VertexImpl) dagImpl.getVertex(vD.getName());
     tImpl = (TaskImpl) vImpl.getTask(0);
     taId = TezTaskAttemptID.getInstance(tImpl.getTaskID(), 0);
-    Assert.assertEquals(1, tImpl.getTaskAttemptTezEvents(taId, 0, 1000).size());
+    assertEquals(1, tImpl.getTaskAttemptTezEvents(taId, 0, 1000).size());
     // vE has single legacy edge and does not use on demand routing and its task provides events
     vImpl = (VertexImpl) dagImpl.getVertex(vE.getName());
     tImpl = (TaskImpl) vImpl.getTask(0);
     taId = TezTaskAttemptID.getInstance(tImpl.getTaskID(), 0);
-    Assert.assertEquals(1, tImpl.getTaskAttemptTezEvents(taId, 0, 1000).size());
+    assertEquals(1, tImpl.getTaskAttemptTezEvents(taId, 0, 1000).size());
 
     tezClient.stop();
   }
 
-  @Test (timeout = 100000)
+  @Test
+  @Timeout(value = 100000, unit = TimeUnit.MILLISECONDS)
   public void testConcurrencyLimit() throws Exception {
     // the test relies on local mode behavior of launching a new container per task.
     // so task concurrency == container concurrency
@@ -454,8 +489,8 @@ public class TestMockDAGAppMaster {
     mockLauncher.startScheduling(true);
     DAGClient dagClient = tezClient.submitDAG(dag);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
-    Assert.assertFalse(exceededConcurrency.get());
+    assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+    assertFalse(exceededConcurrency.get());
     tezClient.stop();
   }
 
@@ -502,7 +537,7 @@ public class TestMockDAGAppMaster {
           // the internal merges of counters covers the constructor code path.
           counters.readFields(in);
         } catch (IOException e) {
-          Assert.fail(e.getMessage());
+          fail(e.getMessage());
         }
         counters.findCounter(vName, procCounterName).setValue(++counterValue);
         for (OutputSpec output : taskSpec.getOutputs()) {
@@ -520,7 +555,7 @@ public class TestMockDAGAppMaster {
     DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
     mockLauncher.startScheduling(true);
     DAGStatus status = dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
     TezCounters counters = dagImpl.getAllCounters();
 
     // verify processor counters
@@ -529,20 +564,21 @@ public class TestMockDAGAppMaster {
     TezCounters vACounters = vAImpl.getAllCounters();
     TezCounters vBCounters = vBImpl.getAllCounters();
 
-    Assert.assertEquals(19, ((AggregateTezCounterDelegate)vACounters.findCounter(vAName, procCounterName)).getMax());
-    Assert.assertEquals(1, ((AggregateTezCounterDelegate)vACounters.findCounter(vAName, procCounterName)).getMin());
-    Assert.assertEquals(20, ((AggregateTezCounterDelegate)vACounters.findCounter(vAName, vBName)).getMax());
-    Assert.assertEquals(2, ((AggregateTezCounterDelegate)vACounters.findCounter(vAName, vBName)).getMin());
+    assertEquals(19, ((AggregateTezCounterDelegate)vACounters.findCounter(vAName, procCounterName)).getMax());
+    assertEquals(1, ((AggregateTezCounterDelegate)vACounters.findCounter(vAName, procCounterName)).getMin());
+    assertEquals(20, ((AggregateTezCounterDelegate)vACounters.findCounter(vAName, vBName)).getMax());
+    assertEquals(2, ((AggregateTezCounterDelegate)vACounters.findCounter(vAName, vBName)).getMin());
 
-    Assert.assertEquals(21, ((AggregateTezCounterDelegate)vBCounters.findCounter(vBName, procCounterName)).getMin());
-    Assert.assertEquals(21, ((AggregateTezCounterDelegate)vBCounters.findCounter(vBName, procCounterName)).getMax());
-    Assert.assertEquals(22, ((AggregateTezCounterDelegate)vBCounters.findCounter(vBName, vAName)).getMin());
-    Assert.assertEquals(22, ((AggregateTezCounterDelegate)vBCounters.findCounter(vBName, vAName)).getMax());
+    assertEquals(21, ((AggregateTezCounterDelegate)vBCounters.findCounter(vBName, procCounterName)).getMin());
+    assertEquals(21, ((AggregateTezCounterDelegate)vBCounters.findCounter(vBName, procCounterName)).getMax());
+    assertEquals(22, ((AggregateTezCounterDelegate)vBCounters.findCounter(vBName, vAName)).getMin());
+    assertEquals(22, ((AggregateTezCounterDelegate)vBCounters.findCounter(vBName, vAName)).getMax());
 
     tezClient.stop();
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testBasicCounters() throws Exception {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
     MockTezClient tezClient = new MockTezClient("testMockAM", tezconf, true, null, null, null,
@@ -584,7 +620,7 @@ public class TestMockDAGAppMaster {
           // the internal merges of counters covers the constructor code path.
           counters.readFields(in);
         } catch (IOException e) {
-          Assert.fail(e.getMessage());
+          fail(e.getMessage());
         }
         counters.findCounter(vName, procCounterName).increment(1);
         for (OutputSpec output : taskSpec.getOutputs()) {
@@ -602,22 +638,22 @@ public class TestMockDAGAppMaster {
     DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
     mockLauncher.startScheduling(true);
     DAGStatus status = dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
     TezCounters counters = dagImpl.getAllCounters();
 
     String osName = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
     if (SystemUtils.IS_OS_LINUX) {
-      Assert.assertTrue(counters.findCounter(DAGCounter.AM_CPU_MILLISECONDS).getValue() > 0);
+      assertTrue(counters.findCounter(DAGCounter.AM_CPU_MILLISECONDS).getValue() > 0);
     }
 
     // verify processor counters
-    Assert.assertEquals(10, counters.findCounter(vAName, procCounterName).getValue());
-    Assert.assertEquals(1, counters.findCounter(vBName, procCounterName).getValue());
+    assertEquals(10, counters.findCounter(vAName, procCounterName).getValue());
+    assertEquals(1, counters.findCounter(vBName, procCounterName).getValue());
     // verify edge counters
-    Assert.assertEquals(10, counters.findCounter(vAName, vBName).getValue());
-    Assert.assertEquals(1, counters.findCounter(vBName, vAName).getValue());
+    assertEquals(10, counters.findCounter(vAName, vBName).getValue());
+    assertEquals(1, counters.findCounter(vBName, vAName).getValue());
     // verify global counters
-    Assert.assertEquals(11, counters.findCounter(globalCounterName, globalCounterName).getValue());
+    assertEquals(11, counters.findCounter(globalCounterName, globalCounterName).getValue());
     VertexImpl vAImpl = (VertexImpl) dagImpl.getVertex(vAName);
     VertexImpl vBImpl = (VertexImpl) dagImpl.getVertex(vBName);
     TezCounters vACounters = vAImpl.getAllCounters();
@@ -625,20 +661,21 @@ public class TestMockDAGAppMaster {
     String vACounterName = vACounters.findCounter(globalCounterName, globalCounterName).getName();
     String vBCounterName = vBCounters.findCounter(globalCounterName, globalCounterName).getName();
     if (vACounterName != vBCounterName) {
-      Assert.fail("String counter name objects dont match despite interning.");
+      fail("String counter name objects dont match despite interning.");
     }
     CounterGroup vaGroup = vACounters.getGroup(globalCounterName);
     String vaGrouName = vaGroup.getName();
     CounterGroup vBGroup = vBCounters.getGroup(globalCounterName);
     String vBGrouName = vBGroup.getName();
     if (vaGrouName != vBGrouName) {
-      Assert.fail("String group name objects dont match despite interning.");
+      fail("String group name objects dont match despite interning.");
     }
 
     tezClient.stop();
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testBasicStatistics() throws Exception {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
     MockTezClient tezClient = new MockTezClient("testMockAM", tezconf, true, null, null, null,
@@ -696,7 +733,7 @@ public class TestMockDAGAppMaster {
           // this ensures that the serde code path is covered.
           stats.readFields(in);
         } catch (IOException e) {
-          Assert.fail(e.getMessage());
+          fail(e.getMessage());
         }
         return stats;
       }
@@ -707,21 +744,21 @@ public class TestMockDAGAppMaster {
     DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
     mockLauncher.startScheduling(true);
     DAGStatus status = dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
 
     // verify that the values have been correct aggregated
     for (org.apache.tez.dag.app.dag.Vertex v : dagImpl.getVertices().values()) {
       VertexStatistics vStats = v.getStatistics();
       if (v.getName().equals(vAName)) {
-        Assert.assertEquals(3, vStats.getOutputStatistics(vBName).getDataSize());
-        Assert.assertEquals(3, vStats.getInputStatistics(sourceName).getDataSize());
-        Assert.assertEquals(3, vStats.getOutputStatistics(vBName).getItemsProcessed());
-        Assert.assertEquals(3, vStats.getInputStatistics(sourceName).getItemsProcessed());
+        assertEquals(3, vStats.getOutputStatistics(vBName).getDataSize());
+        assertEquals(3, vStats.getInputStatistics(sourceName).getDataSize());
+        assertEquals(3, vStats.getOutputStatistics(vBName).getItemsProcessed());
+        assertEquals(3, vStats.getInputStatistics(sourceName).getItemsProcessed());
       } else {
-        Assert.assertEquals(2, vStats.getInputStatistics(vAName).getDataSize());
-        Assert.assertEquals(2, vStats.getOutputStatistics(sinkName).getDataSize());
-        Assert.assertEquals(2, vStats.getInputStatistics(vAName).getItemsProcessed());
-        Assert.assertEquals(2, vStats.getOutputStatistics(sinkName).getItemsProcessed());
+        assertEquals(2, vStats.getInputStatistics(vAName).getDataSize());
+        assertEquals(2, vStats.getOutputStatistics(sinkName).getDataSize());
+        assertEquals(2, vStats.getInputStatistics(vAName).getItemsProcessed());
+        assertEquals(2, vStats.getOutputStatistics(sinkName).getItemsProcessed());
       }
     }
 
@@ -753,8 +790,9 @@ public class TestMockDAGAppMaster {
     System.out.println("##### Max Memory:" + runtime.maxMemory() / mb);
   }
 
-  @Ignore
-  @Test (timeout = 60000)
+  @Disabled
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testBasicCounterMemory() throws Exception {
     Logger.getRootLogger().setLevel(Level.WARN);
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
@@ -791,15 +829,16 @@ public class TestMockDAGAppMaster {
     DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
     mockLauncher.startScheduling(true);
     DAGStatus status = dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
     TezCounters counters = dagImpl.getAllCounters();
-    Assert.assertNotNull(counters);
+    assertNotNull(counters);
     checkMemory(dag.getName(), mockApp);
     tezClient.stop();
   }
 
-  @Ignore
-  @Test (timeout = 60000)
+  @Disabled
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testTaskEventsProcessingSpeed() throws Exception {
     Logger.getRootLogger().setLevel(Level.WARN);
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
@@ -818,12 +857,13 @@ public class TestMockDAGAppMaster {
     mockApp.doSleep = false;
     DAGClient dagClient = tezClient.submitDAG(dag);
     DAGStatus status = dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
     tezClient.stop();
   }
 
-  @Ignore
-  @Test (timeout = 60000)
+  @Disabled
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testBasicStatisticsMemory() throws Exception {
     Logger.getRootLogger().setLevel(Level.WARN);
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
@@ -869,7 +909,7 @@ public class TestMockDAGAppMaster {
           // this ensures that the serde code path is covered.
           stats.readFields(in);
         } catch (IOException e) {
-          Assert.fail(e.getMessage());
+          fail(e.getMessage());
         }
         return stats;
       }
@@ -880,16 +920,17 @@ public class TestMockDAGAppMaster {
     DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
     mockLauncher.startScheduling(true);
     DAGStatus status = dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
-    Assert.assertEquals(numTasks,
+    assertEquals(DAGStatus.State.SUCCEEDED, status.getState());
+    assertEquals(numTasks,
         dagImpl.getVertex(vAName).getStatistics().getInputStatistics(0+vAName).getDataSize());
-    Assert.assertEquals(numTasks,
+    assertEquals(numTasks,
         dagImpl.getVertex(vAName).getStatistics().getInputStatistics(0+vAName).getItemsProcessed());
     checkMemory(dag.getName(), mockApp);
     tezClient.stop();
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleSubmissions() throws Exception {
     Map<String, LocalResource> lrDAG = Maps.newHashMap();
     String lrName1 = "LR1";
@@ -910,7 +951,7 @@ public class TestMockDAGAppMaster {
     tezClient.start();
     DAGClient dagClient = tezClient.submitDAG(dag);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
     tezClient.stop();
 
     // submit the same DAG again to verify it can be done.
@@ -918,11 +959,12 @@ public class TestMockDAGAppMaster {
     tezClient.start();
     dagClient = tezClient.submitDAG(dag);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
     tezClient.stop();
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSchedulerErrorHandling() throws Exception {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
 
@@ -945,10 +987,11 @@ public class TestMockDAGAppMaster {
     while(!mockApp.getShutdownHandler().wasShutdownInvoked()) {
       Thread.sleep(100);
     }
-    Assert.assertEquals(DAGState.RUNNING, mockApp.getContext().getCurrentDAG().getState());
+    assertEquals(DAGState.RUNNING, mockApp.getContext().getCurrentDAG().getState());
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testInitFailed() throws Exception {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
     MockTezClient tezClient = new MockTezClient("testMockAM", tezconf, true,
@@ -957,14 +1000,15 @@ public class TestMockDAGAppMaster {
       tezClient.start();
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.assertEquals("FailInit", e.getCause().getCause().getCause().getMessage());
+      assertEquals("FailInit", e.getCause().getCause().getCause().getMessage());
       MockDAGAppMaster mockApp = tezClient.getLocalClient().getMockApp();
       // will timeout if DAGAppMasterShutdownHook is not invoked
       mockApp.waitForServiceToStop(Integer.MAX_VALUE);
     }
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testStartFailed() {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
     MockTezClient tezClient = new MockTezClient("testMockAM", tezconf, true,
@@ -973,7 +1017,7 @@ public class TestMockDAGAppMaster {
       tezClient.start();
     } catch (Exception e) {
       e.printStackTrace();
-      Assert.assertEquals("FailStart", e.getCause().getCause().getCause().getMessage());
+      assertEquals("FailStart", e.getCause().getCause().getCause().getMessage());
       MockDAGAppMaster mockApp = tezClient.getLocalClient().getMockApp();
       // will timeout if DAGAppMasterShutdownHook is not invoked
       mockApp.waitForServiceToStop(Integer.MAX_VALUE);
@@ -1016,7 +1060,8 @@ public class TestMockDAGAppMaster {
     return dag;
   }
 
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testCommitOutputOnDAGSuccess() throws Exception {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
     MockTezClient tezClient = new MockTezClient("testMockAM", tezconf, true, null, null, null, null);
@@ -1026,49 +1071,50 @@ public class TestMockDAGAppMaster {
     DAG dag1 = createDAG("testDAGBothCommitsSucceed", false, false);
     DAGClient dagClient = tezClient.submitDAG(dag1);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
 
     // vertexGroupCommiter fail (uv12)
     DAG dag2 = createDAG("testDAGVertexGroupCommitFail", true, false);
     dagClient = tezClient.submitDAG(dag2);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
     LOG.info(dagClient.getDAGStatus(null).getDiagnostics());
-    Assert.assertTrue(StringUtils.join(dagClient.getDAGStatus(null).getDiagnostics(),",")
+    assertTrue(StringUtils.join(dagClient.getDAGStatus(null).getDiagnostics(),",")
         .contains("fail output committer:uv12Out"));
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v1", null).getState());
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v2", null).getState());
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v3", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v1", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v2", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v3", null).getState());
 
     // vertex commit fail (v3)
     DAG dag3 = createDAG("testDAGVertexCommitFail", false, true);
     dagClient = tezClient.submitDAG(dag3);
     dagClient.waitForCompletion();
     LOG.info(dagClient.getDAGStatus(null).getDiagnostics());
-    Assert.assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
-    Assert.assertTrue(StringUtils.join(dagClient.getDAGStatus(null).getDiagnostics(),",")
+    assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
+    assertTrue(StringUtils.join(dagClient.getDAGStatus(null).getDiagnostics(),",")
         .contains("fail output committer:v3Out"));
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v1", null).getState());
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v2", null).getState());
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v3", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v1", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v2", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v3", null).getState());
 
     // both committers fail
     DAG dag4 = createDAG("testDAGBothCommitsFail", true, true);
     dagClient = tezClient.submitDAG(dag4);
     dagClient.waitForCompletion();
     LOG.info(dagClient.getDAGStatus(null).getDiagnostics());
-    Assert.assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
     String diag = StringUtils.join(dagClient.getDAGStatus(null).getDiagnostics(),",");
-    Assert.assertTrue(diag.contains("fail output committer:uv12Out") ||
+    assertTrue(diag.contains("fail output committer:uv12Out") ||
         diag.contains("fail output committer:v3Out"));
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v1", null).getState());
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v2", null).getState());
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v3", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v1", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v2", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v3", null).getState());
 
     tezClient.stop();
   }
 
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testCommitOutputOnVertexSuccess() throws Exception {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
     tezconf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS, false);
@@ -1079,25 +1125,25 @@ public class TestMockDAGAppMaster {
     DAG dag1 = createDAG("testDAGBothCommitsSucceed", false, false);
     DAGClient dagClient = tezClient.submitDAG(dag1);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
 
     // vertexGroupCommiter fail (uv12)
     DAG dag2 = createDAG("testDAGVertexGroupCommitFail", true, false);
     dagClient = tezClient.submitDAG(dag2);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
     LOG.info(dagClient.getDAGStatus(null).getDiagnostics());
-    Assert.assertTrue(StringUtils.join(dagClient.getDAGStatus(null).getDiagnostics(),",")
+    assertTrue(StringUtils.join(dagClient.getDAGStatus(null).getDiagnostics(),",")
         .contains("fail output committer:uv12Out"));
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v1", null).getState());
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v2", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v1", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v2", null).getState());
     VertexStatus.State v3State = dagClient.getVertexStatus("v3", null).getState();
     // v3 either succeeded (commit completed before uv12 commit fails)
     // or killed ( uv12 commit fail when v3 is in running/committing)
     if (v3State.equals(VertexStatus.State.SUCCEEDED)) {
       LOG.info("v3 is succeeded");
     } else {
-      Assert.assertEquals(VertexStatus.State.KILLED, v3State);
+      assertEquals(VertexStatus.State.KILLED, v3State);
     }
 
     // vertex commit fail (v3)
@@ -1105,36 +1151,36 @@ public class TestMockDAGAppMaster {
     dagClient = tezClient.submitDAG(dag3);
     dagClient.waitForCompletion();
     LOG.info(dagClient.getDAGStatus(null).getDiagnostics());
-    Assert.assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
-    Assert.assertTrue(StringUtils.join(dagClient.getDAGStatus(null).getDiagnostics(),",")
+    assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
+    assertTrue(StringUtils.join(dagClient.getDAGStatus(null).getDiagnostics(),",")
         .contains("Commit failed"));
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v1", null).getState());
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v2", null).getState());
-    Assert.assertEquals(VertexStatus.State.FAILED, dagClient.getVertexStatus("v3", null).getState());
-    Assert.assertTrue(StringUtils.join(dagClient.getVertexStatus("v3", null).getDiagnostics(),",")
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v1", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v2", null).getState());
+    assertEquals(VertexStatus.State.FAILED, dagClient.getVertexStatus("v3", null).getState());
+    assertTrue(StringUtils.join(dagClient.getVertexStatus("v3", null).getDiagnostics(),",")
         .contains("fail output committer:v3Out"));
 
     // both committers fail
     DAG dag4 = createDAG("testDAGBothCommitsFail", true, true);
     dagClient = tezClient.submitDAG(dag4);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
     LOG.info(dagClient.getDAGStatus(null).getDiagnostics());
-    Assert.assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.FAILED, dagClient.getDAGStatus(null).getState());
     String diag = StringUtils.join(dagClient.getDAGStatus(null).getDiagnostics(),",");
-    Assert.assertTrue(diag.contains("fail output committer:uv12Out") ||
+    assertTrue(diag.contains("fail output committer:uv12Out") ||
         diag.contains("fail output committer:v3Out"));
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v1", null).getState());
-    Assert.assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v2", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v1", null).getState());
+    assertEquals(VertexStatus.State.SUCCEEDED, dagClient.getVertexStatus("v2", null).getState());
     v3State = dagClient.getVertexStatus("v3", null).getState();
     // v3 either failed (commit of v3 fail before uv12 commit)
     // or killed ( uv12 commit fail before commit of v3)
     if (v3State.equals(VertexStatus.State.FAILED)) {
       LOG.info("v3 is failed");
-      Assert.assertTrue(StringUtils.join(dagClient.getVertexStatus("v3", null).getDiagnostics(),",")
+      assertTrue(StringUtils.join(dagClient.getVertexStatus("v3", null).getDiagnostics(),",")
           .contains("fail output committer:v3Out"));
     } else {
-      Assert.assertEquals(VertexStatus.State.KILLED, v3State);
+      assertEquals(VertexStatus.State.KILLED, v3State);
     }
 
     tezClient.stop();
@@ -1200,7 +1246,8 @@ public class TestMockDAGAppMaster {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGFinishedRecoveryError() throws Exception {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
 
@@ -1221,9 +1268,9 @@ public class TestMockDAGAppMaster {
     while(!mockApp.getShutdownHandler().wasShutdownInvoked()) {
       Thread.sleep(100);
     }
-    Assert.assertEquals(DAGState.SUCCEEDED, mockApp.getContext().getCurrentDAG().getState());
-    Assert.assertEquals(DAGAppMasterState.FAILED, mockApp.getState());
-    Assert.assertTrue(StringUtils.join(mockApp.getDiagnostics(),",")
+    assertEquals(DAGState.SUCCEEDED, mockApp.getContext().getCurrentDAG().getState());
+    assertEquals(DAGAppMasterState.FAILED, mockApp.getState());
+    assertTrue(StringUtils.join(mockApp.getDiagnostics(),",")
         .contains("Recovery had a fatal error, shutting down session after" +
               " DAG completion"));
   }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestPreemption.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestPreemption.java
@@ -18,7 +18,10 @@
  */
 package org.apache.tez.dag.app;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.conf.Configuration;
@@ -46,8 +49,8 @@ import org.apache.tez.dag.records.TezTaskAttemptID;
 import org.apache.tez.dag.records.TezTaskID;
 import org.apache.tez.dag.records.TezVertexID;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestPreemption {
 
@@ -85,7 +88,8 @@ public class TestPreemption {
     return dag;
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPreemptionWithoutSession() throws Exception {
     System.out.println("TestPreemptionWithoutSession");
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
@@ -113,18 +117,19 @@ public class TestPreemption {
     mockLauncher.startScheduling(true);
 
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
 
     for (int i=0; i<=upToTaskVersion; ++i) {
       TezTaskAttemptID testTaId = TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexId, 0), i);
       TaskAttemptImpl taImpl = dagImpl.getTaskAttempt(testTaId);
-      Assert.assertEquals(TaskAttemptStateInternal.KILLED, taImpl.getInternalState());
+      assertEquals(TaskAttemptStateInternal.KILLED, taImpl.getInternalState());
     }
 
     tezClient.stop();
   }
 
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testPreemptionWithSession() throws Exception {
     System.out.println("TestPreemptionWithSession");
     MockTezClient tezClient = createTezSession();
@@ -194,13 +199,13 @@ public class TestPreemption {
     mockLauncher.startScheduling(true);
 
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
 
     for (int i=0; i<=upToTaskVersion; ++i) {
       TezTaskAttemptID testTaId = TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexId, 0), i);
       TaskAttemptImpl taImpl = dagImpl.getTaskAttempt(testTaId);
-      Assert.assertEquals(TaskAttemptStateInternal.KILLED, taImpl.getInternalState());
-      Assert.assertEquals(TaskAttemptTerminationCause.EXTERNAL_PREEMPTION, taImpl.getTerminationCause());
+      assertEquals(TaskAttemptStateInternal.KILLED, taImpl.getInternalState());
+      assertEquals(TaskAttemptTerminationCause.EXTERNAL_PREEMPTION, taImpl.getTerminationCause());
     }
 
     System.out.println("TestPreemption - Done running - " + info);

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestRecoveryParser.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestRecoveryParser.java
@@ -18,7 +18,12 @@
  */
 package org.apache.tez.dag.app;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -29,6 +34,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -81,7 +87,9 @@ import org.apache.tez.runtime.api.impl.TezEvent;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import org.junit.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestRecoveryParser {
 
@@ -98,7 +106,7 @@ public class TestRecoveryParser {
   // Protobuf message limit is 64 MB by default
   private static final int PROTOBUF_DEFAULT_SIZE_LIMIT = 64 << 20;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IllegalArgumentException, IOException {
     this.conf = new Configuration();
     this.localFS = FileSystem.getLocal(conf);
@@ -119,7 +127,8 @@ public class TestRecoveryParser {
     return data;
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetLastCompletedDAG() {
     Map<TezDAGID, DAGSummaryData> summaryDataMap =
         new HashMap<TezDAGID, DAGSummaryData>();
@@ -135,7 +144,8 @@ public class TestRecoveryParser {
     assertEquals(lastCompletedDAGId, lastCompletedDAG.dagId.getId());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetLastInProgressDAG() {
     Map<TezDAGID, DAGSummaryData> summaryDataMap =
         new HashMap<TezDAGID, DAGSummaryData>();
@@ -157,7 +167,8 @@ public class TestRecoveryParser {
   }
 
   // skipAllOtherEvents due to non-recoverable (in the middle of commit)
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSkipAllOtherEvents_1() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);
@@ -192,7 +203,7 @@ public class TestRecoveryParser {
     rService.stop();
 
     DAGRecoveryData dagData = parser.parseRecoveryData();
-    assertEquals(true, dagData.nonRecoverable);
+    assertTrue(dagData.nonRecoverable);
     assertTrue(dagData.reason.contains("DAG Commit was in progress, not recoverable,"));
     // DAGSubmittedEvent is handled but DAGInitializedEvent and DAGStartedEvent in the next attempt are both skipped
     // due to the dag is not recoerable.
@@ -202,7 +213,8 @@ public class TestRecoveryParser {
   }
 
   // skipAllOtherEvents due to dag finished
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSkipAllOtherEvents_2() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId, 1);
@@ -239,9 +251,9 @@ public class TestRecoveryParser {
     rService.stop();
 
     DAGRecoveryData dagData = parser.parseRecoveryData();
-    assertEquals(false, dagData.nonRecoverable);
+    assertFalse(dagData.nonRecoverable);
     assertEquals(DAGState.FAILED, dagData.dagState);
-    assertEquals(true, dagData.isCompleted);
+    assertTrue(dagData.isCompleted);
     // DAGSubmittedEvent, DAGInitializedEvent and DAGFinishedEvent is handled
     verify(mockAppMaster).createDAG(any(), any());
     // DAGInitializedEvent may not been handled before DAGFinishedEvent,
@@ -250,7 +262,8 @@ public class TestRecoveryParser {
     assertNull(dagData.getDAGStartedEvent());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLastCorruptedRecoveryRecord() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);
@@ -288,15 +301,16 @@ public class TestRecoveryParser {
 
     // corrupted last records will be skipped but the whole recovery logs will be read
     DAGRecoveryData dagData = parser.parseRecoveryData();
-    assertEquals(false, dagData.isCompleted);
-    assertEquals(null, dagData.reason);
-    assertEquals(false, dagData.nonRecoverable);
+    assertFalse(dagData.isCompleted);
+    assertNull(dagData.reason);
+    assertFalse(dagData.nonRecoverable);
     // verify DAGSubmitedEvent & DAGInititlizedEvent is handled.
     verify(mockAppMaster).createDAG(any(), any());
     assertNotNull(dagData.getDAGInitializedEvent());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLastCorruptedSummaryRecord() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);
@@ -330,7 +344,8 @@ public class TestRecoveryParser {
     }
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRecoverableSummary_DAGInCommitting() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);
@@ -361,7 +376,8 @@ public class TestRecoveryParser {
     assertTrue(dagData.reason.contains("DAG Commit was in progress"));
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRecoverableSummary_DAGFinishCommitting() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId, 1);
@@ -398,7 +414,8 @@ public class TestRecoveryParser {
     assertTrue(dagData.isCompleted);
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRecoverableSummary_VertexInCommitting() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);
@@ -429,7 +446,8 @@ public class TestRecoveryParser {
     assertTrue(dagData.reason.contains("Vertex Commit was in progress"));
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRecoverableSummary_VertexFinishCommitting() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);
@@ -466,7 +484,8 @@ public class TestRecoveryParser {
     assertFalse(dagData.nonRecoverable);
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRecoverableSummary_VertexGroupInCommitting() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);
@@ -500,7 +519,8 @@ public class TestRecoveryParser {
     assertTrue(dagData.reason.contains("Vertex Group Commit was in progress"));
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRecoverableSummary_VertexGroupFinishCommitting() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);
@@ -548,7 +568,8 @@ public class TestRecoveryParser {
     assertFalse(dagData.nonRecoverable);
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRecoverableNonSummary1() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);
@@ -586,7 +607,8 @@ public class TestRecoveryParser {
     assertTrue(dagData.reason.contains("Vertex has been committed, but its full recovery events are not seen"));
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRecoverableNonSummary2() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);
@@ -623,7 +645,8 @@ public class TestRecoveryParser {
               + ", but its full recovery events are not seen"));
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testRecoveryLargeEventData() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);
@@ -684,15 +707,16 @@ public class TestRecoveryParser {
 
     DAGRecoveryData dagData = parser.parseRecoveryData();
     VertexRecoveryData v0data = dagData.getVertexRecoveryData(v0Id);
-    assertNotNull("Vertex Recovery Data should be non-null", v0data);
+    assertNotNull(v0data, "Vertex Recovery Data should be non-null");
     VertexConfigurationDoneEvent parsedVertexConfigurationDoneEvent = v0data.getVertexConfigurationDoneEvent();
-    assertNotNull("Vertex Configuration Done Event should be non-null", parsedVertexConfigurationDoneEvent);
+    assertNotNull(parsedVertexConfigurationDoneEvent, "Vertex Configuration Done Event should be non-null");
     VertexLocationHint parsedVertexLocationHint = parsedVertexConfigurationDoneEvent.getVertexLocationHint();
-    assertNotNull("Vertex Location Hint should be non-null", parsedVertexLocationHint);
+    assertNotNull(parsedVertexLocationHint, "Vertex Location Hint should be non-null");
     assertEquals(parsedVertexLocationHint.getTaskLocationHints().size(), 100000);
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRecoveryData() throws IOException {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(), 1);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestSpeculation.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestSpeculation.java
@@ -18,15 +18,15 @@
  */
 package org.apache.tez.dag.app;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -45,6 +45,7 @@ import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.Vertex;
 import org.apache.tez.dag.api.client.DAGClient;
 import org.apache.tez.dag.api.client.DAGStatus;
+import org.apache.tez.dag.api.client.DAGStatus.State;
 import org.apache.tez.dag.app.MockDAGAppMaster.MockContainerLauncher;
 import org.apache.tez.dag.app.dag.Task;
 import org.apache.tez.dag.app.dag.TaskAttempt;
@@ -61,23 +62,16 @@ import org.apache.tez.dag.records.TezVertexID;
 
 import com.google.common.base.Joiner;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.model.Statement;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * test speculation behavior given the list of estimator classes.
  */
-@RunWith(Parameterized.class)
 public class TestSpeculation {
   private final static Logger LOG = LoggerFactory.getLogger(TezConfiguration.class);
 
@@ -109,72 +103,41 @@ public class TestSpeculation {
    */
   MockContainerLauncher mockLauncher;
 
-  /**
-   * The interface Retry.
-   */
-  @Retention(RetentionPolicy.RUNTIME)
-  public @interface Retry {}
+  private interface TestTask {
+    void run() throws Exception;
+  }
 
-  /**
-   * The type Retry rule.
-   */
-  class RetryRule implements TestRule {
-
-    private AtomicInteger retryCount;
-
-    /**
-     * Instantiates a new Retry rule.
-     *
-     * @param retries the retries
-     */
-    RetryRule(int retries) {
-      super();
-      this.retryCount = new AtomicInteger(retries);
-    }
-
-    @Override
-    public Statement apply(final Statement base,
-        final Description description) {
-      return new Statement() {
-        @Override
-        public void evaluate() throws Throwable {
-          Throwable caughtThrowable = null;
-
-          while (retryCount.getAndDecrement() > 0) {
-            try {
-              base.evaluate();
-              return;
-            } catch (Throwable t) {
-              caughtThrowable = t;
-              if (retryCount.get() > 0 &&
-                  description.getAnnotation(Retry.class) != null) {
-                if (!((t instanceof AssertionError && t.getMessage()
-                    .contains(ASSERT_SPECULATIONS_COUNT_MSG))
-                    || (t instanceof Exception && t.getMessage()
-                    .contains(UNIT_EXCEPTION_MESSAGE)))) {
-                  throw caughtThrowable;
-                }
-                LOG.warn("{} : Failed. Retries remaining: {}", description.getDisplayName(), retryCount.toString());
-              } else {
-                throw caughtThrowable;
-              }
-            }
+  private void runWithRetry(TestTask task) throws Exception {
+    int retries = ASSERT_SPECULATIONS_COUNT_RETRIES;
+    while (retries-- > 0) {
+      try {
+        task.run();
+        return;
+      } catch (Throwable t) {
+        if (retries > 0 &&
+            ((t instanceof AssertionError && t.getMessage().contains(ASSERT_SPECULATIONS_COUNT_MSG))
+                || (t instanceof Exception && t.getMessage().contains(UNIT_EXCEPTION_MESSAGE)))) {
+          LOG.warn("Test failed. Retries remaining: {}", retries);
+        } else {
+          if (t instanceof Exception) {
+            throw (Exception) t;
           }
+          throw new RuntimeException(t);
         }
-      };
+      }
     }
   }
 
-  /**
-   * The Rule.
-   */
-  @Rule
-  public RetryRule rule = new RetryRule(ASSERT_SPECULATIONS_COUNT_RETRIES);
+  private Class<? extends TaskRuntimeEstimator> estimatorClass;
+
+  public void setup(Class<? extends TaskRuntimeEstimator> estimatorClass) {
+    this.estimatorClass = estimatorClass;
+    setDefaultConf();
+  }
 
   /**
    * Sets default conf.
    */
-  @Before
   public void setDefaultConf() {
     try {
       defaultConf = new Configuration(false);
@@ -207,13 +170,19 @@ public class TestSpeculation {
   /**
    * Tear down.
    */
-  @After
+  @AfterEach
   public void tearDown() {
     defaultConf = null;
     try {
-      localFs.close();
-      mockLauncher.shutdown();
-      mockApp.close();
+      if (localFs != null) {
+        localFs.close();
+      }
+      if (mockLauncher != null) {
+        mockLauncher.shutdown();
+      }
+      if (mockApp != null) {
+        mockApp.close();
+      }
     } catch (Exception e) {
       e.printStackTrace();
     }
@@ -224,23 +193,11 @@ public class TestSpeculation {
    *
    * @return the test parameters
    */
-  @Parameterized.Parameters(name = "{index}: TaskEstimator(EstimatorClass {0})")
-  public static Collection<Object[]> getTestParameters() {
-    return Arrays.asList(new Object[][]{
-        {SimpleExponentialTaskRuntimeEstimator.class},
-        {LegacyTaskRuntimeEstimator.class}
-    });
-  }
-
-  private Class<? extends TaskRuntimeEstimator> estimatorClass;
-
-  /**
-   * Instantiates a new Test speculation.
-   *
-   * @param estimatorKlass the estimator klass
-   */
-  public TestSpeculation(Class<? extends TaskRuntimeEstimator>  estimatorKlass) {
-    this.estimatorClass = estimatorKlass;
+  public static Stream<Class<? extends TaskRuntimeEstimator>> getTestParameters() {
+    return Stream.of(
+        SimpleExponentialTaskRuntimeEstimator.class,
+        LegacyTaskRuntimeEstimator.class
+    );
   }
 
   /**
@@ -285,54 +242,58 @@ public class TestSpeculation {
    *
    * @throws Exception the exception
    */
-  @Retry
-  @Test (timeout = 30000)
-  public void testSingleTaskSpeculation() throws Exception {
-    // Map<Timeout conf value, expected number of tasks>
-    Map<Long, Integer> confToExpected = new HashMap<Long, Integer>();
-    confToExpected.put(Long.MAX_VALUE >> 1, 1); // Really long time to speculate
-    confToExpected.put(100L, 2);
-    confToExpected.put(-1L, 1); // Don't speculate
-    defaultConf.setLong(TezConfiguration.TEZ_AM_SOONEST_RETRY_AFTER_NO_SPECULATE, 50);
-    for(Map.Entry<Long, Integer> entry : confToExpected.entrySet()) {
-      defaultConf.setLong(
-              TezConfiguration.TEZ_AM_LEGACY_SPECULATIVE_SINGLE_TASK_VERTEX_TIMEOUT,
-              entry.getKey());
+  @ParameterizedTest(name = "{index}: TaskEstimator(EstimatorClass {0})")
+  @MethodSource("getTestParameters")
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+  public void testSingleTaskSpeculation(Class<? extends TaskRuntimeEstimator> estimatorClass) throws Exception {
+    setup(estimatorClass);
+    runWithRetry(() -> {
+      // Map<Timeout conf value, expected number of tasks>
+      Map<Long, Integer> confToExpected = new HashMap<Long, Integer>();
+      confToExpected.put(Long.MAX_VALUE >> 1, 1); // Really long time to speculate
+      confToExpected.put(100L, 2);
+      confToExpected.put(-1L, 1); // Don't speculate
+      defaultConf.setLong(TezConfiguration.TEZ_AM_SOONEST_RETRY_AFTER_NO_SPECULATE, 50);
+      for(Map.Entry<Long, Integer> entry : confToExpected.entrySet()) {
+        defaultConf.setLong(
+                TezConfiguration.TEZ_AM_LEGACY_SPECULATIVE_SINGLE_TASK_VERTEX_TIMEOUT,
+                entry.getKey());
 
-      DAG dag = DAG.create("DAG-testSingleTaskSpeculation");
-      Vertex vA = Vertex.create("A",
-              ProcessorDescriptor.create("Proc.class"),
-              1);
-      dag.addVertex(vA);
+        DAG dag = DAG.create("DAG-testSingleTaskSpeculation");
+        Vertex vA = Vertex.create("A",
+                ProcessorDescriptor.create("Proc.class"),
+                1);
+        dag.addVertex(vA);
 
-      MockTezClient tezClient = createTezSession();
+        MockTezClient tezClient = createTezSession();
 
-      DAGClient dagClient = tezClient.submitDAG(dag);
-      DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
-      TezVertexID vertexId = TezVertexID.getInstance(dagImpl.getID(), 0);
-      // original attempt is killed and speculative one is successful
-      TezTaskAttemptID killedTaId =
-          TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexId, 0), 0);
-      TezTaskAttemptID successTaId =
-          TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexId, 0), 1);
-      Thread.sleep(200);
-      // cause speculation trigger
-      mockLauncher.setStatusUpdatesForTask(killedTaId, NUM_UPDATES_FOR_TEST_TASK);
+        DAGClient dagClient = tezClient.submitDAG(dag);
+        DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
+        TezVertexID vertexId = TezVertexID.getInstance(dagImpl.getID(), 0);
+        // original attempt is killed and speculative one is successful
+        TezTaskAttemptID killedTaId =
+            TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexId, 0), 0);
+        TezTaskAttemptID successTaId =
+            TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexId, 0), 1);
+        Thread.sleep(200);
+        // cause speculation trigger
+        mockLauncher.setStatusUpdatesForTask(killedTaId, NUM_UPDATES_FOR_TEST_TASK);
 
-      mockLauncher.startScheduling(true);
-      dagClient.waitForCompletion();
-      Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
-      Task task = dagImpl.getTask(killedTaId.getTaskID());
-      Assert.assertEquals(entry.getValue().intValue(), task.getAttempts().size());
-      if (entry.getValue() > 1) {
-        Assert.assertEquals(successTaId, task.getSuccessfulAttempt().getTaskAttemptID());
-        TaskAttempt killedAttempt = task.getAttempt(killedTaId);
-        Joiner.on(",").join(killedAttempt.getDiagnostics()).contains("Killed as speculative attempt");
-        Assert.assertEquals(TaskAttemptTerminationCause.TERMINATED_EFFECTIVE_SPECULATION,
-                killedAttempt.getTerminationCause());
+        mockLauncher.startScheduling(true);
+        dagClient.waitForCompletion();
+        assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+        Task task = dagImpl.getTask(killedTaId.getTaskID());
+        assertEquals(entry.getValue().intValue(), task.getAttempts().size());
+        if (entry.getValue() > 1) {
+          assertEquals(successTaId, task.getSuccessfulAttempt().getTaskAttemptID());
+          TaskAttempt killedAttempt = task.getAttempt(killedTaId);
+          Joiner.on(",").join(killedAttempt.getDiagnostics()).contains("Killed as speculative attempt");
+          assertEquals(TaskAttemptTerminationCause.TERMINATED_EFFECTIVE_SPECULATION,
+                  killedAttempt.getTerminationCause());
+        }
+        tezClient.stop();
       }
-      tezClient.stop();
-    }
+    });
   }
 
   /**
@@ -363,34 +324,33 @@ public class TestSpeculation {
 
     mockLauncher.startScheduling(true);
     dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED,
+    assertEquals(State.SUCCEEDED,
         dagClient.getDAGStatus(null).getState());
     Task task = dagImpl.getTask(killedTaId.getTaskID());
-    Assert.assertEquals(ASSERT_SPECULATIONS_COUNT_MSG, 2,
-        task.getAttempts().size());
-    Assert.assertEquals(successTaId, task.getSuccessfulAttempt().getTaskAttemptID());
+    assertEquals(2, task.getAttempts().size(), ASSERT_SPECULATIONS_COUNT_MSG);
+    assertEquals(successTaId, task.getSuccessfulAttempt().getTaskAttemptID());
     TaskAttempt killedAttempt = task.getAttempt(killedTaId);
     Joiner.on(",").join(killedAttempt.getDiagnostics()).contains("Killed as speculative attempt");
-    Assert.assertEquals(TaskAttemptTerminationCause.TERMINATED_EFFECTIVE_SPECULATION,
+    assertEquals(TaskAttemptTerminationCause.TERMINATED_EFFECTIVE_SPECULATION,
         killedAttempt.getTerminationCause());
     if (withProgress) {
       // without progress updates occasionally more than 1 task speculates
-      Assert.assertEquals(1, task.getCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
+      assertEquals(1, task.getCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
           .getValue());
-      Assert.assertEquals(1, dagImpl.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
+      assertEquals(1, dagImpl.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
           .getValue());
       org.apache.tez.dag.app.dag.Vertex v = dagImpl.getVertex(killedTaId.getVertexID());
-      Assert.assertEquals(1, v.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
+      assertEquals(1, v.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
           .getValue());
     }
 
     LegacySpeculator speculator =
         (LegacySpeculator)(dagImpl.getVertex(vA.getName())).getSpeculator();
-    Assert.assertEquals(20, speculator.getMinimumAllowedSpeculativeTasks());
-    Assert.assertEquals(.2, speculator.getProportionTotalTasksSpeculatable(), 0);
-    Assert.assertEquals(.25, speculator.getProportionRunningTasksSpeculatable(), 0);
-    Assert.assertEquals(25, speculator.getSoonestRetryAfterNoSpeculate());
-    Assert.assertEquals(50, speculator.getSoonestRetryAfterSpeculate());
+    assertEquals(20, speculator.getMinimumAllowedSpeculativeTasks());
+    assertEquals(.2, speculator.getProportionTotalTasksSpeculatable(), 0);
+    assertEquals(.25, speculator.getProportionRunningTasksSpeculatable(), 0);
+    assertEquals(25, speculator.getSoonestRetryAfterNoSpeculate());
+    assertEquals(50, speculator.getSoonestRetryAfterSpeculate());
 
     tezClient.stop();
   }
@@ -400,10 +360,12 @@ public class TestSpeculation {
    *
    * @throws Exception the exception
    */
-  @Retry
-  @Test (timeout=30000)
-  public void testBasicSpeculationWithProgress() throws Exception {
-    testBasicSpeculation(true);
+  @ParameterizedTest(name = "{index}: TaskEstimator(EstimatorClass {0})")
+  @MethodSource("getTestParameters")
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+  public void testBasicSpeculationWithProgress(Class<? extends TaskRuntimeEstimator> estimatorClass) throws Exception {
+    setup(estimatorClass);
+    runWithRetry(() -> testBasicSpeculation(true));
   }
 
   /**
@@ -411,10 +373,12 @@ public class TestSpeculation {
    *
    * @throws Exception the exception
    */
-  @Retry
-  @Test (timeout=30000)
-  public void testBasicSpeculationWithoutProgress() throws Exception {
-    testBasicSpeculation(false);
+  @ParameterizedTest(name = "{index}: TaskEstimator(EstimatorClass {0})")
+  @MethodSource("getTestParameters")
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+  public void testBasicSpeculationWithoutProgress(Class<? extends TaskRuntimeEstimator> estimatorClass) throws Exception {
+    setup(estimatorClass);
+    runWithRetry(() -> testBasicSpeculation(false));
   }
 
   /**
@@ -422,60 +386,63 @@ public class TestSpeculation {
    *
    * @throws Exception the exception
    */
-  @Retry
-  @Test (timeout=30000)
-  public void testBasicSpeculationPerVertexConf() throws Exception {
-    DAG dag = DAG.create("DAG-testBasicSpeculationPerVertexConf");
-    String vNameNoSpec = "A";
-    String vNameSpec = "B";
-    Vertex vA = Vertex.create(vNameNoSpec, ProcessorDescriptor.create("Proc.class"), 5);
-    Vertex vB = Vertex.create(vNameSpec, ProcessorDescriptor.create("Proc.class"), 5);
-    vA.setConf(TezConfiguration.TEZ_AM_SPECULATION_ENABLED, "false");
-    dag.addVertex(vA);
-    dag.addVertex(vB);
-    // min/max src fraction is set to 1. So vertices will run sequentially
-    dag.addEdge(
-        Edge.create(vA, vB,
-            EdgeProperty.create(DataMovementType.SCATTER_GATHER, DataSourceType.PERSISTED,
-                SchedulingType.SEQUENTIAL, OutputDescriptor.create("O"),
-                InputDescriptor.create("I"))));
+  @ParameterizedTest(name = "{index}: TaskEstimator(EstimatorClass {0})")
+  @MethodSource("getTestParameters")
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+  public void testBasicSpeculationPerVertexConf(Class<? extends TaskRuntimeEstimator> estimatorClass) throws Exception {
+    setup(estimatorClass);
+    runWithRetry(() -> {
+      DAG dag = DAG.create("DAG-testBasicSpeculationPerVertexConf");
+      String vNameNoSpec = "A";
+      String vNameSpec = "B";
+      Vertex vA = Vertex.create(vNameNoSpec, ProcessorDescriptor.create("Proc.class"), 5);
+      Vertex vB = Vertex.create(vNameSpec, ProcessorDescriptor.create("Proc.class"), 5);
+      vA.setConf(TezConfiguration.TEZ_AM_SPECULATION_ENABLED, "false");
+      dag.addVertex(vA);
+      dag.addVertex(vB);
+      // min/max src fraction is set to 1. So vertices will run sequentially
+      dag.addEdge(
+          Edge.create(vA, vB,
+              EdgeProperty.create(DataMovementType.SCATTER_GATHER, DataSourceType.PERSISTED,
+                  SchedulingType.SEQUENTIAL, OutputDescriptor.create("O"),
+                  InputDescriptor.create("I"))));
 
-    MockTezClient tezClient = createTezSession();
+      MockTezClient tezClient = createTezSession();
 
-    DAGClient dagClient = tezClient.submitDAG(dag);
-    DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
-    TezVertexID vertexIdSpec = dagImpl.getVertex(vNameSpec).getVertexId();
-    TezVertexID vertexIdNoSpec = dagImpl.getVertex(vNameNoSpec).getVertexId();
-    // original attempt is killed and speculative one is successful
-    TezTaskAttemptID killedTaId =
-        TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexIdSpec, 0), 0);
-    TezTaskAttemptID successfulTaId = TezTaskAttemptID
-        .getInstance(TezTaskID.getInstance(vertexIdNoSpec, 0), 0);
+      DAGClient dagClient = tezClient.submitDAG(dag);
+      DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
+      TezVertexID vertexIdSpec = dagImpl.getVertex(vNameSpec).getVertexId();
+      TezVertexID vertexIdNoSpec = dagImpl.getVertex(vNameNoSpec).getVertexId();
+      // original attempt is killed and speculative one is successful
+      TezTaskAttemptID killedTaId =
+          TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexIdSpec, 0), 0);
+      TezTaskAttemptID successfulTaId = TezTaskAttemptID
+          .getInstance(TezTaskID.getInstance(vertexIdNoSpec, 0), 0);
 
-    // cause speculation trigger for both
-    mockLauncher.setStatusUpdatesForTask(killedTaId, NUM_UPDATES_FOR_TEST_TASK);
-    mockLauncher.setStatusUpdatesForTask(successfulTaId, NUM_UPDATES_FOR_TEST_TASK);
+      // cause speculation trigger for both
+      mockLauncher.setStatusUpdatesForTask(killedTaId, NUM_UPDATES_FOR_TEST_TASK);
+      mockLauncher.setStatusUpdatesForTask(successfulTaId, NUM_UPDATES_FOR_TEST_TASK);
 
-    mockLauncher.startScheduling(true);
-    org.apache.tez.dag.app.dag.Vertex vSpec = dagImpl.getVertex(vertexIdSpec);
-    org.apache.tez.dag.app.dag.Vertex vNoSpec = dagImpl.getVertex(vertexIdNoSpec);
-    // Wait enough time to give chance for the speculator to trigger
-    // speculation on VB.
-    // This would fail because of JUnit time out.
-    do {
-      Thread.sleep(100);
-    } while (vSpec.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-        .getValue() <= 0);
-    dagClient.waitForCompletion();
-    // speculation for vA but not for vB
-    Assert.assertTrue("Num Speculations is not higher than 0",
-        vSpec.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-            .getValue() > 0);
-    Assert.assertEquals(0,
-        vNoSpec.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-            .getValue());
+      mockLauncher.startScheduling(true);
+      org.apache.tez.dag.app.dag.Vertex vSpec = dagImpl.getVertex(vertexIdSpec);
+      org.apache.tez.dag.app.dag.Vertex vNoSpec = dagImpl.getVertex(vertexIdNoSpec);
+      // Wait enough time to give chance for the speculator to trigger
+      // speculation on VB.
+      // This would fail because of JUnit time out.
+      do {
+        Thread.sleep(100);
+      } while (vSpec.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
+          .getValue() <= 0);
+      dagClient.waitForCompletion();
+      // speculation for vA but not for vB
+      assertTrue(vSpec.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
+              .getValue() > 0, "Num Speculations is not higher than 0");
+      assertEquals(0,
+          vNoSpec.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
+              .getValue());
 
-    tezClient.stop();
+      tezClient.stop();
+    });
   }
 
   /**
@@ -483,42 +450,46 @@ public class TestSpeculation {
    *
    * @throws Exception the exception
    */
-  @Retry
-  @Test (timeout=30000)
-  public void testBasicSpeculationNotUseful() throws Exception {
-    DAG dag = DAG.create("DAG-testBasicSpeculationNotUseful");
-    Vertex vA = Vertex.create("A", ProcessorDescriptor.create("Proc.class"), 5);
-    dag.addVertex(vA);
+  @ParameterizedTest(name = "{index}: TaskEstimator(EstimatorClass {0})")
+  @MethodSource("getTestParameters")
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+  public void testBasicSpeculationNotUseful(Class<? extends TaskRuntimeEstimator> estimatorClass) throws Exception {
+    setup(estimatorClass);
+    runWithRetry(() -> {
+      DAG dag = DAG.create("DAG-testBasicSpeculationNotUseful");
+      Vertex vA = Vertex.create("A", ProcessorDescriptor.create("Proc.class"), 5);
+      dag.addVertex(vA);
 
-    MockTezClient tezClient = createTezSession();
+      MockTezClient tezClient = createTezSession();
 
-    DAGClient dagClient = tezClient.submitDAG(dag);
-    DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
-    TezVertexID vertexId = TezVertexID.getInstance(dagImpl.getID(), 0);
-    // original attempt is successful and speculative one is killed
-    TezTaskAttemptID successTaId = TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexId, 0), 0);
-    TezTaskAttemptID killedTaId = TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexId, 0), 1);
+      DAGClient dagClient = tezClient.submitDAG(dag);
+      DAGImpl dagImpl = (DAGImpl) mockApp.getContext().getCurrentDAG();
+      TezVertexID vertexId = TezVertexID.getInstance(dagImpl.getID(), 0);
+      // original attempt is successful and speculative one is killed
+      TezTaskAttemptID successTaId = TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexId, 0), 0);
+      TezTaskAttemptID killedTaId = TezTaskAttemptID.getInstance(TezTaskID.getInstance(vertexId, 0), 1);
 
-    mockLauncher.setStatusUpdatesForTask(successTaId, NUM_UPDATES_FOR_TEST_TASK);
-    mockLauncher.setStatusUpdatesForTask(killedTaId, NUM_UPDATES_FOR_TEST_TASK);
+      mockLauncher.setStatusUpdatesForTask(successTaId, NUM_UPDATES_FOR_TEST_TASK);
+      mockLauncher.setStatusUpdatesForTask(killedTaId, NUM_UPDATES_FOR_TEST_TASK);
 
-    mockLauncher.startScheduling(true);
-    dagClient.waitForCompletion();
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
-    Task task = dagImpl.getTask(killedTaId.getTaskID());
-    Assert.assertEquals(2, task.getAttempts().size());
-    Assert.assertEquals(successTaId, task.getSuccessfulAttempt().getTaskAttemptID());
-    TaskAttempt killedAttempt = task.getAttempt(killedTaId);
-    Joiner.on(",").join(killedAttempt.getDiagnostics()).contains("Killed speculative attempt as");
-    Assert.assertEquals(TaskAttemptTerminationCause.TERMINATED_INEFFECTIVE_SPECULATION,
-        killedAttempt.getTerminationCause());
-    Assert.assertEquals(1, task.getCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-        .getValue());
-    Assert.assertEquals(1, dagImpl.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-        .getValue());
-    org.apache.tez.dag.app.dag.Vertex v = dagImpl.getVertex(killedTaId.getVertexID());
-    Assert.assertEquals(1, v.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-        .getValue());
-    tezClient.stop();
+      mockLauncher.startScheduling(true);
+      dagClient.waitForCompletion();
+      assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+      Task task = dagImpl.getTask(killedTaId.getTaskID());
+      assertEquals(2, task.getAttempts().size());
+      assertEquals(successTaId, task.getSuccessfulAttempt().getTaskAttemptID());
+      TaskAttempt killedAttempt = task.getAttempt(killedTaId);
+      Joiner.on(",").join(killedAttempt.getDiagnostics()).contains("Killed speculative attempt as");
+      assertEquals(TaskAttemptTerminationCause.TERMINATED_INEFFECTIVE_SPECULATION,
+          killedAttempt.getTerminationCause());
+      assertEquals(1, task.getCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
+          .getValue());
+      assertEquals(1, dagImpl.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
+          .getValue());
+      org.apache.tez.dag.app.dag.Vertex v = dagImpl.getVertex(killedTaId.getVertexID());
+      assertEquals(1, v.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
+          .getValue());
+      tezClient.stop();
+    });
   }
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestSpeculation.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestSpeculation.java
@@ -64,8 +64,8 @@ import com.google.common.base.Joiner;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.*;
-import org.junit.jupiter.params.provider.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,14 +109,14 @@ public class TestSpeculation {
 
   private void runWithRetry(TestTask task) throws Exception {
     int retries = ASSERT_SPECULATIONS_COUNT_RETRIES;
-    while (retries-- > 0) {
+    while (true) {
+      retries--;
       try {
         task.run();
         return;
       } catch (Throwable t) {
-        if (retries > 0 &&
-            ((t instanceof AssertionError && t.getMessage().contains(ASSERT_SPECULATIONS_COUNT_MSG))
-                || (t instanceof Exception && t.getMessage().contains(UNIT_EXCEPTION_MESSAGE)))) {
+        if (retries > 0 && ((t instanceof AssertionError && t.getMessage().contains(ASSERT_SPECULATIONS_COUNT_MSG)) ||
+                            (t instanceof Exception && t.getMessage().contains(UNIT_EXCEPTION_MESSAGE)))) {
           LOG.warn("Test failed. Retries remaining: {}", retries);
         } else {
           if (t instanceof Exception) {
@@ -194,10 +194,7 @@ public class TestSpeculation {
    * @return the test parameters
    */
   public static Stream<Class<? extends TaskRuntimeEstimator>> getTestParameters() {
-    return Stream.of(
-        SimpleExponentialTaskRuntimeEstimator.class,
-        LegacyTaskRuntimeEstimator.class
-    );
+    return Stream.of(SimpleExponentialTaskRuntimeEstimator.class, LegacyTaskRuntimeEstimator.class);
   }
 
   /**
@@ -209,8 +206,9 @@ public class TestSpeculation {
   MockTezClient createTezSession() throws Exception {
     TezConfiguration tezconf = new TezConfiguration(defaultConf);
     AtomicBoolean mockAppLauncherGoFlag = new AtomicBoolean(false);
-    MockTezClient tezClient = new MockTezClient("testspeculation", tezconf, true, null, null,
-        new MockClock(), mockAppLauncherGoFlag, false, false, 1, 2);
+    MockTezClient tezClient =
+        new MockTezClient("testspeculation", tezconf, true, null, null, new MockClock(), mockAppLauncherGoFlag, false,
+            false, 1, 2);
     tezClient.start();
     syncWithMockAppLauncher(false, mockAppLauncherGoFlag, tezClient);
     return tezClient;
@@ -289,7 +287,7 @@ public class TestSpeculation {
           TaskAttempt killedAttempt = task.getAttempt(killedTaId);
           Joiner.on(",").join(killedAttempt.getDiagnostics()).contains("Killed as speculative attempt");
           assertEquals(TaskAttemptTerminationCause.TERMINATED_EFFECTIVE_SPECULATION,
-                  killedAttempt.getTerminationCause());
+              killedAttempt.getTerminationCause());
         }
         tezClient.stop();
       }
@@ -324,24 +322,19 @@ public class TestSpeculation {
 
     mockLauncher.startScheduling(true);
     dagClient.waitForCompletion();
-    assertEquals(State.SUCCEEDED,
-        dagClient.getDAGStatus(null).getState());
+    assertEquals(State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
     Task task = dagImpl.getTask(killedTaId.getTaskID());
     assertEquals(2, task.getAttempts().size(), ASSERT_SPECULATIONS_COUNT_MSG);
     assertEquals(successTaId, task.getSuccessfulAttempt().getTaskAttemptID());
     TaskAttempt killedAttempt = task.getAttempt(killedTaId);
     Joiner.on(",").join(killedAttempt.getDiagnostics()).contains("Killed as speculative attempt");
-    assertEquals(TaskAttemptTerminationCause.TERMINATED_EFFECTIVE_SPECULATION,
-        killedAttempt.getTerminationCause());
+    assertEquals(TaskAttemptTerminationCause.TERMINATED_EFFECTIVE_SPECULATION, killedAttempt.getTerminationCause());
     if (withProgress) {
       // without progress updates occasionally more than 1 task speculates
-      assertEquals(1, task.getCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-          .getValue());
-      assertEquals(1, dagImpl.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-          .getValue());
+      assertEquals(1, task.getCounters().findCounter(TaskCounter.NUM_SPECULATIONS).getValue());
+      assertEquals(1, dagImpl.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS).getValue());
       org.apache.tez.dag.app.dag.Vertex v = dagImpl.getVertex(killedTaId.getVertexID());
-      assertEquals(1, v.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-          .getValue());
+      assertEquals(1, v.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS).getValue());
     }
 
     LegacySpeculator speculator =
@@ -376,7 +369,8 @@ public class TestSpeculation {
   @ParameterizedTest(name = "{index}: TaskEstimator(EstimatorClass {0})")
   @MethodSource("getTestParameters")
   @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
-  public void testBasicSpeculationWithoutProgress(Class<? extends TaskRuntimeEstimator> estimatorClass) throws Exception {
+  public void testBasicSpeculationWithoutProgress(Class<? extends TaskRuntimeEstimator> estimatorClass)
+      throws Exception {
     setup(estimatorClass);
     runWithRetry(() -> testBasicSpeculation(false));
   }
@@ -435,11 +429,9 @@ public class TestSpeculation {
           .getValue() <= 0);
       dagClient.waitForCompletion();
       // speculation for vA but not for vB
-      assertTrue(vSpec.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-              .getValue() > 0, "Num Speculations is not higher than 0");
-      assertEquals(0,
-          vNoSpec.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-              .getValue());
+      assertTrue(vSpec.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS).getValue() > 0,
+          "Num Speculations is not higher than 0");
+      assertEquals(0, vNoSpec.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS).getValue());
 
       tezClient.stop();
     });
@@ -480,15 +472,11 @@ public class TestSpeculation {
       assertEquals(successTaId, task.getSuccessfulAttempt().getTaskAttemptID());
       TaskAttempt killedAttempt = task.getAttempt(killedTaId);
       Joiner.on(",").join(killedAttempt.getDiagnostics()).contains("Killed speculative attempt as");
-      assertEquals(TaskAttemptTerminationCause.TERMINATED_INEFFECTIVE_SPECULATION,
-          killedAttempt.getTerminationCause());
-      assertEquals(1, task.getCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-          .getValue());
-      assertEquals(1, dagImpl.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-          .getValue());
+      assertEquals(TaskAttemptTerminationCause.TERMINATED_INEFFECTIVE_SPECULATION, killedAttempt.getTerminationCause());
+      assertEquals(1, task.getCounters().findCounter(TaskCounter.NUM_SPECULATIONS).getValue());
+      assertEquals(1, dagImpl.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS).getValue());
       org.apache.tez.dag.app.dag.Vertex v = dagImpl.getVertex(killedTaId.getVertexID());
-      assertEquals(1, v.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS)
-          .getValue());
+      assertEquals(1, v.getAllCounters().findCounter(TaskCounter.NUM_SPECULATIONS).getValue());
       tezClient.stop();
     });
   }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorContextImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorContextImpl.java
@@ -108,9 +108,7 @@ public class TestTaskCommunicatorContextImpl {
     TaskCommunicatorContextImpl commContext = new TaskCommunicatorContextImpl(null, null, null, 0);
     commContext.dag = dag;
 
-    assertEquals(
-        commContext.getCurrentDagInfo().getConf().get("dagkey"),
-        "dagvalue",
+    assertEquals("dagvalue", commContext.getCurrentDagInfo().getConf().get("dagkey"),
         "DAG config should be exposed via context.dag.getConf()");
 
     // TaskCommunicatorContextImpl.appContext.getCurrentDAG() is present
@@ -118,9 +116,7 @@ public class TestTaskCommunicatorContextImpl {
     when(appContext.getCurrentDAG()).thenReturn(dag);
     commContext = new TaskCommunicatorContextImpl(appContext, null, null, 0);
 
-    assertEquals(
-        commContext.getCurrentDagInfo().getConf().get("dagkey"),
-        "dagvalue",
+    assertEquals("dagvalue", commContext.getCurrentDagInfo().getConf().get("dagkey"),
         "DAG config should be exposed via context.appContext.getCurrentDAG().getConf()");
   }
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorContextImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorContextImpl.java
@@ -18,14 +18,17 @@
  */
 package org.apache.tez.dag.app;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.Container;
@@ -35,12 +38,13 @@ import org.apache.tez.dag.app.dag.DAG;
 import org.apache.tez.dag.app.rm.container.AMContainerMap;
 import org.apache.tez.serviceplugins.api.TaskCommunicatorContext;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTaskCommunicatorContextImpl {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testIsKnownContainer() {
     AppContext appContext = mock(AppContext.class);
     when(appContext.getAMConf()).thenReturn(new Configuration());
@@ -104,16 +108,19 @@ public class TestTaskCommunicatorContextImpl {
     TaskCommunicatorContextImpl commContext = new TaskCommunicatorContextImpl(null, null, null, 0);
     commContext.dag = dag;
 
-    Assert.assertEquals("DAG config should be exposed via context.dag.getConf()",
-        commContext.getCurrentDagInfo().getConf().get("dagkey"), "dagvalue");
+    assertEquals(
+        commContext.getCurrentDagInfo().getConf().get("dagkey"),
+        "dagvalue",
+        "DAG config should be exposed via context.dag.getConf()");
 
     // TaskCommunicatorContextImpl.appContext.getCurrentDAG() is present
     AppContext appContext = mock(AppContext.class);
     when(appContext.getCurrentDAG()).thenReturn(dag);
     commContext = new TaskCommunicatorContextImpl(appContext, null, null, 0);
 
-    Assert.assertEquals(
-        "DAG config should be exposed via context.appContext.getCurrentDAG().getConf()",
-        commContext.getCurrentDagInfo().getConf().get("dagkey"), "dagvalue");
+    assertEquals(
+        commContext.getCurrentDagInfo().getConf().get("dagkey"),
+        "dagvalue",
+        "DAG config should be exposed via context.appContext.getCurrentDAG().getConf()");
   }
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorManager.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorManager.java
@@ -18,10 +18,11 @@
  */
 package org.apache.tez.dag.app;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
@@ -42,6 +43,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -77,22 +79,24 @@ import org.apache.tez.serviceplugins.api.TaskCommunicator;
 import org.apache.tez.serviceplugins.api.TaskCommunicatorContext;
 import org.apache.tez.serviceplugins.api.TaskCommunicatorDescriptor;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 public class TestTaskCommunicatorManager {
 
-  @Before
-  @After
+  @BeforeEach
+  @AfterEach
   public void resetForNextTest() {
     TaskCommManagerForMultipleCommTest.reset();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNoTaskCommSpecified() throws IOException, TezException {
 
     AppContext appContext = mock(AppContext.class);
@@ -109,7 +113,8 @@ public class TestTaskCommunicatorManager {
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCustomTaskCommSpecified() throws IOException, TezException {
 
     AppContext appContext = mock(AppContext.class);
@@ -144,7 +149,8 @@ public class TestTaskCommunicatorManager {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleTaskComms() throws IOException, TezException {
 
     AppContext appContext = mock(AppContext.class);
@@ -188,7 +194,8 @@ public class TestTaskCommunicatorManager {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEventRouting() throws Exception {
 
     AppContext appContext = mock(AppContext.class, RETURNS_DEEP_STUBS);
@@ -247,7 +254,8 @@ public class TestTaskCommunicatorManager {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testReportFailureFromTaskCommunicator() throws TezException {
     String dagName = DAG_NAME;
     EventHandler eventHandler = mock(EventHandler.class);
@@ -279,7 +287,7 @@ public class TestTaskCommunicatorManager {
       verify(eventHandler, times(1)).handle(argumentCaptor.capture());
 
       Event rawEvent = argumentCaptor.getValue();
-      assertTrue(rawEvent instanceof DAGEventTerminateDag);
+      assertInstanceOf(DAGEventTerminateDag.class, rawEvent);
       DAGEventTerminateDag killEvent = (DAGEventTerminateDag) rawEvent;
       assertTrue(killEvent.getDiagnosticInfo().contains("ReportError"));
       assertTrue(killEvent.getDiagnosticInfo()
@@ -296,7 +304,7 @@ public class TestTaskCommunicatorManager {
       verify(eventHandler, times(1)).handle(argumentCaptor.capture());
       rawEvent = argumentCaptor.getValue();
 
-      assertTrue(rawEvent instanceof DAGAppMasterEventUserServiceFatalError);
+      assertInstanceOf(DAGAppMasterEventUserServiceFatalError.class, rawEvent);
       DAGAppMasterEventUserServiceFatalError event =
           (DAGAppMasterEventUserServiceFatalError) rawEvent;
       assertEquals(DAGAppMasterEventType.TASK_COMMUNICATOR_SERVICE_FATAL_ERROR, event.getType());
@@ -312,7 +320,8 @@ public class TestTaskCommunicatorManager {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskCommunicatorUserError() {
     TaskCommunicatorContextImpl taskCommContext = mock(TaskCommunicatorContextImpl.class);
     TaskCommunicator taskCommunicator = mock(TaskCommunicator.class, new ExceptionAnswer());
@@ -344,7 +353,7 @@ public class TestTaskCommunicatorManager {
       verify(eventHandler, times(1)).handle(argumentCaptor.capture());
 
       Event rawEvent = argumentCaptor.getValue();
-      assertTrue(rawEvent instanceof DAGAppMasterEventUserServiceFatalError);
+      assertInstanceOf(DAGAppMasterEventUserServiceFatalError.class, rawEvent);
       DAGAppMasterEventUserServiceFatalError event =
           (DAGAppMasterEventUserServiceFatalError) rawEvent;
 
@@ -362,7 +371,7 @@ public class TestTaskCommunicatorManager {
       verify(eventHandler, times(2)).handle(argumentCaptor.capture());
 
       rawEvent = argumentCaptor.getAllValues().get(1);
-      assertTrue(rawEvent instanceof DAGAppMasterEventUserServiceFatalError);
+      assertInstanceOf(DAGAppMasterEventUserServiceFatalError.class, rawEvent);
       event = (DAGAppMasterEventUserServiceFatalError) rawEvent;
 
       assertEquals(DAGAppMasterEventType.TASK_COMMUNICATOR_SERVICE_FATAL_ERROR, event.getType());
@@ -432,7 +441,7 @@ public class TestTaskCommunicatorManager {
                                             int taskCommIndex) throws TezException {
       numTaskComms.incrementAndGet();
       boolean added = taskCommIndices.add(taskCommIndex);
-      assertTrue("Cannot add multiple taskComms with the same index", added);
+      assertTrue(added, "Cannot add multiple taskComms with the same index");
       taskCommNames.add(taskCommDescriptor.getEntityName());
       return super.createTaskCommunicator(taskCommDescriptor, taskCommIndex);
     }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorManager1.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorManager1.java
@@ -18,11 +18,11 @@
  */
 package org.apache.tez.dag.app;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -96,8 +97,9 @@ import org.apache.tez.serviceplugins.api.TaskHeartbeatResponse;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 @SuppressWarnings("unchecked")
@@ -118,7 +120,7 @@ public class TestTaskCommunicatorManager1 {
   TezTaskID taskID;
   TezTaskAttemptID taskAttemptID;
 
-  @Before
+  @BeforeEach
   public void setUp() throws TezException {
     appId = ApplicationId.newInstance(1000, 1);
     appAttemptId = ApplicationAttemptId.newInstance(appId, 1);
@@ -171,7 +173,8 @@ public class TestTaskCommunicatorManager1 {
     containerTask = null;
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetTask() throws IOException {
 
     TezTaskCommunicatorImpl taskCommunicator =
@@ -220,7 +223,8 @@ public class TestTaskCommunicatorManager1 {
     assertTrue(containerTask.shouldDie());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetTaskMultiplePulls() throws IOException {
     TezTaskCommunicatorImpl taskCommunicator =
         (TezTaskCommunicatorImpl) taskAttemptListener.getTaskCommunicator(0).getTaskCommunicator();
@@ -244,7 +248,8 @@ public class TestTaskCommunicatorManager1 {
     assertNull(containerTask);
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskEventRouting() throws Exception {
     List<TezEvent> events =  Arrays.asList(
       new TezEvent(new TaskStatusUpdateEvent(null, 0.0f, null, false), new EventMetaData(EventProducerConsumerType.PROCESSOR,
@@ -262,9 +267,8 @@ public class TestTaskCommunicatorManager1 {
     final List<Event> argAllValues = arg.getAllValues();
 
     final Event statusUpdateEvent = argAllValues.get(0);
-    assertEquals("First event should be status update", TaskAttemptEventType.TA_STATUS_UPDATE,
-        statusUpdateEvent.getType());
-    assertEquals(false, ((TaskAttemptEventStatusUpdate)statusUpdateEvent).getReadErrorReported());
+    assertEquals(TaskAttemptEventType.TA_STATUS_UPDATE, statusUpdateEvent.getType(), "First event should be status update");
+    assertFalse(((TaskAttemptEventStatusUpdate) statusUpdateEvent).getReadErrorReported());
 
     final TaskAttemptEventTezEventUpdate taEvent = (TaskAttemptEventTezEventUpdate)argAllValues.get(1);
     assertEquals(1, taEvent.getTezEvents().size());
@@ -279,7 +283,8 @@ public class TestTaskCommunicatorManager1 {
         vertexRouteEvent.getEvents().get(0).getEventType());
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskEventRoutingWithReadError() throws Exception {
     List<TezEvent> events =  Arrays.asList(
       new TezEvent(new TaskStatusUpdateEvent(null, 0.0f, null, false), null),
@@ -296,29 +301,27 @@ public class TestTaskCommunicatorManager1 {
     final List<Event> argAllValues = arg.getAllValues();
 
     final Event statusUpdateEvent = argAllValues.get(0);
-    assertEquals("First event should be status update", TaskAttemptEventType.TA_STATUS_UPDATE,
-        statusUpdateEvent.getType());
-    assertEquals(true, ((TaskAttemptEventStatusUpdate)statusUpdateEvent).getReadErrorReported());
+    assertEquals(TaskAttemptEventType.TA_STATUS_UPDATE, statusUpdateEvent.getType(), "First event should be status update");
+    assertTrue(((TaskAttemptEventStatusUpdate) statusUpdateEvent).getReadErrorReported());
 
     final Event taFinishedEvent = argAllValues.get(1);
-    assertEquals("Second event should be TA_DONE", TaskAttemptEventType.TA_DONE,
-        taFinishedEvent.getType());
+    assertEquals(TaskAttemptEventType.TA_DONE, taFinishedEvent.getType(), "Second event should be TA_DONE");
 
     final Event vertexEvent = argAllValues.get(2);
     final VertexEventRouteEvent vertexRouteEvent = (VertexEventRouteEvent)vertexEvent;
-    assertEquals("Third event should be routed to vertex", VertexEventType.V_ROUTE_EVENT,
-        vertexEvent.getType());
+    assertEquals(VertexEventType.V_ROUTE_EVENT, vertexEvent.getType(), "Third event should be routed to vertex");
     assertEquals(EventType.INPUT_READ_ERROR_EVENT,
         vertexRouteEvent.getEvents().get(0).getEventType());
   }
 
-
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskEventRoutingTaskAttemptOnly() throws Exception {
-    List<TezEvent> events = Arrays.asList(
-      new TezEvent(new TaskAttemptCompletedEvent(), new EventMetaData(EventProducerConsumerType.SYSTEM,
-          "v1", "v2", taskAttemptID))
-    );
+    List<TezEvent> events =
+        Arrays.asList(
+            new TezEvent(
+                new TaskAttemptCompletedEvent(),
+                new EventMetaData(EventProducerConsumerType.SYSTEM, "v1", "v2", taskAttemptID)));
     generateHeartbeat(events, 0, 1, 0, new ArrayList<TezEvent>());
 
     ArgumentCaptor<Event> arg = ArgumentCaptor.forClass(Event.class);
@@ -327,11 +330,11 @@ public class TestTaskCommunicatorManager1 {
 
     final Event event = argAllValues.get(0);
     // Route to TaskAttempt directly rather than through Vertex
-    assertEquals("only event should be route event", TaskAttemptEventType.TA_DONE,
-        event.getType());
+    assertEquals(TaskAttemptEventType.TA_DONE, event.getType(), "only event should be route event");
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskHeartbeatResponse() throws Exception {
     List<TezEvent> events = new ArrayList<TezEvent>();
     List<TezEvent> eventsToSend = new ArrayList<TezEvent>();
@@ -342,7 +345,8 @@ public class TestTaskCommunicatorManager1 {
   }
 
   //try 10 times to allocate random port, fail it if no one is succeed.
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPortRange() {
     boolean succeedToAllocate = false;
     Random rand = new Random();
@@ -359,7 +363,8 @@ public class TestTaskCommunicatorManager1 {
   }
 
   // TODO TEZ-2003 Move this into TestTezTaskCommunicator. Potentially other tests as well.
-  @Test (timeout= 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPortRange_NotSpecified() throws IOException, TezException {
     Configuration conf = new Configuration();
     JobTokenIdentifier identifier = new JobTokenIdentifier(new Text(

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorManager1.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorManager1.java
@@ -267,20 +267,19 @@ public class TestTaskCommunicatorManager1 {
     final List<Event> argAllValues = arg.getAllValues();
 
     final Event statusUpdateEvent = argAllValues.get(0);
-    assertEquals(TaskAttemptEventType.TA_STATUS_UPDATE, statusUpdateEvent.getType(), "First event should be status update");
+    assertEquals(TaskAttemptEventType.TA_STATUS_UPDATE, statusUpdateEvent.getType(),
+        "First event should be status update");
     assertFalse(((TaskAttemptEventStatusUpdate) statusUpdateEvent).getReadErrorReported());
 
     final TaskAttemptEventTezEventUpdate taEvent = (TaskAttemptEventTezEventUpdate)argAllValues.get(1);
     assertEquals(1, taEvent.getTezEvents().size());
-    assertEquals(EventType.DATA_MOVEMENT_EVENT,
-        taEvent.getTezEvents().get(0).getEventType());
+    assertEquals(EventType.DATA_MOVEMENT_EVENT, taEvent.getTezEvents().getFirst().getEventType());
 
     final TaskAttemptEvent taCompleteEvent = (TaskAttemptEvent)argAllValues.get(2);
     assertEquals(TaskAttemptEventType.TA_DONE, taCompleteEvent.getType());
     final VertexEventRouteEvent vertexRouteEvent = (VertexEventRouteEvent)argAllValues.get(3);
     assertEquals(1, vertexRouteEvent.getEvents().size());
-    assertEquals(EventType.DATA_MOVEMENT_EVENT,
-        vertexRouteEvent.getEvents().get(0).getEventType());
+    assertEquals(EventType.DATA_MOVEMENT_EVENT, vertexRouteEvent.getEvents().getFirst().getEventType());
   }
 
   @Test
@@ -301,7 +300,8 @@ public class TestTaskCommunicatorManager1 {
     final List<Event> argAllValues = arg.getAllValues();
 
     final Event statusUpdateEvent = argAllValues.get(0);
-    assertEquals(TaskAttemptEventType.TA_STATUS_UPDATE, statusUpdateEvent.getType(), "First event should be status update");
+    assertEquals(TaskAttemptEventType.TA_STATUS_UPDATE, statusUpdateEvent.getType(),
+        "First event should be status update");
     assertTrue(((TaskAttemptEventStatusUpdate) statusUpdateEvent).getReadErrorReported());
 
     final Event taFinishedEvent = argAllValues.get(1);
@@ -310,18 +310,14 @@ public class TestTaskCommunicatorManager1 {
     final Event vertexEvent = argAllValues.get(2);
     final VertexEventRouteEvent vertexRouteEvent = (VertexEventRouteEvent)vertexEvent;
     assertEquals(VertexEventType.V_ROUTE_EVENT, vertexEvent.getType(), "Third event should be routed to vertex");
-    assertEquals(EventType.INPUT_READ_ERROR_EVENT,
-        vertexRouteEvent.getEvents().get(0).getEventType());
+    assertEquals(EventType.INPUT_READ_ERROR_EVENT, vertexRouteEvent.getEvents().get(0).getEventType());
   }
 
   @Test
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskEventRoutingTaskAttemptOnly() throws Exception {
-    List<TezEvent> events =
-        Arrays.asList(
-            new TezEvent(
-                new TaskAttemptCompletedEvent(),
-                new EventMetaData(EventProducerConsumerType.SYSTEM, "v1", "v2", taskAttemptID)));
+    List<TezEvent> events = Arrays.asList(new TezEvent(new TaskAttemptCompletedEvent(),
+        new EventMetaData(EventProducerConsumerType.SYSTEM, "v1", "v2", taskAttemptID)));
     generateHeartbeat(events, 0, 1, 0, new ArrayList<TezEvent>());
 
     ArgumentCaptor<Event> arg = ArgumentCaptor.forClass(Event.class);
@@ -336,8 +332,8 @@ public class TestTaskCommunicatorManager1 {
   @Test
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskHeartbeatResponse() throws Exception {
-    List<TezEvent> events = new ArrayList<TezEvent>();
-    List<TezEvent> eventsToSend = new ArrayList<TezEvent>();
+    List<TezEvent> events = new ArrayList<>();
+    List<TezEvent> eventsToSend = new ArrayList<>();
     TaskHeartbeatResponse response = generateHeartbeat(events, 0, 1, 2, eventsToSend);
 
     assertEquals(2, response.getNextFromEventId());

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorManager2.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorManager2.java
@@ -18,8 +18,9 @@
  */
 package org.apache.tez.dag.app;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doReturn;
@@ -34,6 +35,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.conf.Configuration;
@@ -75,13 +77,15 @@ import org.apache.tez.serviceplugins.api.TaskHeartbeatRequest;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 public class TestTaskCommunicatorManager2 {
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskAttemptFailedKilled() throws IOException, TezException {
 
     TaskCommunicatorManagerWrapperForTest wrapper = new TaskCommunicatorManagerWrapperForTest();
@@ -107,8 +111,8 @@ public class TestTaskCommunicatorManager2 {
 
     ArgumentCaptor<Event> argumentCaptor = ArgumentCaptor.forClass(Event.class);
     verify(wrapper.getEventHandler(), times(2)).handle(argumentCaptor.capture());
-    assertTrue(argumentCaptor.getAllValues().get(0) instanceof TaskAttemptEventAttemptFailed);
-    assertTrue(argumentCaptor.getAllValues().get(1) instanceof TaskAttemptEventAttemptKilled);
+    assertInstanceOf(TaskAttemptEventAttemptFailed.class, argumentCaptor.getAllValues().get(0));
+    assertInstanceOf(TaskAttemptEventAttemptKilled.class, argumentCaptor.getAllValues().get(1));
     TaskAttemptEventAttemptFailed failedEvent =
         (TaskAttemptEventAttemptFailed) argumentCaptor.getAllValues().get(0);
     TaskAttemptEventAttemptKilled killedEvent =
@@ -125,7 +129,8 @@ public class TestTaskCommunicatorManager2 {
 
   // Tests fatal and non fatal
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskAttemptFailureViaHeartbeat() throws IOException, TezException {
 
     TaskCommunicatorManagerWrapperForTest wrapper = new TaskCommunicatorManagerWrapperForTest();
@@ -160,7 +165,7 @@ public class TestTaskCommunicatorManager2 {
 
     ArgumentCaptor<Event> argumentCaptor = ArgumentCaptor.forClass(Event.class);
     verify(wrapper.getEventHandler(), times(1)).handle(argumentCaptor.capture());
-    assertTrue(argumentCaptor.getAllValues().get(0) instanceof TaskAttemptEventAttemptFailed);
+    assertInstanceOf(TaskAttemptEventAttemptFailed.class, argumentCaptor.getAllValues().get(0));
     TaskAttemptEventAttemptFailed failedEvent =
         (TaskAttemptEventAttemptFailed) argumentCaptor.getAllValues().get(0);
     assertEquals(TaskFailureType.NON_FATAL, failedEvent.getTaskFailureType());
@@ -183,7 +188,7 @@ public class TestTaskCommunicatorManager2 {
 
     argumentCaptor = ArgumentCaptor.forClass(Event.class);
     verify(wrapper.getEventHandler(), times(1)).handle(argumentCaptor.capture());
-    assertTrue(argumentCaptor.getAllValues().get(0) instanceof TaskAttemptEventAttemptFailed);
+    assertInstanceOf(TaskAttemptEventAttemptFailed.class, argumentCaptor.getAllValues().get(0));
     failedEvent = (TaskAttemptEventAttemptFailed) argumentCaptor.getAllValues().get(0);
     assertEquals(TaskFailureType.FATAL, failedEvent.getTaskFailureType());
     assertTrue(failedEvent.getDiagnosticInfo().contains("-fatal-"));
@@ -191,7 +196,8 @@ public class TestTaskCommunicatorManager2 {
 
   // Tests fatal and non fatal
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskAttemptFailureViaContext() throws IOException, TezException {
     TaskCommunicatorManagerWrapperForTest wrapper = new TaskCommunicatorManagerWrapperForTest();
 
@@ -216,7 +222,7 @@ public class TestTaskCommunicatorManager2 {
             TaskAttemptEndReason.CONTAINER_EXITED, "--non-fatal--");
     ArgumentCaptor<Event> argumentCaptor = ArgumentCaptor.forClass(Event.class);
     verify(wrapper.getEventHandler(), times(1)).handle(argumentCaptor.capture());
-    assertTrue(argumentCaptor.getAllValues().get(0) instanceof TaskAttemptEventAttemptFailed);
+    assertInstanceOf(TaskAttemptEventAttemptFailed.class, argumentCaptor.getAllValues().get(0));
     TaskAttemptEventAttemptFailed failedEvent =
         (TaskAttemptEventAttemptFailed) argumentCaptor.getAllValues().get(0);
     assertEquals(TaskFailureType.NON_FATAL, failedEvent.getTaskFailureType());
@@ -230,7 +236,7 @@ public class TestTaskCommunicatorManager2 {
             "--fatal--");
     argumentCaptor = ArgumentCaptor.forClass(Event.class);
     verify(wrapper.getEventHandler(), times(1)).handle(argumentCaptor.capture());
-    assertTrue(argumentCaptor.getAllValues().get(0) instanceof TaskAttemptEventAttemptFailed);
+    assertInstanceOf(TaskAttemptEventAttemptFailed.class, argumentCaptor.getAllValues().get(0));
     failedEvent = (TaskAttemptEventAttemptFailed) argumentCaptor.getAllValues().get(0);
     assertEquals(TaskFailureType.FATAL, failedEvent.getTaskFailureType());
     assertTrue(failedEvent.getDiagnosticInfo().contains("--fatal--"));

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorWrapper.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/TestTaskCommunicatorWrapper.java
@@ -18,15 +18,19 @@
  */
 package org.apache.tez.dag.app;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.tez.serviceplugins.api.TaskCommunicator;
 
 import com.google.common.collect.Sets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTaskCommunicatorWrapper {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDelegation() throws Exception {
     PluginWrapperTestHelpers.testDelegation(TaskCommunicatorWrapper.class, TaskCommunicator.class,
         Sets.newHashSet("getTaskCommunicator"));

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/TestRootInputInitializerManager.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/TestRootInputInitializerManager.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tez.dag.app.dag;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -56,7 +57,8 @@ import org.apache.tez.runtime.api.impl.TezEvent;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 public class TestRootInputInitializerManager {
@@ -66,7 +68,8 @@ public class TestRootInputInitializerManager {
   // Primarily a failure scenario, when a Task moves back to running from success
   // Order event1, success1, event2, success2
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEventBeforeSuccess() throws Exception {
     InputDescriptor id = mock(InputDescriptor.class);
     InputInitializerDescriptor iid = mock(InputInitializerDescriptor.class);
@@ -141,7 +144,8 @@ public class TestRootInputInitializerManager {
   // Order event1 success1, success2, event2
   // Primarily a failure scenario, when a Task moves back to running from success
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSuccessBeforeEvent() throws Exception {
     InputDescriptor id = mock(InputDescriptor.class);
     InputInitializerDescriptor iid = mock(InputInitializerDescriptor.class);
@@ -213,7 +217,8 @@ public class TestRootInputInitializerManager {
   }
 
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCorrectUgiUsage() throws TezException, InterruptedException {
     Vertex vertex = mock(Vertex.class);
     doReturn(mock(TezVertexID.class)).when(vertex).getVertexId();

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/TestStateChangeNotifier.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/TestStateChangeNotifier.java
@@ -18,8 +18,8 @@
  */
 package org.apache.tez.dag.app.dag;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.tez.dag.api.TezUncheckedException;
@@ -41,8 +42,8 @@ import org.apache.tez.dag.records.TezVertexID;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +103,8 @@ public class TestStateChangeNotifier {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEventsOnRegistration() {
     TezDAGID dagId = TezDAGID.getInstance("1", 1, 1);
     Vertex v1 = createMockVertex(dagId, 1);
@@ -146,7 +148,7 @@ public class TestStateChangeNotifier {
     tracker.reset();
     VertexStateUpdateListener mockListener2 = mock(VertexStateUpdateListener.class);
     tracker.registerForVertexUpdates(v2.getName(), null, mockListener2);
-    Assert.assertEquals(0, tracker.totalCount.get()); // there should no be any event sent out
+    assertEquals(0, tracker.totalCount.get()); // there should no be any event sent out
     verify(mockListener2, never()).onStateUpdated(any());
 
     // Vertex has notified about parallelism update only
@@ -158,7 +160,8 @@ public class TestStateChangeNotifier {
         argumentCaptor.getValue().getVertexState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleStateUpdates() {
     TezDAGID dagId = TezDAGID.getInstance("1", 1, 1);
     Vertex v1 = createMockVertex(dagId, 1);
@@ -193,7 +196,8 @@ public class TestStateChangeNotifier {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDuplicateRegistration() {
     TezDAGID dagId = TezDAGID.getInstance("1", 1, 1);
     Vertex v1 = createMockVertex(dagId, 1);
@@ -211,7 +215,8 @@ public class TestStateChangeNotifier {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSpecificStateUpdates() {
     TezDAGID dagId = TezDAGID.getInstance("1", 1, 1);
     Vertex v1 = createMockVertex(dagId, 1);
@@ -253,7 +258,8 @@ public class TestStateChangeNotifier {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testUnregister() {
     TezDAGID dagId = TezDAGID.getInstance("1", 1, 1);
     Vertex v1 = createMockVertex(dagId, 1);

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/app/TestTezTaskCommunicatorManager.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/app/TestTezTaskCommunicatorManager.java
@@ -18,12 +18,13 @@
  */
 package org.apache.tez.dag.app.dag.app;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.Credentials;
@@ -37,11 +38,13 @@ import org.apache.tez.dag.api.UserPayload;
 import org.apache.tez.dag.app.TezTaskCommunicatorImpl;
 import org.apache.tez.serviceplugins.api.TaskCommunicatorContext;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTezTaskCommunicatorManager {
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerAliveOnGetTask() throws IOException {
 
     TaskCommunicatorContext context = mock(TaskCommunicatorContext.class);

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestCommit.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestCommit.java
@@ -18,6 +18,10 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -120,9 +124,9 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  *
@@ -305,7 +309,7 @@ public class TestCommit {
     appAttemptId = ApplicationAttemptId.newInstance(
         ApplicationId.newInstance(100, 1), 1);
     dagId = TezDAGID.getInstance(appAttemptId.getApplicationId(), 1);
-    Assert.assertNotNull(dagId);
+    assertNotNull(dagId);
     dispatcher = new DrainDispatcher();
     fsTokens = new Credentials();
     appContext = mock(AppContext.class);
@@ -346,7 +350,7 @@ public class TestCommit {
     dispatcher.start();
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     if (dispatcher != null) {
       dispatcher.await();
@@ -552,7 +556,7 @@ public class TestCommit {
 
   private void initDAG(DAGImpl dag) {
     dag.handle(new DAGEvent(dag.getID(), DAGEventType.DAG_INIT));
-    Assert.assertEquals(DAGState.INITED, dag.getState());
+    assertEquals(DAGState.INITED, dag.getState());
   }
 
   @SuppressWarnings("unchecked")
@@ -560,10 +564,11 @@ public class TestCommit {
     dispatcher.getEventHandler().handle(
         new DAGEventStartDag(impl.getID(), null));
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, impl.getState());
+    assertEquals(DAGState.RUNNING, impl.getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexCommit_OnDAGSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         true);
@@ -574,9 +579,9 @@ public class TestCommit {
     VertexImpl v1 = (VertexImpl) dag.getVertex("vertex1");
     v1.handle(new VertexEventTaskCompleted(v1.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertNull(v1.getTerminationCause());
-    Assert.assertTrue(v1.commitFutures.isEmpty());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertNull(v1.getTerminationCause());
+    assertTrue(v1.commitFutures.isEmpty());
     CountingOutputCommitter v1OutputCommitter_1 = (CountingOutputCommitter) v1
         .getOutputCommitter("v1Out_1");
     CountingOutputCommitter v1OutputCommitter_2 = (CountingOutputCommitter) v1
@@ -584,18 +589,19 @@ public class TestCommit {
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
     historyEventHandler.verifyVertexFinishedEvent(v1.getVertexId(), 1);
 
-    Assert.assertEquals(1, v1OutputCommitter_1.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.setupCounter);
-    Assert.assertEquals(0, v1OutputCommitter_1.commitCounter);
-    Assert.assertEquals(0, v1OutputCommitter_1.abortCounter);
+    assertEquals(1, v1OutputCommitter_1.initCounter);
+    assertEquals(1, v1OutputCommitter_1.setupCounter);
+    assertEquals(0, v1OutputCommitter_1.commitCounter);
+    assertEquals(0, v1OutputCommitter_1.abortCounter);
 
-    Assert.assertEquals(1, v1OutputCommitter_2.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_2.setupCounter);
-    Assert.assertEquals(0, v1OutputCommitter_2.commitCounter);
-    Assert.assertEquals(0, v1OutputCommitter_2.abortCounter);
+    assertEquals(1, v1OutputCommitter_2.initCounter);
+    assertEquals(1, v1OutputCommitter_2.setupCounter);
+    assertEquals(0, v1OutputCommitter_2.commitCounter);
+    assertEquals(0, v1OutputCommitter_2.abortCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexCommit_OnVertexSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -606,36 +612,37 @@ public class TestCommit {
     VertexImpl v1 = (VertexImpl) dag.getVertex("vertex1");
     v1.handle(new VertexEventTaskCompleted(v1.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.COMMITTING, v1.getState());
+    assertEquals(VertexState.COMMITTING, v1.getState());
     CountingOutputCommitter v1OutputCommitter_1 = (CountingOutputCommitter) v1
         .getOutputCommitter("v1Out_1");
     v1OutputCommitter_1.unblockCommit();
     waitForCommitCompleted(v1, "v1Out_1");
     // still in COMMITTING due to another pending commit
-    Assert.assertEquals(VertexState.COMMITTING, v1.getState());
+    assertEquals(VertexState.COMMITTING, v1.getState());
 
     CountingOutputCommitter v1OutputCommitter_2 = (CountingOutputCommitter) v1
         .getOutputCommitter("v1Out_2");
     v1OutputCommitter_2.unblockCommit();
     waitUntil(v1, VertexState.SUCCEEDED);
-    Assert.assertNull(v1.getTerminationCause());
-    Assert.assertTrue(v1.commitFutures.isEmpty());
+    assertNull(v1.getTerminationCause());
+    assertTrue(v1.commitFutures.isEmpty());
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 1);
     historyEventHandler.verifyVertexFinishedEvent(v1.getVertexId(), 1);
 
-    Assert.assertEquals(1, v1OutputCommitter_1.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.setupCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.commitCounter);
-    Assert.assertEquals(0, v1OutputCommitter_1.abortCounter);
+    assertEquals(1, v1OutputCommitter_1.initCounter);
+    assertEquals(1, v1OutputCommitter_1.setupCounter);
+    assertEquals(1, v1OutputCommitter_1.commitCounter);
+    assertEquals(0, v1OutputCommitter_1.abortCounter);
 
-    Assert.assertEquals(1, v1OutputCommitter_2.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_2.setupCounter);
-    Assert.assertEquals(1, v1OutputCommitter_2.commitCounter);
-    Assert.assertEquals(0, v1OutputCommitter_2.abortCounter);
+    assertEquals(1, v1OutputCommitter_2.initCounter);
+    assertEquals(1, v1OutputCommitter_2.setupCounter);
+    assertEquals(1, v1OutputCommitter_2.commitCounter);
+    assertEquals(0, v1OutputCommitter_2.abortCounter);
   }
 
   // the first commit fail which cause the second commit abort
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexCommitFail1_OnVertexSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -646,33 +653,34 @@ public class TestCommit {
     VertexImpl v1 = (VertexImpl) dag.getVertex("vertex1");
     v1.handle(new VertexEventTaskCompleted(v1.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.COMMITTING, v1.getState());
+    assertEquals(VertexState.COMMITTING, v1.getState());
     CountingOutputCommitter v1OutputCommitter_1 = (CountingOutputCommitter) v1
         .getOutputCommitter("v1Out_1");
     v1OutputCommitter_1.unblockCommit();
     waitUntil(v1, VertexState.FAILED);
 
-    Assert.assertEquals(VertexTerminationCause.COMMIT_FAILURE,
+    assertEquals(VertexTerminationCause.COMMIT_FAILURE,
         v1.getTerminationCause());
-    Assert.assertTrue(v1.commitFutures.isEmpty());
+    assertTrue(v1.commitFutures.isEmpty());
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 1);
     historyEventHandler.verifyVertexFinishedEvent(v1.getVertexId(), 1);
     CountingOutputCommitter v1OutputCommitter_2 = (CountingOutputCommitter) v1
         .getOutputCommitter("v1Out_2");
 
-    Assert.assertEquals(1, v1OutputCommitter_1.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.setupCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.commitCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.abortCounter);
+    assertEquals(1, v1OutputCommitter_1.initCounter);
+    assertEquals(1, v1OutputCommitter_1.setupCounter);
+    assertEquals(1, v1OutputCommitter_1.commitCounter);
+    assertEquals(1, v1OutputCommitter_1.abortCounter);
 
-    Assert.assertEquals(1, v1OutputCommitter_2.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_2.setupCounter);
+    assertEquals(1, v1OutputCommitter_2.initCounter);
+    assertEquals(1, v1OutputCommitter_2.setupCounter);
     // can't verify the commitCounter because v1OutputCommitter_2 may not be started
-    Assert.assertEquals(1, v1OutputCommitter_2.abortCounter);
+    assertEquals(1, v1OutputCommitter_2.abortCounter);
   }
 
   // the first commit succeed while the second fails
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexCommitFail2_OnVertexSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -683,12 +691,12 @@ public class TestCommit {
     VertexImpl v1 = (VertexImpl) dag.getVertex("vertex1");
     v1.handle(new VertexEventTaskCompleted(v1.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.COMMITTING, v1.getState());
+    assertEquals(VertexState.COMMITTING, v1.getState());
     CountingOutputCommitter v1OutputCommitter_1 = (CountingOutputCommitter) v1
         .getOutputCommitter("v1Out_1");
     v1OutputCommitter_1.unblockCommit();
     waitForCommitCompleted(v1, "v1Out_1");
-    Assert.assertEquals(VertexState.COMMITTING, v1.getState());
+    assertEquals(VertexState.COMMITTING, v1.getState());
 
     CountingOutputCommitter v1OutputCommitter_2 = (CountingOutputCommitter) v1
         .getOutputCommitter("v1Out_2");
@@ -697,21 +705,22 @@ public class TestCommit {
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 1);
     historyEventHandler.verifyVertexFinishedEvent(v1.getVertexId(), 1);
 
-    Assert.assertEquals(VertexTerminationCause.COMMIT_FAILURE,
+    assertEquals(VertexTerminationCause.COMMIT_FAILURE,
         v1.getTerminationCause());
-    Assert.assertTrue(v1.commitFutures.isEmpty());
-    Assert.assertEquals(1, v1OutputCommitter_1.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.setupCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.commitCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.abortCounter);
+    assertTrue(v1.commitFutures.isEmpty());
+    assertEquals(1, v1OutputCommitter_1.initCounter);
+    assertEquals(1, v1OutputCommitter_1.setupCounter);
+    assertEquals(1, v1OutputCommitter_1.commitCounter);
+    assertEquals(1, v1OutputCommitter_1.abortCounter);
 
-    Assert.assertEquals(1, v1OutputCommitter_2.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_2.setupCounter);
-    Assert.assertEquals(1, v1OutputCommitter_2.commitCounter);
-    Assert.assertEquals(1, v1OutputCommitter_2.abortCounter);
+    assertEquals(1, v1OutputCommitter_2.initCounter);
+    assertEquals(1, v1OutputCommitter_2.setupCounter);
+    assertEquals(1, v1OutputCommitter_2.commitCounter);
+    assertEquals(1, v1OutputCommitter_2.abortCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexKilledWhileCommitting() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -722,17 +731,16 @@ public class TestCommit {
     VertexImpl v1 = (VertexImpl) dag.getVertex("vertex1");
     v1.handle(new VertexEventTaskCompleted(v1.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.COMMITTING, v1.getState());
+    assertEquals(VertexState.COMMITTING, v1.getState());
     // kill dag which will trigger the vertex killed event
     dag.handle(new DAGEventTerminateDag(dag.getID(), DAGTerminationCause.DAG_KILL, null));
     dispatcher.await();
-    Assert.assertEquals(VertexState.KILLED, v1.getState());
-    Assert.assertTrue(v1.commitFutures.isEmpty());
-    Assert.assertEquals(VertexTerminationCause.DAG_TERMINATED,
+    assertEquals(VertexState.KILLED, v1.getState());
+    assertTrue(v1.commitFutures.isEmpty());
+    assertEquals(VertexTerminationCause.DAG_TERMINATED,
         v1.getTerminationCause());
-    Assert.assertEquals(DAGState.KILLED, dag.getState());
-    Assert
-        .assertEquals(DAGTerminationCause.DAG_KILL, dag.getTerminationCause());
+    assertEquals(DAGState.KILLED, dag.getState());
+    assertEquals(DAGTerminationCause.DAG_KILL, dag.getTerminationCause());
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 1);
     historyEventHandler.verifyVertexFinishedEvent(v1.getVertexId(), 1);
 
@@ -740,18 +748,19 @@ public class TestCommit {
         .getOutputCommitter("v1Out_1");
     CountingOutputCommitter v1OutputCommitter_2 = (CountingOutputCommitter) v1
         .getOutputCommitter("v1Out_2");
-    Assert.assertEquals(1, v1OutputCommitter_1.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.setupCounter);
+    assertEquals(1, v1OutputCommitter_1.initCounter);
+    assertEquals(1, v1OutputCommitter_1.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v1OutputCommitter_1.abortCounter);
+    assertEquals(1, v1OutputCommitter_1.abortCounter);
 
-    Assert.assertEquals(1, v1OutputCommitter_2.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_2.setupCounter);
+    assertEquals(1, v1OutputCommitter_2.initCounter);
+    assertEquals(1, v1OutputCommitter_2.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v1OutputCommitter_2.abortCounter);
+    assertEquals(1, v1OutputCommitter_2.abortCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexRescheduleWhileCommitting() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -762,17 +771,17 @@ public class TestCommit {
     VertexImpl v1 = (VertexImpl) dag.getVertex("vertex1");
     v1.handle(new VertexEventTaskCompleted(v1.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.COMMITTING, v1.getState());
+    assertEquals(VertexState.COMMITTING, v1.getState());
     // reschedule task
     v1.handle(new VertexEventTaskReschedule(TezTaskID.getInstance(
         v1.getVertexId(), 2)));
     dispatcher.await();
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
-    Assert.assertEquals(VertexTerminationCause.VERTEX_RERUN_IN_COMMITTING,
+    assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(VertexTerminationCause.VERTEX_RERUN_IN_COMMITTING,
         v1.getTerminationCause());
-    Assert.assertTrue(v1.commitFutures.isEmpty());
-    Assert.assertEquals(DAGState.FAILED, dag.getState());
-    Assert.assertEquals(DAGTerminationCause.VERTEX_FAILURE,
+    assertTrue(v1.commitFutures.isEmpty());
+    assertEquals(DAGState.FAILED, dag.getState());
+    assertEquals(DAGTerminationCause.VERTEX_FAILURE,
         dag.getTerminationCause());
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 1);
     historyEventHandler.verifyVertexFinishedEvent(v1.getVertexId(), 1);
@@ -781,18 +790,19 @@ public class TestCommit {
         .getOutputCommitter("v1Out_1");
     CountingOutputCommitter v1OutputCommitter_2 = (CountingOutputCommitter) v1
         .getOutputCommitter("v1Out_2");
-    Assert.assertEquals(1, v1OutputCommitter_1.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.setupCounter);
+    assertEquals(1, v1OutputCommitter_1.initCounter);
+    assertEquals(1, v1OutputCommitter_1.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v1OutputCommitter_1.abortCounter);
+    assertEquals(1, v1OutputCommitter_1.abortCounter);
 
-    Assert.assertEquals(1, v1OutputCommitter_2.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_2.setupCounter);
+    assertEquals(1, v1OutputCommitter_2.initCounter);
+    assertEquals(1, v1OutputCommitter_2.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v1OutputCommitter_2.abortCounter);
+    assertEquals(1, v1OutputCommitter_2.abortCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexRouteEventErrorWhileCommitting() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -803,7 +813,7 @@ public class TestCommit {
     VertexImpl v1 = (VertexImpl) dag.getVertex("vertex1");
     v1.handle(new VertexEventTaskCompleted(v1.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.COMMITTING, v1.getState());
+    assertEquals(VertexState.COMMITTING, v1.getState());
     // reschedule task
     VertexManagerEvent vmEvent = VertexManagerEvent.create("vertex1", ByteBuffer.wrap(new byte[0]));
     TezTaskAttemptID taId = TezTaskAttemptID.getInstance(TezTaskID.getInstance(v1.getVertexId(), 0), 0);
@@ -813,12 +823,12 @@ public class TestCommit {
     v1.handle(new VertexEventRouteEvent(v1.getVertexId(), Collections.singletonList(tezEvent)));
     waitUntil(dag, DAGState.FAILED);
 
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
-    Assert.assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE,
+    assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE,
         v1.getTerminationCause());
-    Assert.assertTrue(v1.commitFutures.isEmpty());
-    Assert.assertEquals(DAGState.FAILED, dag.getState());
-    Assert.assertEquals(DAGTerminationCause.VERTEX_FAILURE,
+    assertTrue(v1.commitFutures.isEmpty());
+    assertEquals(DAGState.FAILED, dag.getState());
+    assertEquals(DAGTerminationCause.VERTEX_FAILURE,
         dag.getTerminationCause());
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 1);
     historyEventHandler.verifyVertexFinishedEvent(v1.getVertexId(), 1);
@@ -827,18 +837,19 @@ public class TestCommit {
         .getOutputCommitter("v1Out_1");
     CountingOutputCommitter v1OutputCommitter_2 = (CountingOutputCommitter) v1
         .getOutputCommitter("v1Out_2");
-    Assert.assertEquals(1, v1OutputCommitter_1.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.setupCounter);
+    assertEquals(1, v1OutputCommitter_1.initCounter);
+    assertEquals(1, v1OutputCommitter_1.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v1OutputCommitter_1.abortCounter);
+    assertEquals(1, v1OutputCommitter_1.abortCounter);
 
-    Assert.assertEquals(1, v1OutputCommitter_2.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_2.setupCounter);
+    assertEquals(1, v1OutputCommitter_2.initCounter);
+    assertEquals(1, v1OutputCommitter_2.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v1OutputCommitter_2.abortCounter);
+    assertEquals(1, v1OutputCommitter_2.abortCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexInternalErrorWhileCommiting() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -849,16 +860,16 @@ public class TestCommit {
     VertexImpl v1 = (VertexImpl) dag.getVertex("vertex1");
     v1.handle(new VertexEventTaskCompleted(v1.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.COMMITTING, v1.getState());
+    assertEquals(VertexState.COMMITTING, v1.getState());
     // internal error
     v1.handle(new VertexEvent(v1.getVertexId(),
         VertexEventType.V_INTERNAL_ERROR));
     dispatcher.await();
-    Assert.assertEquals(VertexState.ERROR, v1.getState());
-    Assert.assertEquals(VertexTerminationCause.INTERNAL_ERROR,
+    assertEquals(VertexState.ERROR, v1.getState());
+    assertEquals(VertexTerminationCause.INTERNAL_ERROR,
         v1.getTerminationCause());
-    Assert.assertEquals(DAGState.ERROR, dag.getState());
-    Assert.assertEquals(DAGTerminationCause.INTERNAL_ERROR,
+    assertEquals(DAGState.ERROR, dag.getState());
+    assertEquals(DAGTerminationCause.INTERNAL_ERROR,
         dag.getTerminationCause());
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 1);
     historyEventHandler.verifyVertexFinishedEvent(v1.getVertexId(), 1);
@@ -867,20 +878,21 @@ public class TestCommit {
         .getOutputCommitter("v1Out_1");
     CountingOutputCommitter v1OutputCommitter_2 = (CountingOutputCommitter) v1
         .getOutputCommitter("v1Out_2");
-    Assert.assertEquals(1, v1OutputCommitter_1.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_1.setupCounter);
+    assertEquals(1, v1OutputCommitter_1.initCounter);
+    assertEquals(1, v1OutputCommitter_1.setupCounter);
     // commit may not have started, so can't verify commitCounter
     // TODO abort it when internal error happens TEZ-2250
-    // Assert.assertEquals(1, v1OutputCommitter_1.abortCounter);
+    // assertEquals(1, v1OutputCommitter_1.abortCounter);
 
-    Assert.assertEquals(1, v1OutputCommitter_2.initCounter);
-    Assert.assertEquals(1, v1OutputCommitter_2.setupCounter);
+    assertEquals(1, v1OutputCommitter_2.initCounter);
+    assertEquals(1, v1OutputCommitter_2.setupCounter);
     // commit may not have started, so can't verify commitCounter
     // TODO abort it when internal error happens TEZ-2250
-    // Assert.assertEquals(1, v1OutputCommitter_2.abortCounter);
+    // assertEquals(1, v1OutputCommitter_2.abortCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitSucceeded_OnDAGSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         true);
@@ -907,8 +919,8 @@ public class TestCommit {
         .getOutputCommitter("v3Out");
     v3OutputCommitter.unblockCommit();
     waitUntil(dag, DAGState.SUCCEEDED);
-    Assert.assertTrue(dag.commitFutures.isEmpty());
-    Assert.assertNull(dag.getTerminationCause());
+    assertTrue(dag.commitFutures.isEmpty());
+    assertNull(dag.getTerminationCause());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitStartedEvent("v1", 0);
@@ -924,19 +936,20 @@ public class TestCommit {
     historyEventHandler.verifyDAGCommitStartedEvent(dag.getID(), 1);
     historyEventHandler.verifyDAGFinishedEvent(dag.getID(), 1);
 
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v12OutputCommitter.commitCounter);
-    Assert.assertEquals(0, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.commitCounter);
+    assertEquals(0, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v3OutputCommitter.commitCounter);
-    Assert.assertEquals(0, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.commitCounter);
+    assertEquals(0, v3OutputCommitter.abortCounter);
   }
 
   // first commit(v12Out) succeed and then the second commit(v3Out) fail
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitFail1_OnDAGSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         true);
@@ -960,18 +973,18 @@ public class TestCommit {
     v12OutputCommitter.unblockCommit();
     waitForCommitCompleted(dag, new OutputKey("v12Out", "uv12", true));
     // still in COMMITTING due to another pending commit
-    Assert.assertEquals(DAGState.COMMITTING, dag.getState());
+    assertEquals(DAGState.COMMITTING, dag.getState());
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
     v3OutputCommitter.unblockCommit();
     waitUntil(dag, DAGState.FAILED);
 
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v3.getState());
-    Assert.assertEquals(DAGTerminationCause.COMMIT_FAILURE,
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.SUCCEEDED, v3.getState());
+    assertEquals(DAGTerminationCause.COMMIT_FAILURE,
         dag.getTerminationCause());
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitStartedEvent("v1", 0);
@@ -985,19 +998,20 @@ public class TestCommit {
     historyEventHandler.verifyDAGCommitStartedEvent(dag.getID(), 1);
     historyEventHandler.verifyDAGFinishedEvent(dag.getID(), 1);
 
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v12OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.commitCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v3OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.commitCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
   // the first commit(v12Out) fail
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitFail2_OnDAGSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         true);
@@ -1025,13 +1039,13 @@ public class TestCommit {
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
 
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v3.getState());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.SUCCEEDED, v3.getState());
 
-    Assert.assertEquals(DAGTerminationCause.COMMIT_FAILURE,
+    assertEquals(DAGTerminationCause.COMMIT_FAILURE,
         dag.getTerminationCause());
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitStartedEvent("v1", 0);
@@ -1045,19 +1059,20 @@ public class TestCommit {
     historyEventHandler.verifyDAGCommitStartedEvent(dag.getID(), 1);
     historyEventHandler.verifyDAGFinishedEvent(dag.getID(), 1);
 
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v12OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.commitCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
   // commit of v3Out complete first then commit of v12Out complete
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitSucceeded1_OnVertexSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -1074,10 +1089,10 @@ public class TestCommit {
         TaskState.SUCCEEDED));
     v3.handle(new VertexEventTaskCompleted(v3.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
-    Assert.assertEquals(VertexState.COMMITTING, v3.getState());
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.COMMITTING, v3.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
@@ -1089,7 +1104,7 @@ public class TestCommit {
         .getOutputCommitter("v12Out");
     v12OutputCommitter.unblockCommit();
     waitUntil(dag, DAGState.SUCCEEDED);
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 1);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 1);
     historyEventHandler.verifyVertexGroupCommitStartedEvent("v1", 0);
@@ -1103,19 +1118,20 @@ public class TestCommit {
     historyEventHandler.verifyDAGCommitStartedEvent(dag.getID(), 0);
     historyEventHandler.verifyDAGFinishedEvent(dag.getID(), 1);
 
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v12OutputCommitter.commitCounter);
-    Assert.assertEquals(0, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.commitCounter);
+    assertEquals(0, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v3OutputCommitter.commitCounter);
-    Assert.assertEquals(0, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.commitCounter);
+    assertEquals(0, v3OutputCommitter.abortCounter);
   }
 
   // commit of v12Out complete first then commit of v3Out
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitSucceeded2_OnVertexSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -1132,10 +1148,10 @@ public class TestCommit {
         TaskState.SUCCEEDED));
     v3.handle(new VertexEventTaskCompleted(v3.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
-    Assert.assertEquals(VertexState.COMMITTING, v3.getState());
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.COMMITTING, v3.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     CountingOutputCommitter v12OutputCommitter = (CountingOutputCommitter) v1
         .getOutputCommitter("v12Out");
@@ -1143,13 +1159,13 @@ public class TestCommit {
     // ugly (wait for commit event sent out)
     Thread.sleep(500);
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
     v3OutputCommitter.unblockCommit();
     waitUntil(dag, DAGState.SUCCEEDED);
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 1);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 1);
     historyEventHandler.verifyVertexGroupCommitStartedEvent("v1", 0);
@@ -1163,19 +1179,20 @@ public class TestCommit {
     historyEventHandler.verifyDAGCommitStartedEvent(dag.getID(), 0);
     historyEventHandler.verifyDAGFinishedEvent(dag.getID(), 1);
 
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v12OutputCommitter.commitCounter);
-    Assert.assertEquals(0, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.commitCounter);
+    assertEquals(0, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v3OutputCommitter.commitCounter);
-    Assert.assertEquals(0, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.commitCounter);
+    assertEquals(0, v3OutputCommitter.abortCounter);
   }
 
   // test DAGCommitSucceeded when vertex group has multiple shared outputs
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitSucceeded3_OnVertexSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -1192,10 +1209,10 @@ public class TestCommit {
         TaskState.SUCCEEDED));
     v3.handle(new VertexEventTaskCompleted(v3.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
-    Assert.assertEquals(VertexState.COMMITTING, v3.getState());
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.COMMITTING, v3.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     CountingOutputCommitter v12OutputCommitter1 = (CountingOutputCommitter) v1
         .getOutputCommitter("v12Out1");
@@ -1203,13 +1220,13 @@ public class TestCommit {
     CountingOutputCommitter v12OutputCommitter2 = (CountingOutputCommitter) v1
         .getOutputCommitter("v12Out2");
     v12OutputCommitter2.unblockCommit();
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
     v3OutputCommitter.unblockCommit();
     waitUntil(dag, DAGState.SUCCEEDED);
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 1);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 1);
     historyEventHandler.verifyVertexGroupCommitStartedEvent("v1", 0);
@@ -1223,24 +1240,25 @@ public class TestCommit {
     historyEventHandler.verifyDAGCommitStartedEvent(dag.getID(), 0);
     historyEventHandler.verifyDAGFinishedEvent(dag.getID(), 1);
 
-    Assert.assertEquals(1, v12OutputCommitter1.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter1.setupCounter);
-    Assert.assertEquals(1, v12OutputCommitter1.commitCounter);
-    Assert.assertEquals(0, v12OutputCommitter1.abortCounter);
+    assertEquals(1, v12OutputCommitter1.initCounter);
+    assertEquals(1, v12OutputCommitter1.setupCounter);
+    assertEquals(1, v12OutputCommitter1.commitCounter);
+    assertEquals(0, v12OutputCommitter1.abortCounter);
 
-    Assert.assertEquals(1, v12OutputCommitter2.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter2.setupCounter);
-    Assert.assertEquals(1, v12OutputCommitter2.commitCounter);
-    Assert.assertEquals(0, v12OutputCommitter2.abortCounter);
+    assertEquals(1, v12OutputCommitter2.initCounter);
+    assertEquals(1, v12OutputCommitter2.setupCounter);
+    assertEquals(1, v12OutputCommitter2.commitCounter);
+    assertEquals(0, v12OutputCommitter2.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v3OutputCommitter.commitCounter);
-    Assert.assertEquals(0, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.commitCounter);
+    assertEquals(0, v3OutputCommitter.abortCounter);
   }
 
   // commit of vertex group(v1,v2) fail and commit of v3 is not completed
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitFail1_OnVertexSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -1257,23 +1275,23 @@ public class TestCommit {
         TaskState.SUCCEEDED));
     v3.handle(new VertexEventTaskCompleted(v3.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
-    Assert.assertEquals(VertexState.COMMITTING, v3.getState());
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.COMMITTING, v3.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     CountingOutputCommitter v12OutputCommitter = (CountingOutputCommitter) v1
         .getOutputCommitter("v12Out");
     v12OutputCommitter.unblockCommit();
     waitUntil(dag, DAGState.FAILED);
     // v3 is killed due to the commit failure of the vertex group (v1,v2)
-    Assert.assertEquals(VertexState.KILLED, v3.getState());
-    Assert.assertEquals(VertexTerminationCause.OTHER_VERTEX_FAILURE,
+    assertEquals(VertexState.KILLED, v3.getState());
+    assertEquals(VertexTerminationCause.OTHER_VERTEX_FAILURE,
         v3.getTerminationCause());
-    Assert.assertTrue(v3.commitFutures.isEmpty());
-    Assert.assertEquals(DAGTerminationCause.COMMIT_FAILURE,
+    assertTrue(v3.commitFutures.isEmpty());
+    assertEquals(DAGTerminationCause.COMMIT_FAILURE,
         dag.getTerminationCause());
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 1);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
@@ -1285,21 +1303,22 @@ public class TestCommit {
     historyEventHandler.verifyDAGCommitStartedEvent(dag.getID(), 0);
     historyEventHandler.verifyDAGFinishedEvent(dag.getID(), 1);
 
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v12OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.commitCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
   // commit of vertex v3 fail and commit of vertex group (v1,v2) is not completed
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitFail2_OnVertexSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -1316,23 +1335,23 @@ public class TestCommit {
         TaskState.SUCCEEDED));
     v3.handle(new VertexEventTaskCompleted(v3.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
-    Assert.assertEquals(VertexState.COMMITTING, v3.getState());
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.COMMITTING, v3.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
     v3OutputCommitter.unblockCommit();
     waitUntil(dag, DAGState.FAILED);
 
-    Assert.assertEquals(VertexState.FAILED, v3.getState());
-    Assert.assertEquals(VertexTerminationCause.COMMIT_FAILURE,
+    assertEquals(VertexState.FAILED, v3.getState());
+    assertEquals(VertexTerminationCause.COMMIT_FAILURE,
         v3.getTerminationCause());
-    Assert.assertTrue(v3.commitFutures.isEmpty());
-    Assert.assertEquals(DAGTerminationCause.VERTEX_FAILURE,
+    assertTrue(v3.commitFutures.isEmpty());
+    assertEquals(DAGTerminationCause.VERTEX_FAILURE,
         dag.getTerminationCause());
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 1);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
@@ -1346,19 +1365,20 @@ public class TestCommit {
 
     CountingOutputCommitter v12OutputCommitter = (CountingOutputCommitter) v1
         .getOutputCommitter("v12Out");
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v3OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.commitCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
   // vertex group (v1,v2) succeeded first and then commit of vertex v3 fail
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitFail3_OnVertexSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -1375,10 +1395,10 @@ public class TestCommit {
         TaskState.SUCCEEDED));
     v3.handle(new VertexEventTaskCompleted(v3.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
-    Assert.assertEquals(VertexState.COMMITTING, v3.getState());
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.COMMITTING, v3.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     CountingOutputCommitter v12OutputCommitter = (CountingOutputCommitter) v1
         .getOutputCommitter("v12Out");
@@ -1391,13 +1411,13 @@ public class TestCommit {
     v3OutputCommitter.unblockCommit();
     waitUntil(dag, DAGState.FAILED);
 
-    Assert.assertEquals(VertexState.FAILED, v3.getState());
-    Assert.assertEquals(VertexTerminationCause.COMMIT_FAILURE,
+    assertEquals(VertexState.FAILED, v3.getState());
+    assertEquals(VertexTerminationCause.COMMIT_FAILURE,
         v3.getTerminationCause());
-    Assert.assertTrue(v3.commitFutures.isEmpty());
-    Assert.assertEquals(DAGTerminationCause.VERTEX_FAILURE,
+    assertTrue(v3.commitFutures.isEmpty());
+    assertEquals(DAGTerminationCause.VERTEX_FAILURE,
         dag.getTerminationCause());
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 1);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 1);
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
@@ -1409,19 +1429,20 @@ public class TestCommit {
     historyEventHandler.verifyDAGCommitStartedEvent(dag.getID(), 0);
     historyEventHandler.verifyDAGFinishedEvent(dag.getID(), 1);
 
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v12OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.commitCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v3OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.commitCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
   // commit of vertex v3 succeeded first and then commit of vertex group(v1,v2) fail
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitFail4_OnVertexSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -1438,26 +1459,26 @@ public class TestCommit {
         TaskState.SUCCEEDED));
     v3.handle(new VertexEventTaskCompleted(v3.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
-    Assert.assertEquals(VertexState.COMMITTING, v3.getState());
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.COMMITTING, v3.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
     v3OutputCommitter.unblockCommit();
     waitForCommitCompleted(dag, new OutputKey("v3Out", "vertex3", true));
     waitUntil(v3, VertexState.SUCCEEDED);
-    Assert.assertTrue(v3.commitFutures.isEmpty());
+    assertTrue(v3.commitFutures.isEmpty());
 
     CountingOutputCommitter v12OutputCommitter = (CountingOutputCommitter) v1
         .getOutputCommitter("v12Out");
     v12OutputCommitter.unblockCommit();
     waitUntil(dag, DAGState.FAILED);
 
-    Assert.assertEquals(DAGTerminationCause.COMMIT_FAILURE,
+    assertEquals(DAGTerminationCause.COMMIT_FAILURE,
         dag.getTerminationCause());
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 1);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
@@ -1469,18 +1490,19 @@ public class TestCommit {
     historyEventHandler.verifyDAGCommitStartedEvent(dag.getID(), 0);
     historyEventHandler.verifyDAGFinishedEvent(dag.getID(), 1);
 
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v12OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.commitCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v3OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.commitCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGInternalErrorWhileCommiting_OnDAGSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         true);
@@ -1501,7 +1523,7 @@ public class TestCommit {
     dag.handle(new DAGEvent(dag.getID(), DAGEventType.INTERNAL_ERROR));
     waitUntil(dag, DAGState.ERROR);
 
-    Assert.assertEquals(DAGTerminationCause.INTERNAL_ERROR, dag.getTerminationCause());
+    assertEquals(DAGTerminationCause.INTERNAL_ERROR, dag.getTerminationCause());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
@@ -1517,26 +1539,28 @@ public class TestCommit {
         .getOutputCommitter("v12Out");
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
     // TODO abort it when internal error happens TEZ-2250
-    // Assert.assertEquals(0, v12OutputCommitter.abortCounter);
+    // assertEquals(0, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
     // TODO abort it when internal error happens TEZ-2250
-    // Assert.assertEquals(0, v3OutputCommitter.abortCounter);
+    // assertEquals(0, v3OutputCommitter.abortCounter);
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGKilledWhileCommitting1_OnDAGSuccess() throws Exception {
     _testDAGTerminatedWhileCommitting1_OnDAGSuccess(DAGTerminationCause.DAG_KILL);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testServiceErrorWhileCommitting1_OnDAGSuccess() throws Exception {
     _testDAGTerminatedWhileCommitting1_OnDAGSuccess(DAGTerminationCause.SERVICE_PLUGIN_ERROR);
   }
@@ -1563,12 +1587,11 @@ public class TestCommit {
     dag.handle(new DAGEventTerminateDag(dag.getID(), terminationCause, null));
     waitUntil(dag, terminationCause.getFinishedState());
 
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v3.getState());
-    Assert
-        .assertEquals(terminationCause, dag.getTerminationCause());
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.SUCCEEDED, v3.getState());
+    assertEquals(terminationCause, dag.getTerminationCause());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
@@ -1584,24 +1607,26 @@ public class TestCommit {
         .getOutputCommitter("v12Out");
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGKilledWhileCommitting1_OnVertexSuccess() throws Exception {
     _testDAGTerminatedWhileCommitting1_OnVertexSuccess(DAGTerminationCause.DAG_KILL);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testServiceErrorWhileCommitting1_OnVertexSuccess() throws Exception {
     _testDAGTerminatedWhileCommitting1_OnVertexSuccess(DAGTerminationCause.SERVICE_PLUGIN_ERROR);
   }
@@ -1624,9 +1649,9 @@ public class TestCommit {
         TaskState.SUCCEEDED));
     v3.handle(new VertexEventTaskCompleted(v3.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.COMMITTING, v3.getState());
+    assertEquals(VertexState.COMMITTING, v3.getState());
     // dag is still in RUNNING because v3 has not completed
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
     v3OutputCommitter.unblockCommit();
@@ -1635,13 +1660,12 @@ public class TestCommit {
     dag.handle(new DAGEventTerminateDag(dag.getID(), terminationCause, null));
     waitUntil(dag, terminationCause.getFinishedState());
 
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v3.getState());
-    Assert.assertEquals(terminationCause.getFinishedState(), dag.getState());
-    Assert
-        .assertEquals(terminationCause, dag.getTerminationCause());
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.SUCCEEDED, v3.getState());
+    assertEquals(terminationCause.getFinishedState(), dag.getState());
+    assertEquals(terminationCause, dag.getTerminationCause());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 1);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
@@ -1656,23 +1680,25 @@ public class TestCommit {
     CountingOutputCommitter v12OutputCommitter = (CountingOutputCommitter) v1
         .getOutputCommitter("v12Out");
 
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v3OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.commitCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGKilledWhileRunning_OnVertexSuccess() throws Exception {
     _testDAGKilledWhileRunning_OnVertexSuccess(DAGTerminationCause.DAG_KILL);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testServiceErrorWhileRunning_OnVertexSuccess() throws Exception {
     _testDAGKilledWhileRunning_OnVertexSuccess(DAGTerminationCause.SERVICE_PLUGIN_ERROR);
   }
@@ -1694,21 +1720,20 @@ public class TestCommit {
         TaskState.SUCCEEDED));
     v3.handle(new VertexEventTaskCompleted(v3.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
-    Assert.assertEquals(VertexState.COMMITTING, v3.getState());
+    assertEquals(VertexState.COMMITTING, v3.getState());
     // dag is still in RUNNING because v3 has not completed
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
     dag.handle(new DAGEventTerminateDag(dag.getID(), terminationCause, null));
     waitUntil(dag, terminationCause.getFinishedState());
 
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
-    Assert.assertEquals(VertexState.KILLED, v3.getState());
-    Assert.assertEquals(VertexTerminationCause.DAG_TERMINATED, v3.getTerminationCause());
-    Assert.assertTrue(v3.commitFutures.isEmpty());
-    Assert.assertEquals(terminationCause.getFinishedState(), dag.getState());
-    Assert
-        .assertEquals(terminationCause, dag.getTerminationCause());
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.KILLED, v3.getState());
+    assertEquals(VertexTerminationCause.DAG_TERMINATED, v3.getTerminationCause());
+    assertTrue(v3.commitFutures.isEmpty());
+    assertEquals(terminationCause.getFinishedState(), dag.getState());
+    assertEquals(terminationCause, dag.getTerminationCause());
+    assertTrue(dag.commitFutures.isEmpty());
     // commit uv12 may not have started, so can't verify the VertexGroupCommitStartedEvent
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
@@ -1725,18 +1750,19 @@ public class TestCommit {
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
 
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitVertexRerunWhileCommitting_OnDAGSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         true);
@@ -1762,12 +1788,12 @@ public class TestCommit {
     // reschedueled task is killed
     v1.handle(new VertexEventTaskCompleted(newTaskId, TaskState.KILLED));
     waitUntil(dag, DAGState.FAILED);
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
-    Assert.assertEquals(DAGState.FAILED, dag.getState());
-    Assert.assertEquals(VertexTerminationCause.VERTEX_RERUN_IN_COMMITTING, v1.getTerminationCause());
+    assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(DAGState.FAILED, dag.getState());
+    assertEquals(VertexTerminationCause.VERTEX_RERUN_IN_COMMITTING, v1.getTerminationCause());
 
-    Assert.assertEquals(DAGTerminationCause.VERTEX_RERUN_IN_COMMITTING, dag.getTerminationCause());
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertEquals(DAGTerminationCause.VERTEX_RERUN_IN_COMMITTING, dag.getTerminationCause());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
@@ -1784,18 +1810,19 @@ public class TestCommit {
         .getOutputCommitter("v12Out");
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitInternalErrorWhileCommiting_OnDAGSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         true);
@@ -1816,7 +1843,7 @@ public class TestCommit {
     dag.handle(new DAGEvent(dag.getID(), DAGEventType.INTERNAL_ERROR));
     waitUntil(dag, DAGState.ERROR);
 
-    Assert.assertEquals(DAGTerminationCause.INTERNAL_ERROR, dag.getTerminationCause());
+    assertEquals(DAGTerminationCause.INTERNAL_ERROR, dag.getTerminationCause());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
@@ -1832,18 +1859,19 @@ public class TestCommit {
         .getOutputCommitter("v12Out");
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexGroupCommitFinishedEventFail_OnVertexSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         false);
@@ -1879,26 +1907,27 @@ public class TestCommit {
     historyEventHandler.verifyDAGCommitStartedEvent(dag.getID(), 0);
     historyEventHandler.verifyDAGFinishedEvent(dag.getID(), 1);
 
-    Assert.assertEquals(DAGState.FAILED, dag.getState());
-    Assert.assertEquals(DAGTerminationCause.RECOVERY_FAILURE,
+    assertEquals(DAGState.FAILED, dag.getState());
+    assertEquals(DAGTerminationCause.RECOVERY_FAILURE,
         dag.getTerminationCause());
-    Assert.assertTrue(dag.commitFutures.isEmpty());
-    Assert.assertEquals(VertexState.KILLED, v3.getState());
-    Assert.assertEquals(VertexTerminationCause.OTHER_VERTEX_FAILURE, v3.getTerminationCause());
-    Assert.assertTrue(v3.commitFutures.isEmpty());
+    assertTrue(dag.commitFutures.isEmpty());
+    assertEquals(VertexState.KILLED, v3.getState());
+    assertEquals(VertexTerminationCause.OTHER_VERTEX_FAILURE, v3.getTerminationCause());
+    assertTrue(v3.commitFutures.isEmpty());
 
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
-    Assert.assertEquals(1, v12OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.commitCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
     // commit may not have started, so can't verify commitCounter
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCommitStartedEventFail_OnDAGSuccess() throws Exception {
     conf.setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS,
         true);
@@ -1918,8 +1947,8 @@ public class TestCommit {
     v3.handle(new VertexEventTaskCompleted(v3.getTask(0).getTaskID(),
         TaskState.SUCCEEDED));
     waitUntil(dag, DAGState.FAILED);
-    Assert.assertEquals(DAGTerminationCause.RECOVERY_FAILURE, dag.getTerminationCause());
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertEquals(DAGTerminationCause.RECOVERY_FAILURE, dag.getTerminationCause());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
@@ -1935,25 +1964,27 @@ public class TestCommit {
         .getOutputCommitter("v12Out");
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
     // commit has not started
-    Assert.assertEquals(0, v12OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(0, v12OutputCommitter.commitCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
     // commit has not started
-    Assert.assertEquals(0, v12OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(0, v12OutputCommitter.commitCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCommitCanceled_OnDAGSuccess() throws Exception {
     _testCommitCanceled_OnDAGSuccess(DAGTerminationCause.DAG_KILL);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCommitCanceled_OnDAGSuccess2() throws Exception {
     _testCommitCanceled_OnDAGSuccess(DAGTerminationCause.SERVICE_PLUGIN_ERROR);
   }
@@ -1983,14 +2014,14 @@ public class TestCommit {
         TaskState.SUCCEEDED));
     waitUntil(dag, DAGState.COMMITTING);
     // mean the commits have been submitted to ThreadPool
-    Assert.assertEquals(2, dag.commitFutures.size());
+    assertEquals(2, dag.commitFutures.size());
 
     dag.handle(new DAGEventTerminateDag(dag.getID(), terminationCause, null));
     waitUntil(dag, terminationCause.getFinishedState());
 
-    Assert.assertEquals(terminationCause, dag.getTerminationCause());
+    assertEquals(terminationCause, dag.getTerminationCause());
     // mean the commits have been canceled
-    Assert.assertTrue(dag.commitFutures.isEmpty());
+    assertTrue(dag.commitFutures.isEmpty());
     historyEventHandler.verifyVertexGroupCommitStartedEvent("uv12", 0);
     historyEventHandler.verifyVertexGroupCommitFinishedEvent("uv12", 0);
     historyEventHandler.verifyVertexCommitStartedEvent(v1.getVertexId(), 0);
@@ -2006,17 +2037,17 @@ public class TestCommit {
         .getOutputCommitter("v12Out");
     CountingOutputCommitter v3OutputCommitter = (CountingOutputCommitter) v3
         .getOutputCommitter("v3Out");
-    Assert.assertEquals(1, v12OutputCommitter.initCounter);
-    Assert.assertEquals(1, v12OutputCommitter.setupCounter);
+    assertEquals(1, v12OutputCommitter.initCounter);
+    assertEquals(1, v12OutputCommitter.setupCounter);
     // commit is not started because ControlledThreadPoolExecutor wait before schedule tasks
-    Assert.assertEquals(0, v12OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v12OutputCommitter.abortCounter);
+    assertEquals(0, v12OutputCommitter.commitCounter);
+    assertEquals(1, v12OutputCommitter.abortCounter);
 
-    Assert.assertEquals(1, v3OutputCommitter.initCounter);
-    Assert.assertEquals(1, v3OutputCommitter.setupCounter);
+    assertEquals(1, v3OutputCommitter.initCounter);
+    assertEquals(1, v3OutputCommitter.setupCounter);
     // commit is not started because ControlledThreadPoolExecutor  wait before schedule tasks
-    Assert.assertEquals(0, v3OutputCommitter.commitCounter);
-    Assert.assertEquals(1, v3OutputCommitter.abortCounter);
+    assertEquals(0, v3OutputCommitter.commitCounter);
+    assertEquals(1, v3OutputCommitter.abortCounter);
 
   }
 
@@ -2066,7 +2097,7 @@ public class TestCommit {
           }
         }
       }
-      Assert.assertEquals(expectedTimes, actualTimes);
+      assertEquals(expectedTimes, actualTimes);
     }
 
     public void verifyVertexGroupCommitFinishedEvent(String groupName, int expectedTimes) {
@@ -2079,7 +2110,7 @@ public class TestCommit {
           }
         }
       }
-      Assert.assertEquals(expectedTimes, actualTimes);
+      assertEquals(expectedTimes, actualTimes);
     }
 
     public void verifyVertexCommitStartedEvent(TezVertexID vertexId, int expectedTimes) {
@@ -2092,7 +2123,7 @@ public class TestCommit {
           }
         }
       }
-      Assert.assertEquals(expectedTimes, actualTimes);
+      assertEquals(expectedTimes, actualTimes);
     }
 
     public void verifyVertexFinishedEvent(TezVertexID vertexId, int expectedTimes) {
@@ -2105,7 +2136,7 @@ public class TestCommit {
           }
         }
       }
-      Assert.assertEquals(expectedTimes, actualTimes);
+      assertEquals(expectedTimes, actualTimes);
     }
 
     public void verifyDAGCommitStartedEvent(TezDAGID dagId, int expectedTimes) {
@@ -2118,7 +2149,7 @@ public class TestCommit {
           }
         }
       }
-      Assert.assertEquals(expectedTimes, actualTimes);
+      assertEquals(expectedTimes, actualTimes);
     }
 
     public void verifyDAGFinishedEvent(TezDAGID dagId, int expectedTimes) {
@@ -2131,7 +2162,7 @@ public class TestCommit {
           }
         }
       }
-      Assert.assertEquals(expectedTimes, actualTimes);
+      assertEquals(expectedTimes, actualTimes);
     }
   }
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGImpl.java
@@ -1996,7 +1996,7 @@ public class TestDAGImpl {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   @SuppressWarnings("unchecked")
   public void testDAGHang() throws Exception {
     conf.setBoolean(
@@ -2038,7 +2038,7 @@ public class TestDAGImpl {
         dag).logJobHistoryUnsuccesfulEvent(any(), any());
     dag.handle(dagEvent);
     dispatcher.await();
-    assertSame(dag.getInternalState(), DAGState.FAILED, "DAG did not terminate!");
+    assertSame(DAGState.FAILED, dag.getInternalState(), "DAG did not terminate!");
   }
 
   @Test

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGImpl.java
@@ -18,6 +18,10 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
@@ -39,6 +43,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -81,6 +86,7 @@ import org.apache.tez.dag.api.TezConstants;
 import org.apache.tez.dag.api.TezException;
 import org.apache.tez.dag.api.UserPayload;
 import org.apache.tez.dag.api.client.DAGStatus;
+import org.apache.tez.dag.api.client.DAGStatus.State;
 import org.apache.tez.dag.api.client.DAGStatusBuilder;
 import org.apache.tez.dag.api.client.StatusGetOpts;
 import org.apache.tez.dag.api.oldrecords.TaskState;
@@ -159,23 +165,18 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TestDAGImpl {
-
-  @Rule
-  public TestName testName = new TestName();
 
   private static final Logger LOG = LoggerFactory.getLogger(TestDAGImpl.class);
   private DAGPlan dagPlan;
@@ -852,20 +853,20 @@ public class TestDAGImpl {
     return dag;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     MockDNSToSwitchMapping.initializeMockRackResolver();
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
-  @Before
-  public void setup() {
+  @BeforeEach
+  public void setup(org.junit.jupiter.api.TestInfo testInfo) {
     conf = new Configuration();
     conf.setBoolean(TezConfiguration.TEZ_AM_CONTAINER_REUSE_ENABLED, false);
     appAttemptId = ApplicationAttemptId.newInstance(
         ApplicationId.newInstance(100, 1), 1);
     dagId = TezDAGID.getInstance(appAttemptId.getApplicationId(), 1);
-    Assert.assertNotNull(dagId);
+    assertNotNull(dagId);
     dagPlan = createTestDAGPlan();
     dispatcher = new DrainDispatcher();
     fsTokens = new Credentials();
@@ -927,7 +928,7 @@ public class TestDAGImpl {
     doReturn(defaultShim).when(groupAppContext).getHadoopShim();
 
     groupDagId = TezDAGID.getInstance(appAttemptId.getApplicationId(), 3);
-    groupDagPlan = createGroupDAGPlan(testName.getMethodName());
+    groupDagPlan = createGroupDAGPlan(testInfo.getTestMethod().get().getName());
     groupDag = new DAGImpl(groupDagId, conf, groupDagPlan,
         dispatcher.getEventHandler(), taskCommunicatorManagerInterface,
         fsTokens, clock, "user", thh,
@@ -959,7 +960,7 @@ public class TestDAGImpl {
     dispatcher.start();
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     dispatcher.await();
     dispatcher.stop();
@@ -1021,7 +1022,7 @@ public class TestDAGImpl {
   private void initDAG(DAGImpl impl) {
     impl.handle(
         new DAGEvent(impl.getID(), DAGEventType.DAG_INIT));
-    Assert.assertEquals(DAGState.INITED, impl.getState());
+    assertEquals(DAGState.INITED, impl.getState());
   }
 
   @SuppressWarnings("unchecked")
@@ -1029,28 +1030,31 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(
         new DAGEventStartDag(impl.getID(), null));
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, impl.getState());
+    assertEquals(DAGState.RUNNING, impl.getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGInit() {
     initDAG(dag);
-    Assert.assertEquals(6, dag.getTotalVertices());
+    assertEquals(6, dag.getTotalVertices());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGInitFailed() {
     setupDAGWithCustomEdge(ExceptionLocation.Initialize);
     dagWithCustomEdge.handle(
         new DAGEvent(dagWithCustomEdge.getID(), DAGEventType.DAG_INIT));
-    Assert.assertEquals(DAGState.FAILED, dagWithCustomEdge.getState());
+    assertEquals(DAGState.FAILED, dagWithCustomEdge.getState());
     // START event is followed after INIT event
     dagWithCustomEdge.handle(new DAGEvent(dagWithCustomEdge.getID(), DAGEventType.DAG_START));
     dispatcher.await();
-    Assert.assertEquals(DAGState.FAILED, dagWithCustomEdge.getState());
+    assertEquals(DAGState.FAILED, dagWithCustomEdge.getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGInitFailedDuetoInvalidResource() {
     // cluster maxContainerCapability is less than the vertex resource request
     ClusterInfo clusterInfo = new ClusterInfo(Resource.newInstance(512,10));
@@ -1058,13 +1062,14 @@ public class TestDAGImpl {
     dag.handle(
         new DAGEvent(dag.getID(), DAGEventType.DAG_INIT));
     dispatcher.await();
-    Assert.assertEquals(DAGState.FAILED, dag.getState());
-    Assert.assertEquals(DAGTerminationCause.INIT_FAILURE, dag.getTerminationCause());
-    Assert.assertTrue(StringUtils.join(dag.getDiagnostics(), ",")
+    assertEquals(DAGState.FAILED, dag.getState());
+    assertEquals(DAGTerminationCause.INIT_FAILURE, dag.getTerminationCause());
+    assertTrue(StringUtils.join(dag.getDiagnostics(), ",")
         .contains("Vertex's TaskResource is beyond the cluster container capability"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGStart() {
     initDAG(dag);
     startDAG(dag);
@@ -1073,15 +1078,15 @@ public class TestDAGImpl {
     for (int i = 0 ; i < 6; ++i ) {
       TezVertexID vId = TezVertexID.getInstance(dagId, i);
       Vertex v = dag.getVertex(vId);
-      Assert.assertEquals(VertexState.RUNNING, v.getState());
+      assertEquals(VertexState.RUNNING, v.getState());
       if (i < 2) {
-        Assert.assertEquals(0, v.getDistanceFromRoot());
+        assertEquals(0, v.getDistanceFromRoot());
       } else if (i == 2) {
-        Assert.assertEquals(1, v.getDistanceFromRoot());
+        assertEquals(1, v.getDistanceFromRoot());
       } else if ( i > 2 && i < 5) {
-        Assert.assertEquals(2, v.getDistanceFromRoot());
+        assertEquals(2, v.getDistanceFromRoot());
       } else if (i == 5) {
-        Assert.assertEquals(3, v.getDistanceFromRoot());
+        assertEquals(3, v.getDistanceFromRoot());
       }
     }
 
@@ -1092,7 +1097,8 @@ public class TestDAGImpl {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNonExistEdgeManagerPlugin() {
     dagPlan = createDAGWithNonExistEdgeManager();
     dag = new DAGImpl(dagId, conf, dagPlan,
@@ -1102,13 +1108,14 @@ public class TestDAGImpl {
     doReturn(dag).when(appContext).getCurrentDAG();
 
     dag.handle(new DAGEvent(dagId, DAGEventType.DAG_INIT));
-    Assert.assertEquals(DAGState.FAILED, dag.getState());
-    Assert.assertEquals(DAGTerminationCause.INIT_FAILURE, dag.getTerminationCause());
-    Assert.assertTrue(StringUtils.join(dag.getDiagnostics(), "")
+    assertEquals(DAGState.FAILED, dag.getState());
+    assertEquals(DAGTerminationCause.INIT_FAILURE, dag.getTerminationCause());
+    assertTrue(StringUtils.join(dag.getDiagnostics(), "")
         .contains("java.lang.ClassNotFoundException: non-exist-edge-manager"));
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNonExistDAGScheduler() {
     conf.set(TezConfiguration.TEZ_AM_DAG_SCHEDULER_CLASS, "non-exist-dag-scheduler");
     dag = new DAGImpl(dagId, conf, dagPlan,
@@ -1118,20 +1125,21 @@ public class TestDAGImpl {
     doReturn(dag).when(appContext).getCurrentDAG();
 
     dag.handle(new DAGEvent(dag.getID(), DAGEventType.DAG_INIT));
-    Assert.assertEquals(DAGState.FAILED, dag.getState());
-    Assert.assertEquals(DAGState.FAILED, dag.getState());
-    Assert.assertEquals(DAGTerminationCause.INIT_FAILURE, dag.getTerminationCause());
-    Assert.assertTrue(StringUtils.join(dag.getDiagnostics(), "")
+    assertEquals(DAGState.FAILED, dag.getState());
+    assertEquals(DAGState.FAILED, dag.getState());
+    assertEquals(DAGTerminationCause.INIT_FAILURE, dag.getTerminationCause());
+    assertTrue(StringUtils.join(dag.getDiagnostics(), "")
         .contains("java.lang.ClassNotFoundException: non-exist-dag-scheduler"));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexCompletion() {
     initDAG(dag);
-    Assert.assertTrue(0.0f == dag.getCompletedTaskProgress());
+    assertEquals(0.0f, dag.getCompletedTaskProgress());
     startDAG(dag);
-    Assert.assertTrue(0.0f == dag.getCompletedTaskProgress());
+    assertEquals(0.0f, dag.getCompletedTaskProgress());
     dispatcher.await();
 
     TezVertexID vId = TezVertexID.getInstance(dagId, 1);
@@ -1142,16 +1150,17 @@ public class TestDAGImpl {
         TezTaskID.getInstance(vId, 1), TaskState.SUCCEEDED));
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertEquals(1, dag.getSuccessfulVertices());
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(1, dag.getSuccessfulVertices());
 
     // 2 tasks completed, total plan has 11 vertices
-    Assert.assertEquals((float) 2 / 11,
+    assertEquals((float) 2 / 11,
         dag.getCompletedTaskProgress(), 0.05);
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEdgeManager_GetNumDestinationTaskPhysicalInputs() {
     setupDAGWithCustomEdge(ExceptionLocation.GetNumDestinationTaskPhysicalInputs);
     dispatcher.getEventHandler().handle(
@@ -1162,11 +1171,12 @@ public class TestDAGImpl {
 
     VertexImpl v2 = (VertexImpl)dagWithCustomEdge.getVertex("vertex2");
     String diag = StringUtils.join(v2.getDiagnostics(), ",");
-    Assert.assertTrue(diag.contains(ExceptionLocation.GetNumDestinationTaskPhysicalInputs.name()));
+    assertTrue(diag.contains(ExceptionLocation.GetNumDestinationTaskPhysicalInputs.name()));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEdgeManager_GetNumSourceTaskPhysicalOutputs() {
     setupDAGWithCustomEdge(ExceptionLocation.GetNumSourceTaskPhysicalOutputs);
     dispatcher.getEventHandler().handle(
@@ -1176,15 +1186,16 @@ public class TestDAGImpl {
     dispatcher.await();
     // After TEZ-1711, all task attempts of v1 fail which result in task fail, and finally
     // dag failed.
-    Assert.assertEquals(DAGState.FAILED, dagWithCustomEdge.getState());
+    assertEquals(DAGState.FAILED, dagWithCustomEdge.getState());
 
     VertexImpl v1 = (VertexImpl)dagWithCustomEdge.getVertex("vertex1");
     String diag = StringUtils.join(v1.getDiagnostics(), ",");
-    Assert.assertTrue(diag.contains(ExceptionLocation.GetNumSourceTaskPhysicalOutputs.name()));
+    assertTrue(diag.contains(ExceptionLocation.GetNumSourceTaskPhysicalOutputs.name()));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEdgeManager_RouteDataMovementEventToDestination() {
     setupDAGWithCustomEdge(ExceptionLocation.RouteDataMovementEventToDestination);
     dispatcher.getEventHandler().handle(
@@ -1192,7 +1203,7 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventStartDag(dagWithCustomEdge.getID(),
         null));
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dagWithCustomEdge.getState());
+    assertEquals(DAGState.RUNNING, dagWithCustomEdge.getState());
 
     VertexImpl v1 = (VertexImpl)dagWithCustomEdge.getVertex("vertex1");
     VertexImpl v2 = (VertexImpl)dagWithCustomEdge.getVertex("vertex2");
@@ -1208,14 +1219,15 @@ public class TestDAGImpl {
     v2.getTaskAttemptTezEvents(ta1.getTaskAttemptID(), 0, 0, 1000);
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.FAILED, v2.getState());
-    Assert.assertEquals(VertexState.KILLED, v1.getState());
+    assertEquals(VertexState.FAILED, v2.getState());
+    assertEquals(VertexState.KILLED, v1.getState());
     String diag = StringUtils.join(v2.getDiagnostics(), ",");
-    Assert.assertTrue(diag.contains(ExceptionLocation.RouteDataMovementEventToDestination.name()));
+    assertTrue(diag.contains(ExceptionLocation.RouteDataMovementEventToDestination.name()));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEdgeManager_RouteDataMovementEventToDestinationWithLegacyRouting() {
     // Remove after legacy routing is removed
     setupDAGWithCustomEdge(ExceptionLocation.RouteDataMovementEventToDestination, true);
@@ -1224,7 +1236,7 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventStartDag(dagWithCustomEdge.getID(),
         null));
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dagWithCustomEdge.getState());
+    assertEquals(DAGState.RUNNING, dagWithCustomEdge.getState());
 
     VertexImpl v1 = (VertexImpl)dagWithCustomEdge.getVertex("vertex1");
     VertexImpl v2 = (VertexImpl)dagWithCustomEdge.getVertex("vertex2");
@@ -1240,14 +1252,15 @@ public class TestDAGImpl {
         new VertexEventRouteEvent(v2.getVertexId(), Lists.newArrayList(tezEvent)));
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.FAILED, v2.getState());
-    Assert.assertEquals(VertexState.KILLED, v1.getState());
+    assertEquals(VertexState.FAILED, v2.getState());
+    assertEquals(VertexState.KILLED, v1.getState());
     String diag = StringUtils.join(v2.getDiagnostics(), ",");
-    Assert.assertTrue(diag.contains(ExceptionLocation.RouteDataMovementEventToDestination.name()));
+    assertTrue(diag.contains(ExceptionLocation.RouteDataMovementEventToDestination.name()));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEdgeManager_RouteInputSourceTaskFailedEventToDestinationLegacyRouting() {
     // Remove after legacy routing is removed
     setupDAGWithCustomEdge(ExceptionLocation.RouteInputSourceTaskFailedEventToDestination, true);
@@ -1256,7 +1269,7 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventStartDag(dagWithCustomEdge.getID(),
         null));
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dagWithCustomEdge.getState());
+    assertEquals(DAGState.RUNNING, dagWithCustomEdge.getState());
 
     VertexImpl v1 = (VertexImpl)dagWithCustomEdge.getVertex("vertex1");
     VertexImpl v2 = (VertexImpl)dagWithCustomEdge.getVertex("vertex2");
@@ -1271,15 +1284,16 @@ public class TestDAGImpl {
     dispatcher.await();
     v2.getTaskAttemptTezEvents(ta1.getTaskAttemptID(), 0, 0, 1000);
     dispatcher.await();
-    Assert.assertEquals(VertexState.FAILED, v2.getState());
+    assertEquals(VertexState.FAILED, v2.getState());
 
-    Assert.assertEquals(VertexState.KILLED, v1.getState());
+    assertEquals(VertexState.KILLED, v1.getState());
     String diag = StringUtils.join(v2.getDiagnostics(), ",");
-    Assert.assertTrue(diag.contains(ExceptionLocation.RouteInputSourceTaskFailedEventToDestination.name()));
+    assertTrue(diag.contains(ExceptionLocation.RouteInputSourceTaskFailedEventToDestination.name()));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEdgeManager_GetNumDestinationConsumerTasks() {
     setupDAGWithCustomEdge(ExceptionLocation.GetNumDestinationConsumerTasks);
     dispatcher.getEventHandler().handle(
@@ -1287,7 +1301,7 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventStartDag(dagWithCustomEdge.getID(),
         null));
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dagWithCustomEdge.getState());
+    assertEquals(DAGState.RUNNING, dagWithCustomEdge.getState());
 
     VertexImpl v1 = (VertexImpl)dagWithCustomEdge.getVertex("vertex1");
     VertexImpl v2 = (VertexImpl)dagWithCustomEdge.getVertex("vertex2");
@@ -1303,14 +1317,15 @@ public class TestDAGImpl {
         new VertexEventRouteEvent(v2.getVertexId(), Lists.newArrayList(tezEvent)));
     dispatcher.await();
     //
-    Assert.assertEquals(VertexState.FAILED, v2.getState());
-    Assert.assertEquals(VertexState.KILLED, v1.getState());
+    assertEquals(VertexState.FAILED, v2.getState());
+    assertEquals(VertexState.KILLED, v1.getState());
     String diag = StringUtils.join(v2.getDiagnostics(), ",");
-    Assert.assertTrue(diag.contains(ExceptionLocation.GetNumDestinationConsumerTasks.name()));
+    assertTrue(diag.contains(ExceptionLocation.GetNumDestinationConsumerTasks.name()));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEdgeManager_RouteInputErrorEventToSource() {
     setupDAGWithCustomEdge(ExceptionLocation.RouteInputErrorEventToSource);
     dispatcher.getEventHandler().handle(
@@ -1318,7 +1333,7 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventStartDag(dagWithCustomEdge.getID(),
         null));
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dagWithCustomEdge.getState());
+    assertEquals(DAGState.RUNNING, dagWithCustomEdge.getState());
 
     VertexImpl v1 = (VertexImpl)dagWithCustomEdge.getVertex("vertex1");
     VertexImpl v2 = (VertexImpl)dagWithCustomEdge.getVertex("vertex2");
@@ -1332,14 +1347,15 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new VertexEventRouteEvent(v2.getVertexId(), Lists.newArrayList(tezEvent)));
     dispatcher.await();
     //
-    Assert.assertEquals(VertexState.FAILED, v2.getState());
-    Assert.assertEquals(VertexState.KILLED, v1.getState());
+    assertEquals(VertexState.FAILED, v2.getState());
+    assertEquals(VertexState.KILLED, v1.getState());
     String diag = StringUtils.join(v2.getDiagnostics(), ",");
-    Assert.assertTrue(diag.contains(ExceptionLocation.RouteInputErrorEventToSource.name()));
+    assertTrue(diag.contains(ExceptionLocation.RouteInputErrorEventToSource.name()));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGroupDAGCompletionWithCommitSuccess() {
     // should have only 2 commits. 1 vertex3 commit and 1 group commit.
     initDAG(groupDag);
@@ -1351,18 +1367,19 @@ public class TestDAGImpl {
       dispatcher.getEventHandler().handle(new VertexEventTaskCompleted(
           TezTaskID.getInstance(v.getVertexId(), 0), TaskState.SUCCEEDED));
       dispatcher.await();
-      Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-      Assert.assertEquals(i+1, groupDag.getSuccessfulVertices());
+      assertEquals(VertexState.SUCCEEDED, v.getState());
+      assertEquals(i+1, groupDag.getSuccessfulVertices());
     }
 
-    Assert.assertEquals(3, groupDag.getSuccessfulVertices());
-    Assert.assertTrue(1.0f == groupDag.getCompletedTaskProgress());
-    Assert.assertEquals(DAGState.SUCCEEDED, groupDag.getState());
-    Assert.assertEquals(2, TotalCountingOutputCommitter.totalCommitCounter);
+    assertEquals(3, groupDag.getSuccessfulVertices());
+    assertEquals(1.0f, groupDag.getCompletedTaskProgress());
+    assertEquals(DAGState.SUCCEEDED, groupDag.getState());
+    assertEquals(2, TotalCountingOutputCommitter.totalCommitCounter);
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGroupDAGWithVertexReRunning() {
     groupDag.getConf().setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS, false);
     initDAG(groupDag);
@@ -1377,18 +1394,19 @@ public class TestDAGImpl {
         new DAGEventVertexCompleted(v2.getVertexId(), VertexState.SUCCEEDED));
     dispatcher.await();
     // commit should not happen due to vertex-rerunning
-    Assert.assertEquals(0, TotalCountingOutputCommitter.totalCommitCounter);
+    assertEquals(0, TotalCountingOutputCommitter.totalCommitCounter);
 
     dispatcher.getEventHandler().handle(
         new DAGEventVertexCompleted(v1.getVertexId(), VertexState.SUCCEEDED));
     dispatcher.await();
     // commit happen
-    Assert.assertEquals(1, TotalCountingOutputCommitter.totalCommitCounter);
-    Assert.assertEquals(2, groupDag.getSuccessfulVertices());
+    assertEquals(1, TotalCountingOutputCommitter.totalCommitCounter);
+    assertEquals(2, groupDag.getSuccessfulVertices());
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGroupDAGWithVertexReRunningAfterCommit() {
     groupDag.getConf().setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS, false);
     initDAG(groupDag);
@@ -1401,17 +1419,18 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(v2.getVertexId(), VertexState.SUCCEEDED));
     dispatcher.await();
     // vertex group commit happens
-    Assert.assertEquals(1, TotalCountingOutputCommitter.totalCommitCounter);
+    assertEquals(1, TotalCountingOutputCommitter.totalCommitCounter);
 
     // dag failed when vertex re-run happens after vertex group commit is done.
     dispatcher.getEventHandler().handle(new DAGEventVertexReRunning(v1.getVertexId()));
     dispatcher.await();
-    Assert.assertEquals(DAGState.FAILED, groupDag.getState());
-    Assert.assertEquals(DAGTerminationCause.VERTEX_RERUN_AFTER_COMMIT, groupDag.getTerminationCause());
+    assertEquals(DAGState.FAILED, groupDag.getState());
+    assertEquals(DAGTerminationCause.VERTEX_RERUN_AFTER_COMMIT, groupDag.getTerminationCause());
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCompletionWithCommitSuccess() {
     // all vertices completed -> DAG completion and commit
     initDAG(mrrDag);
@@ -1423,18 +1442,18 @@ public class TestDAGImpl {
       dispatcher.getEventHandler().handle(new VertexEventTaskCompleted(
           TezTaskID.getInstance(v.getVertexId(), 0), TaskState.SUCCEEDED));
       dispatcher.await();
-      Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-      Assert.assertEquals(i+1, mrrDag.getSuccessfulVertices());
+      assertEquals(VertexState.SUCCEEDED, v.getState());
+      assertEquals(i+1, mrrDag.getSuccessfulVertices());
     }
 
     // no commit yet
     for (Vertex v : mrrDag.vertices.values()) {
       for (OutputCommitter c : v.getOutputCommitters().values()) {
         CountingOutputCommitter committer= (CountingOutputCommitter) c;
-        Assert.assertEquals(0, committer.abortCounter);
-        Assert.assertEquals(0, committer.commitCounter);
-        Assert.assertEquals(1, committer.initCounter);
-        Assert.assertEquals(1, committer.setupCounter);
+        assertEquals(0, committer.abortCounter);
+        assertEquals(0, committer.commitCounter);
+        assertEquals(1, committer.initCounter);
+        assertEquals(1, committer.setupCounter);
       }
     }
 
@@ -1443,23 +1462,24 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new VertexEventTaskCompleted(
         TezTaskID.getInstance(v.getVertexId(), 0), TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertEquals(3, mrrDag.getSuccessfulVertices());
-    Assert.assertEquals(DAGState.SUCCEEDED, mrrDag.getState());
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(3, mrrDag.getSuccessfulVertices());
+    assertEquals(DAGState.SUCCEEDED, mrrDag.getState());
 
     for (Vertex vertex : mrrDag.vertices.values()) {
       for (OutputCommitter c : vertex.getOutputCommitters().values()) {
         CountingOutputCommitter committer= (CountingOutputCommitter) c;
-        Assert.assertEquals(0, committer.abortCounter);
-        Assert.assertEquals(1, committer.commitCounter);
-        Assert.assertEquals(1, committer.initCounter);
-        Assert.assertEquals(1, committer.setupCounter);
+        assertEquals(0, committer.abortCounter);
+        assertEquals(1, committer.commitCounter);
+        assertEquals(1, committer.initCounter);
+        assertEquals(1, committer.setupCounter);
       }
     }
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGCompletionWithCommitFailure() throws IOException {
     // all vertices completed -> DAG completion and commit
     initDAG(mrrDag);
@@ -1492,18 +1512,18 @@ public class TestDAGImpl {
       dispatcher.getEventHandler().handle(new VertexEventTaskCompleted(
           TezTaskID.getInstance(v.getVertexId(), 0), TaskState.SUCCEEDED));
       dispatcher.await();
-      Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-      Assert.assertEquals(i+1, mrrDag.getSuccessfulVertices());
+      assertEquals(VertexState.SUCCEEDED, v.getState());
+      assertEquals(i+1, mrrDag.getSuccessfulVertices());
     }
 
     // no commit yet
     for (Vertex v : mrrDag.vertices.values()) {
       for (OutputCommitter c : v.getOutputCommitters().values()) {
         CountingOutputCommitter committer= (CountingOutputCommitter) c;
-        Assert.assertEquals(0, committer.abortCounter);
-        Assert.assertEquals(0, committer.commitCounter);
-        Assert.assertEquals(1, committer.initCounter);
-        Assert.assertEquals(1, committer.setupCounter);
+        assertEquals(0, committer.abortCounter);
+        assertEquals(0, committer.commitCounter);
+        assertEquals(1, committer.initCounter);
+        assertEquals(1, committer.setupCounter);
       }
     }
 
@@ -1512,23 +1532,24 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new VertexEventTaskCompleted(
         TezTaskID.getInstance(v.getVertexId(), 0), TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertEquals(3, mrrDag.getSuccessfulVertices());
-    Assert.assertEquals(DAGState.FAILED, mrrDag.getState());
-    Assert.assertEquals(DAGTerminationCause.COMMIT_FAILURE, mrrDag.getTerminationCause());
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(3, mrrDag.getSuccessfulVertices());
+    assertEquals(DAGState.FAILED, mrrDag.getState());
+    assertEquals(DAGTerminationCause.COMMIT_FAILURE, mrrDag.getTerminationCause());
 
     for (Vertex vertex : mrrDag.vertices.values()) {
       for (OutputCommitter c : vertex.getOutputCommitters().values()) {
         CountingOutputCommitter committer= (CountingOutputCommitter) c;
-        Assert.assertEquals(1, committer.abortCounter);
-        Assert.assertEquals(1, committer.initCounter);
-        Assert.assertEquals(1, committer.setupCounter);
+        assertEquals(1, committer.abortCounter);
+        assertEquals(1, committer.initCounter);
+        assertEquals(1, committer.setupCounter);
       }
     }
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGErrorAbortAllOutputs() {
     // error on a vertex -> dag error -> all outputs aborted.
     initDAG(mrrDag);
@@ -1540,18 +1561,18 @@ public class TestDAGImpl {
       dispatcher.getEventHandler().handle(new VertexEventTaskCompleted(
           TezTaskID.getInstance(v.getVertexId(), 0), TaskState.SUCCEEDED));
       dispatcher.await();
-      Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-      Assert.assertEquals(i+1, mrrDag.getSuccessfulVertices());
+      assertEquals(VertexState.SUCCEEDED, v.getState());
+      assertEquals(i+1, mrrDag.getSuccessfulVertices());
     }
 
     // no commit yet
     for (Vertex v : mrrDag.vertices.values()) {
       for (OutputCommitter c : v.getOutputCommitters().values()) {
         CountingOutputCommitter committer= (CountingOutputCommitter) c;
-        Assert.assertEquals(0, committer.abortCounter);
-        Assert.assertEquals(0, committer.commitCounter);
-        Assert.assertEquals(1, committer.initCounter);
-        Assert.assertEquals(1, committer.setupCounter);
+        assertEquals(0, committer.abortCounter);
+        assertEquals(0, committer.commitCounter);
+        assertEquals(1, committer.initCounter);
+        assertEquals(1, committer.setupCounter);
       }
     }
 
@@ -1560,22 +1581,23 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new VertexEvent(
         v.getVertexId(), VertexEventType.V_INTERNAL_ERROR));
     dispatcher.await();
-    Assert.assertEquals(VertexState.ERROR, v.getState());
-    Assert.assertEquals(DAGState.ERROR, mrrDag.getState());
+    assertEquals(VertexState.ERROR, v.getState());
+    assertEquals(DAGState.ERROR, mrrDag.getState());
 
     for (Vertex vertex : mrrDag.vertices.values()) {
       for (OutputCommitter c : vertex.getOutputCommitters().values()) {
         CountingOutputCommitter committer= (CountingOutputCommitter) c;
-        Assert.assertEquals(1, committer.abortCounter);
-        Assert.assertEquals(0, committer.commitCounter);
-        Assert.assertEquals(1, committer.initCounter);
-        Assert.assertEquals(1, committer.setupCounter);
+        assertEquals(1, committer.abortCounter);
+        assertEquals(0, committer.commitCounter);
+        assertEquals(1, committer.initCounter);
+        assertEquals(1, committer.setupCounter);
       }
     }
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGErrorAbortNonSuccessfulOutputs() {
     // vertex success -> vertex output commit. failed dag aborts only non-successful vertices
     mrrDag.getConf().setBoolean(TezConfiguration.TEZ_AM_COMMIT_ALL_OUTPUTS_ON_DAG_SUCCESS, false);
@@ -1588,14 +1610,14 @@ public class TestDAGImpl {
       dispatcher.getEventHandler().handle(new VertexEventTaskCompleted(
           TezTaskID.getInstance(v.getVertexId(), 0), TaskState.SUCCEEDED));
       dispatcher.await();
-      Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-      Assert.assertEquals(i+1, mrrDag.getSuccessfulVertices());
+      assertEquals(VertexState.SUCCEEDED, v.getState());
+      assertEquals(i+1, mrrDag.getSuccessfulVertices());
       for (OutputCommitter c : v.getOutputCommitters().values()) {
         CountingOutputCommitter committer= (CountingOutputCommitter) c;
-        Assert.assertEquals(0, committer.abortCounter);
-        Assert.assertEquals(1, committer.commitCounter);
-        Assert.assertEquals(1, committer.initCounter);
-        Assert.assertEquals(1, committer.setupCounter);
+        assertEquals(0, committer.abortCounter);
+        assertEquals(1, committer.commitCounter);
+        assertEquals(1, committer.initCounter);
+        assertEquals(1, committer.setupCounter);
       }
     }
 
@@ -1604,32 +1626,33 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new VertexEvent(
         errorVertex.getVertexId(), VertexEventType.V_INTERNAL_ERROR));
     dispatcher.await();
-    Assert.assertEquals(VertexState.ERROR, errorVertex.getState());
+    assertEquals(VertexState.ERROR, errorVertex.getState());
 
     dispatcher.await();
-    Assert.assertEquals(DAGState.ERROR, mrrDag.getState());
+    assertEquals(DAGState.ERROR, mrrDag.getState());
 
     for (Vertex vertex : mrrDag.vertices.values()) {
       for (OutputCommitter c : vertex.getOutputCommitters().values()) {
         CountingOutputCommitter committer= (CountingOutputCommitter) c;
         if (vertex == errorVertex) {
-          Assert.assertEquals(1, committer.abortCounter);
-          Assert.assertEquals(0, committer.commitCounter);
-          Assert.assertEquals(1, committer.initCounter);
-          Assert.assertEquals(1, committer.setupCounter);
+          assertEquals(1, committer.abortCounter);
+          assertEquals(0, committer.commitCounter);
+          assertEquals(1, committer.initCounter);
+          assertEquals(1, committer.setupCounter);
         } else {
           // abort operation should take no side effort on the successful commit
-          Assert.assertEquals(1, committer.abortCounter);
-          Assert.assertEquals(1, committer.commitCounter);
-          Assert.assertEquals(1, committer.initCounter);
-          Assert.assertEquals(1, committer.setupCounter);
+          assertEquals(1, committer.abortCounter);
+          assertEquals(1, committer.commitCounter);
+          assertEquals(1, committer.initCounter);
+          assertEquals(1, committer.setupCounter);
         }
       }
     }
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexReRunning() {
     initDAG(dag);
     dag.dagScheduler = mock(DAGScheduler.class);
@@ -1644,24 +1667,24 @@ public class TestDAGImpl {
         TezTaskID.getInstance(vId, 1), TaskState.SUCCEEDED));
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertEquals(1, dag.getSuccessfulVertices());
-    Assert.assertEquals(1, dag.numCompletedVertices);
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(1, dag.getSuccessfulVertices());
+    assertEquals(1, dag.numCompletedVertices);
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskReschedule(TezTaskID.getInstance(vId, 0)));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
-    Assert.assertEquals(0, dag.getSuccessfulVertices());
-    Assert.assertEquals(0, dag.numCompletedVertices);
+    assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(0, dag.getSuccessfulVertices());
+    assertEquals(0, dag.numCompletedVertices);
 
     dispatcher.getEventHandler().handle(new VertexEventTaskCompleted(
         TezTaskID.getInstance(vId, 0), TaskState.SUCCEEDED));
           dispatcher.await();
 
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertEquals(1, dag.getSuccessfulVertices());
-    Assert.assertEquals(1, dag.numCompletedVertices);
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(1, dag.getSuccessfulVertices());
+    assertEquals(1, dag.numCompletedVertices);
 
   }
 
@@ -1674,21 +1697,23 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventTerminateDag(dagId, DAGTerminationCause.DAG_KILL, null));
     dispatcher.await();
 
-    Assert.assertEquals(DAGState.KILLED, dag.getState());
+    assertEquals(DAGState.KILLED, dag.getState());
     for (int i = 0 ; i < 6; ++i ) {
       TezVertexID vId = TezVertexID.getInstance(dagId, i);
       Vertex v = dag.getVertex(vId);
-      Assert.assertEquals(VertexState.KILLED, v.getState());
+      assertEquals(VertexState.KILLED, v.getState());
     }
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testKillRunningDAG() {
     _testTerminateRunningDAG(DAGTerminationCause.DAG_KILL);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testServiceErrorRunningDAG() {
     _testTerminateRunningDAG(DAGTerminationCause.SERVICE_PLUGIN_ERROR);
   }
@@ -1709,35 +1734,37 @@ public class TestDAGImpl {
         TezTaskID.getInstance(vId0, 0), TaskState.SUCCEEDED));
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.SUCCEEDED, v0.getState());
-    Assert.assertEquals(VertexState.RUNNING, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v0.getState());
+    assertEquals(VertexState.RUNNING, v1.getState());
 
     dispatcher.getEventHandler().handle(new DAGEventTerminateDag(dagId, terminationCause, null));
     dispatcher.await();
 
-    Assert.assertEquals(DAGState.TERMINATING, dag.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v0.getState());
-    Assert.assertEquals(VertexState.TERMINATING, v1.getState());
+    assertEquals(DAGState.TERMINATING, dag.getState());
+    assertEquals(VertexState.SUCCEEDED, v0.getState());
+    assertEquals(VertexState.TERMINATING, v1.getState());
     for (int i = 2 ; i < 6; ++i ) {
       TezVertexID vId = TezVertexID.getInstance(dagId, i);
       Vertex v = dag.getVertex(vId);
-      Assert.assertEquals(VertexState.KILLED, v.getState());
+      assertEquals(VertexState.KILLED, v.getState());
     }
-    Assert.assertEquals(1, dag.getSuccessfulVertices());
+    assertEquals(1, dag.getSuccessfulVertices());
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidEvent() {
     dispatcher.getEventHandler().handle(
         new DAGEventStartDag(dagId, null));
     dispatcher.await();
-    Assert.assertEquals(DAGState.ERROR, dag.getState());
+    assertEquals(DAGState.ERROR, dag.getState());
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
-  @Ignore // Duplicate completions from a vertex would be a bug. Invalid test.
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  @Disabled // Duplicate completions from a vertex would be a bug. Invalid test.
   public void testVertexSuccessfulCompletionUpdates() {
     initDAG(dag);
     startDAG(dag);
@@ -1748,8 +1775,8 @@ public class TestDAGImpl {
           TezVertexID.getInstance(dagId, 0), VertexState.SUCCEEDED));
     }
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
-    Assert.assertEquals(1, dag.getSuccessfulVertices());
+    assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(1, dag.getSuccessfulVertices());
 
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 1), VertexState.SUCCEEDED));
@@ -1762,12 +1789,13 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 5), VertexState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(DAGState.SUCCEEDED, dag.getState());
-    Assert.assertEquals(6, dag.getSuccessfulVertices());
+    assertEquals(DAGState.SUCCEEDED, dag.getState());
+    assertEquals(6, dag.getSuccessfulVertices());
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testGetDAGStatusWithWait() throws TezException {
     initDAG(dag);
     startDAG(dag);
@@ -1779,37 +1807,41 @@ public class TestDAGImpl {
           TezVertexID.getInstance(dagId, i), VertexState.SUCCEEDED));
     }
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
-    Assert.assertEquals(5, dag.getSuccessfulVertices());
+    assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(5, dag.getSuccessfulVertices());
 
     long dagStatusStartTime = System.currentTimeMillis();
     DAGStatusBuilder dagStatus = dag.getDAGStatus(EnumSet.noneOf(StatusGetOpts.class), 2000l);
     long dagStatusEndTime = System.currentTimeMillis();
     long diff = dagStatusEndTime - dagStatusStartTime;
-    Assert.assertTrue(diff >= 0 && diff < 2500);
-    Assert.assertEquals(DAGStatusBuilder.State.RUNNING, dagStatus.getState());
+    assertTrue(diff >= 0 && diff < 2500);
+    assertEquals(DAGStatusBuilder.State.RUNNING, dagStatus.getState());
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testGetDAGStatusReturnOnDagSucceeded() throws InterruptedException, TezException {
     runTestGetDAGStatusReturnOnDagFinished(DAGStatus.State.SUCCEEDED);
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testGetDAGStatusReturnOnDagFailed() throws InterruptedException, TezException {
     runTestGetDAGStatusReturnOnDagFinished(DAGStatus.State.FAILED);
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testGetDAGStatusReturnOnDagKilled() throws InterruptedException, TezException {
     runTestGetDAGStatusReturnOnDagFinished(DAGStatus.State.KILLED);
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testGetDAGStatusReturnOnDagError() throws InterruptedException, TezException {
     runTestGetDAGStatusReturnOnDagFinished(DAGStatus.State.ERROR);
   }
@@ -1827,10 +1859,10 @@ public class TestDAGImpl {
           TezVertexID.getInstance(dagId, 0), VertexState.SUCCEEDED));
     }
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
-    Assert.assertEquals(5, dag.getSuccessfulVertices());
+    assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(5, dag.getSuccessfulVertices());
     // Verify that dagStatus is running state
-    Assert.assertEquals(DAGStatus.State.RUNNING, dag.getDAGStatus(EnumSet.noneOf(StatusGetOpts.class),
+    assertEquals(State.RUNNING, dag.getDAGStatus(EnumSet.noneOf(StatusGetOpts.class),
         10000L).getState());
 
     ReentrantLock lock = new ReentrantLock();
@@ -1851,15 +1883,15 @@ public class TestDAGImpl {
 
     // Sleep for 2 seconds. Then mark the last vertex is successful.
     Thread.sleep(2000l);
-    if (testState == DAGStatus.State.SUCCEEDED) {
+    if (testState == State.SUCCEEDED) {
       dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
           TezVertexID.getInstance(dagId, 5), VertexState.SUCCEEDED));
-    } else if (testState == DAGStatus.State.FAILED) {
+    } else if (testState == State.FAILED) {
       dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
           TezVertexID.getInstance(dagId, 5), VertexState.FAILED));
-    } else if (testState == DAGStatus.State.KILLED) {
+    } else if (testState == State.KILLED) {
       dispatcher.getEventHandler().handle(new DAGEventTerminateDag(dagId, DAGTerminationCause.DAG_KILL, null));
-    } else if (testState == DAGStatus.State.ERROR) {
+    } else if (testState == State.ERROR) {
       dispatcher.getEventHandler().handle(new DAGEventStartDag(dagId, new LinkedList<URL>()));
     } else {
       throw new UnsupportedOperationException("Unsupported state for test: " + testState);
@@ -1877,16 +1909,17 @@ public class TestDAGImpl {
     }
 
     long diff = statusCheckRunnable.dagStatusEndTime - statusCheckRunnable.dagStatusStartTime;
-    Assert.assertNotNull(statusCheckRunnable.dagStatus);
-    Assert.assertTrue("Status: " + statusCheckRunnable.dagStatus.getState()
-            + ", Diff:" + diff, diff >= 0 && diff < 3500);
-    Assert.assertEquals(testState, statusCheckRunnable.dagStatus.getState());
+    assertNotNull(statusCheckRunnable.dagStatus);
+    assertTrue(diff >= 0 && diff < 3500, "Status: " + statusCheckRunnable.dagStatus.getState()
+            + ", Diff:" + diff);
+    assertEquals(testState, statusCheckRunnable.dagStatus.getState());
     t1.join();
   }
 
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexFailureHandling() {
     initDAG(dag);
     startDAG(dag);
@@ -1895,31 +1928,33 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 0), VertexState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 1), VertexState.SUCCEEDED));
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 2), VertexState.FAILED));
     dispatcher.await();
-    Assert.assertEquals(DAGState.FAILED, dag.getState());
-    Assert.assertEquals(2, dag.getSuccessfulVertices());
+    assertEquals(DAGState.FAILED, dag.getState());
+    assertEquals(2, dag.getSuccessfulVertices());
 
     // Expect running vertices to be killed on first failure
     for (int i = 3; i < 6; ++i) {
       TezVertexID vId = TezVertexID.getInstance(dagId, i);
       Vertex v = dag.getVertex(vId);
-      Assert.assertEquals(VertexState.KILLED, v.getState());
+      assertEquals(VertexState.KILLED, v.getState());
     }
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGKill() {
     _testDAGTerminate(DAGTerminationCause.DAG_KILL);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGServiceError() {
     _testDAGTerminate(DAGTerminationCause.SERVICE_PLUGIN_ERROR);
   }
@@ -1935,15 +1970,15 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 0), VertexState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 1), VertexState.SUCCEEDED));
     dispatcher.getEventHandler().handle(new DAGEventTerminateDag(dagId, terminationCause, null));
     dispatcher.await();
-    Assert.assertEquals(terminationCause.getFinishedState(), dag.getState());
-    Assert.assertEquals(terminationCause, dag.getTerminationCause());
-    Assert.assertEquals(2, dag.getSuccessfulVertices());
+    assertEquals(terminationCause.getFinishedState(), dag.getState());
+    assertEquals(terminationCause, dag.getTerminationCause());
+    assertEquals(2, dag.getSuccessfulVertices());
 
     int killedCount = 0;
     for (Map.Entry<TezVertexID, Vertex> vEntry : dag.getVertices().entrySet()) {
@@ -1951,16 +1986,17 @@ public class TestDAGImpl {
         killedCount++;
       }
     }
-    Assert.assertEquals(4, killedCount);
+    assertEquals(4, killedCount);
 
     for (Vertex v : dag.getVertices().values()) {
-      Assert.assertEquals(VertexTerminationCause.DAG_TERMINATED, v.getTerminationCause());
+      assertEquals(VertexTerminationCause.DAG_TERMINATED, v.getTerminationCause());
     }
 
-    Assert.assertEquals(1, dagFinishEventHandler.dagFinishEvents);
+    assertEquals(1, dagFinishEventHandler.dagFinishEvents);
   }
 
-  @Test (timeout = 5000L)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 5000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   @SuppressWarnings("unchecked")
   public void testDAGHang() throws Exception {
     conf.setBoolean(
@@ -1995,22 +2031,24 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 5), VertexState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(DAGState.COMMITTING, dag.getState());
+    assertEquals(DAGState.COMMITTING, dag.getState());
     DAGEventCommitCompleted dagEvent = new DAGEventCommitCompleted(
         dagId, outputKey, false , new RuntimeException("test"));
     doThrow(new RuntimeException("test")).when(
         dag).logJobHistoryUnsuccesfulEvent(any(), any());
     dag.handle(dagEvent);
     dispatcher.await();
-    Assert.assertTrue("DAG did not terminate!", dag.getInternalState() == DAGState.FAILED);
+    assertSame(dag.getInternalState(), DAGState.FAILED, "DAG did not terminate!");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGKillVertexSuccessAfterTerminated() {
     _testDAGKillVertexSuccessAfterTerminated(DAGTerminationCause.DAG_KILL);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGServiceErrorVertexSuccessAfterTerminated() {
     _testDAGKillVertexSuccessAfterTerminated(DAGTerminationCause.SERVICE_PLUGIN_ERROR);
   }
@@ -2025,14 +2063,14 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 0), VertexState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 1), VertexState.SUCCEEDED));
     dispatcher.getEventHandler().handle(new DAGEventTerminateDag(dagId, terminationCause, null));
     dispatcher.await();
 
-    Assert.assertEquals(terminationCause.getFinishedState(), dag.getState());
+    assertEquals(terminationCause.getFinishedState(), dag.getState());
 
     // Vertex SUCCESS gets processed after the DAG has reached the KILLED state. Should be ignored.
     for (int i = 2; i < 6; ++i) {
@@ -2047,22 +2085,24 @@ public class TestDAGImpl {
         killedCount++;
       }
     }
-    Assert.assertEquals(4, killedCount);
+    assertEquals(4, killedCount);
 
-    Assert.assertEquals(terminationCause, dag.getTerminationCause());
-    Assert.assertEquals(2, dag.getSuccessfulVertices());
+    assertEquals(terminationCause, dag.getTerminationCause());
+    assertEquals(2, dag.getSuccessfulVertices());
     for (Vertex v : dag.getVertices().values()) {
-      Assert.assertEquals(VertexTerminationCause.DAG_TERMINATED, v.getTerminationCause());
+      assertEquals(VertexTerminationCause.DAG_TERMINATED, v.getTerminationCause());
     }
-    Assert.assertEquals(1, dagFinishEventHandler.dagFinishEvents);
+    assertEquals(1, dagFinishEventHandler.dagFinishEvents);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGKillPending() {
     _testDAGKillPending(DAGTerminationCause.DAG_KILL);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGServiceErrorPending() {
     _testDAGKillPending(DAGTerminationCause.SERVICE_PLUGIN_ERROR);
   }
@@ -2077,7 +2117,7 @@ public class TestDAGImpl {
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 0), VertexState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(DAGState.RUNNING, dag.getState());
+    assertEquals(DAGState.RUNNING, dag.getState());
 
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 1), VertexState.SUCCEEDED));
@@ -2089,31 +2129,32 @@ public class TestDAGImpl {
     dispatcher.await();
     dispatcher.getEventHandler().handle(new DAGEventTerminateDag(dagId, terminationCause, null));
     dispatcher.await();
-    Assert.assertEquals(terminationCause.getFinishedState(), dag.getState());
+    assertEquals(terminationCause.getFinishedState(), dag.getState());
 
     dispatcher.getEventHandler().handle(new DAGEventVertexCompleted(
         TezVertexID.getInstance(dagId, 5), VertexState.KILLED));
     dispatcher.await();
-    Assert.assertEquals(terminationCause.getFinishedState(), dag.getState());
-    Assert.assertEquals(5, dag.getSuccessfulVertices());
-    Assert.assertEquals(dag.getVertex(TezVertexID.getInstance(dagId, 5)).getTerminationCause(),
+    assertEquals(terminationCause.getFinishedState(), dag.getState());
+    assertEquals(5, dag.getSuccessfulVertices());
+    assertEquals(dag.getVertex(TezVertexID.getInstance(dagId, 5)).getTerminationCause(),
         VertexTerminationCause.DAG_TERMINATED);
-    Assert.assertEquals(1, dagFinishEventHandler.dagFinishEvents);
+    assertEquals(1, dagFinishEventHandler.dagFinishEvents);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConfiguration() throws AMUserCodeException {
     initDAG(dag);
     // dag override the default configuration
-    Assert.assertEquals(3, dag.getConf().getInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS,
+    assertEquals(3, dag.getConf().getInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS,
         TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS_DEFAULT));
     Vertex v1 = dag.getVertex("vertex1");
     Vertex v2 = dag.getVertex("vertex2");
     // v1 override the dagConfiguration
-    Assert.assertEquals(2, v1.getConf().getInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS,
+    assertEquals(2, v1.getConf().getInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS,
         TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS_DEFAULT));
     // v2 inherit the configuration from dag
-    Assert.assertEquals(3, v2.getConf().getInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS,
+    assertEquals(3, v2.getConf().getInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS,
         TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS_DEFAULT));
   }
 
@@ -2345,7 +2386,8 @@ public class TestDAGImpl {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCounterLimits() {
     initDAG(mrrDag);
     dispatcher.await();
@@ -2361,18 +2403,18 @@ public class TestDAGImpl {
       dispatcher.getEventHandler().handle(new VertexEventTaskCompleted(
         TezTaskID.getInstance(v.getVertexId(), 0), TaskState.SUCCEEDED));
       dispatcher.await();
-      Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-      Assert.assertEquals(i+1, mrrDag.getSuccessfulVertices());
+      assertEquals(VertexState.SUCCEEDED, v.getState());
+      assertEquals(i+1, mrrDag.getSuccessfulVertices());
     }
 
-    Assert.assertEquals(3, mrrDag.getSuccessfulVertices());
-    Assert.assertEquals(DAGState.FAILED, mrrDag.getState());
-    Assert.assertTrue("Diagnostics should contain counter limits error message",
-        StringUtils.join(mrrDag.getDiagnostics(), ",").contains("Counters limit exceeded"));
+    assertEquals(3, mrrDag.getSuccessfulVertices());
+    assertEquals(DAGState.FAILED, mrrDag.getState());
+    assertTrue(StringUtils.join(mrrDag.getDiagnostics(), ",").contains("Counters limit exceeded"), "Diagnostics should contain counter limits error message");
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTotalContainersUsedCounter() {
     DAGImpl spy = getDagSpy();
 
@@ -2385,12 +2427,13 @@ public class TestDAGImpl {
     // 2 calls to addUsedContainer
     verify(spy, times(2)).addUsedContainer(any(Container.class));
     // 2 containers were used
-    Assert.assertEquals(2,
+    assertEquals(2,
         spy.getAllCounters().getGroup(DAGCounter.class.getName()).findCounter(DAGCounter.TOTAL_CONTAINERS_USED.name())
             .getValue());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNodesUsedCounter() {
     DAGImpl spy = getDagSpy();
 
@@ -2415,14 +2458,14 @@ public class TestDAGImpl {
     verify(spy, times(4)).addUsedContainer(any(Container.class));
 
     // 2 distinct node hosts were seen: localhost, otherhost
-    Assert.assertEquals(2,
+    assertEquals(2,
         spy.getAllCounters().getGroup(DAGCounter.class.getName()).findCounter(DAGCounter.NODE_USED_COUNT.name())
             .getValue());
 
-    Assert.assertTrue(spy.nodesUsedByCurrentDAG.contains("localhost"));
-    Assert.assertTrue(spy.nodesUsedByCurrentDAG.contains("otherhost"));
+    assertTrue(spy.nodesUsedByCurrentDAG.contains("localhost"));
+    assertTrue(spy.nodesUsedByCurrentDAG.contains("otherhost"));
 
-    Assert.assertEquals(10,
+    assertEquals(10,
         spy.getAllCounters().getGroup(DAGCounter.class.getName())
             .findCounter(DAGCounter.NODE_TOTAL_COUNT.name())
             .getValue());

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGRecovery.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGRecovery.java
@@ -18,7 +18,8 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.Credentials;
@@ -135,11 +137,11 @@ import org.apache.tez.runtime.api.impl.TezEvent;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -303,20 +305,20 @@ public class TestDAGRecovery {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     MockDNSToSwitchMapping.initializeMockRackResolver();
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
-  @Before
+  @BeforeEach
   public void setup() {
     conf = new Configuration();
     conf.setBoolean(TezConfiguration.TEZ_AM_CONTAINER_REUSE_ENABLED, false);
     appAttemptId = ApplicationAttemptId.newInstance(
         ApplicationId.newInstance(100, 1), 1);
     dagId = TezDAGID.getInstance(appAttemptId.getApplicationId(), 1);
-    Assert.assertNotNull(dagId);
+    assertNotNull(dagId);
     dagPlan = createDAGPlan();
     dispatcher = new DrainDispatcher();
     fsTokens = new Credentials();
@@ -533,7 +535,7 @@ public class TestDAGRecovery {
   }
 
 
-  @After
+  @AfterEach
   public void teardown() {
     dispatcher.await();
     dispatcher.stop();
@@ -551,7 +553,8 @@ public class TestDAGRecovery {
    * RecoveryEvents: SummaryEvent_DAGFinishedEvent(SUCCEEDED)
    * Recover dag to SUCCEEDED and all of its vertices to SUCCEEDED
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGRecoverFromDesiredSucceeded() {
     DAGEventRecoverEvent recoveryEvent = new DAGEventRecoverEvent(dagId, DAGState.SUCCEEDED, dagRecoveryData);
     dag.handle(recoveryEvent);
@@ -569,7 +572,8 @@ public class TestDAGRecovery {
    * RecoveryEvents: SummaryEvent_DAGFinishedEvent(FAILED)
    * Recover dag to FAILED and all of its vertices to FAILED
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGRecoverFromDesiredFailed() {
     DAGEventRecoverEvent recoveryEvent = new DAGEventRecoverEvent(dagId, DAGState.FAILED, dagRecoveryData);
     dag.handle(recoveryEvent);
@@ -587,7 +591,8 @@ public class TestDAGRecovery {
    * RecoveryEvents: SummaryEvent_DAGFinishedEvent(KILLED)
    * Recover dag to KILLED and all of its vertices to KILLED
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGRecoverFromDesiredKilled() {
     DAGEventRecoverEvent recoveryEvent = new DAGEventRecoverEvent(dagId, DAGState.KILLED, dagRecoveryData);
     dag.handle(recoveryEvent);
@@ -605,7 +610,8 @@ public class TestDAGRecovery {
    * RecoveryEvents: SummaryEvent_DAGFinishedEvent(ERROR)
    * Recover dag to ERROR and all of its vertices to ERROR
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGRecoverFromDesiredError() {
     DAGEventRecoverEvent recoveryEvent = new DAGEventRecoverEvent(dagId, DAGState.ERROR, dagRecoveryData);
     dag.handle(recoveryEvent);
@@ -623,7 +629,8 @@ public class TestDAGRecovery {
    * RecoveryEvents: DAGSubmittedEvent
    * Recover it as normal dag execution
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGRecoverFromNew() {
     DAGEventRecoverEvent recoveryEvent = new DAGEventRecoverEvent(dagId, dagRecoveryData);
     dag.handle(recoveryEvent);
@@ -636,7 +643,8 @@ public class TestDAGRecovery {
    * RecoveryEvents: DAGSubmittedEvent, DAGInitializedEvent
    * Recover it as normal dag execution
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGRecoverFromInited() {
     DAGInitializedEvent dagInitedEvent = new DAGInitializedEvent(dagId, dagInitedTime,
         "user", "dagName", null);
@@ -649,7 +657,8 @@ public class TestDAGRecovery {
     assertEquals(dagInitedTime, dag.initTime);
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGRecoverFromStarted() {
     DAGInitializedEvent dagInitedEvent = new DAGInitializedEvent(dagId, dagInitedTime,
         "user", "dagName", null);
@@ -683,7 +692,8 @@ public class TestDAGRecovery {
    *
    * Reinitialize V1 again.
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexRecoverFromNew() {
     initMockDAGRecoveryDataForVertex();
 
@@ -708,7 +718,8 @@ public class TestDAGRecovery {
    *
    * Reinitialize V1 again.
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexRecoverFromInited() {
     initMockDAGRecoveryDataForVertex();
     List<TezEvent> inputGeneratedTezEvents = new ArrayList<TezEvent>();
@@ -778,7 +789,8 @@ public class TestDAGRecovery {
    *
    * Reinitialize V1 again.
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexRecoverFromStart() {
     initMockDAGRecoveryDataForVertex();
     List<TezEvent> inputGeneratedTezEvents = new ArrayList<TezEvent>();
@@ -813,7 +825,8 @@ public class TestDAGRecovery {
    *
    * V1 skip initialization.
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexRecoverWithSetParallelismCalledFlag() {
     initMockDAGRecoveryDataForVertex();
     List<TezEvent> inputGeneratedTezEvents = new ArrayList<TezEvent>();
@@ -851,7 +864,8 @@ public class TestDAGRecovery {
    *
    * V1 skip initialization.
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexRecoverFromVertexTaskStart() {
     initMockDAGRecoveryDataForVertex();
     List<TezEvent> inputGeneratedTezEvents = new ArrayList<TezEvent>();
@@ -900,7 +914,8 @@ public class TestDAGRecovery {
    * V2 skip initialization.
    * V3 skip initialization.
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleVertexRecoverFromVertexTaskStart() {
     initMockDAGRecoveryDataForVertex();
     List<TezEvent> inputGeneratedTezEvents = new ArrayList<TezEvent>();
@@ -994,7 +1009,8 @@ public class TestDAGRecovery {
    *  V2 skip initialization.
    *  Reinitialize V3 again. Since V3 is dependent on V1
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleVertexRecoverFromVertex() {
     initMockDAGRecoveryDataForVertex();
     List<TezEvent> inputGeneratedTezEvents = new ArrayList<TezEvent>();
@@ -1092,7 +1108,8 @@ public class TestDAGRecovery {
    * RecoveryEvent: TaskFinishedEvent(KILLED)
    * Recover it to KILLED
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskRecoverFromKilled() {
     initMockDAGRecoveryDataForTask();
     TaskFinishedEvent taskFinishedEvent = new TaskFinishedEvent(t1v1Id, "v1",
@@ -1113,7 +1130,8 @@ public class TestDAGRecovery {
    * RecoveryEvent: TaskStartedEvent
    * Recover it to Scheduled
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskRecoverFromStarted() {
     initMockDAGRecoveryDataForTask();
     TaskStartedEvent taskStartedEvent = new TaskStartedEvent(t1v1Id, "v1", 0L, 0L);
@@ -1132,7 +1150,8 @@ public class TestDAGRecovery {
    * RecoveryEvent: TaskStartedEvent -> TaskFinishedEvent
    * Recover it to Scheduled
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskRecoverFromSucceeded() {
     initMockDAGRecoveryDataForTask();
     TaskStartedEvent taskStartedEvent = new TaskStartedEvent(t1v1Id, "v1", 0L, 0L);
@@ -1200,7 +1219,8 @@ public class TestDAGRecovery {
    * RecoveryEvents: TaskAttemptFinishedEvent (FAILED)
    * Recover it to FAILED
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTARecoverFromNewToFailed() {
     initMockDAGRecoveryDataForTaskAttempt();
     TaskAttemptFinishedEvent taFinishedEvent = new TaskAttemptFinishedEvent(
@@ -1229,7 +1249,8 @@ public class TestDAGRecovery {
    * RecoveryEvents: TaskAttemptFinishedEvent (KILLED)
    * Recover it to KILLED
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTARecoverFromNewToKilled() {
     initMockDAGRecoveryDataForTaskAttempt();
     TaskAttemptFinishedEvent taFinishedEvent = new TaskAttemptFinishedEvent(
@@ -1256,7 +1277,8 @@ public class TestDAGRecovery {
    * RecoveryEvents: TaskAttemptStartedEvent
    * Recover it to KILLED
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTARecoverFromRunning() {
     initMockDAGRecoveryDataForTaskAttempt();
     TaskAttemptStartedEvent taStartedEvent = new TaskAttemptStartedEvent(
@@ -1281,7 +1303,8 @@ public class TestDAGRecovery {
    * RecoveryEvents: TaskAttemptStartedEvent -> TaskAttemptFinishedEvent (SUCCEEDED)
    * Recover it to SUCCEEDED
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTARecoverFromSucceeded() {
     initMockDAGRecoveryDataForTaskAttempt();
     TaskAttemptStartedEvent taStartedEvent = new TaskAttemptStartedEvent(
@@ -1375,7 +1398,8 @@ public class TestDAGRecovery {
    * RecoveryEvents: TaskAttemptStartedEvent -> TaskAttemptFinishedEvent (FAILED)
    * Recover it to FAILED
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTARecoverFromFailed() {
     initMockDAGRecoveryDataForTaskAttempt();
     TaskAttemptStartedEvent taStartedEvent = new TaskAttemptStartedEvent(
@@ -1406,7 +1430,8 @@ public class TestDAGRecovery {
    * RecoveryEvents: TaskAttemptStartedEvent -> TaskAttemptFinishedEvent (KILLED)
    * Recover it to KILLED
    */
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTARecoverFromKilled() {
     initMockDAGRecoveryDataForTaskAttempt();
     TaskAttemptStartedEvent taStartedEvent = new TaskAttemptStartedEvent(

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGScheduler.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGScheduler.java
@@ -18,9 +18,11 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.yarn.event.EventHandler;
 import org.apache.tez.dag.app.dag.DAG;
@@ -35,8 +37,8 @@ import org.apache.tez.dag.records.TezVertexID;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestDAGScheduler {
 
@@ -51,7 +53,8 @@ public class TestDAGScheduler {
   }
 
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGSchedulerNaturalOrder() {
     MockEventHandler mockEventHandler = new MockEventHandler();
     DAG mockDag = mock(DAG.class);
@@ -79,20 +82,21 @@ public class TestDAGScheduler {
     DAGScheduler scheduler = new DAGSchedulerNaturalOrder(mockDag,
         mockEventHandler);
     scheduler.scheduleTaskEx(event);
-    Assert.assertEquals(10, mockEventHandler.event.getPriorityHighLimit());
-    Assert.assertEquals(12, mockEventHandler.event.getPriorityLowLimit());
+    assertEquals(10, mockEventHandler.event.getPriorityHighLimit());
+    assertEquals(12, mockEventHandler.event.getPriorityLowLimit());
     scheduler.scheduleTaskEx(event);
-    Assert.assertEquals(25, mockEventHandler.event.getPriorityHighLimit());
-    Assert.assertEquals(27, mockEventHandler.event.getPriorityLowLimit());
+    assertEquals(25, mockEventHandler.event.getPriorityHighLimit());
+    assertEquals(27, mockEventHandler.event.getPriorityLowLimit());
     scheduler.scheduleTaskEx(event);
-    Assert.assertEquals(40, mockEventHandler.event.getPriorityHighLimit());
-    Assert.assertEquals(42, mockEventHandler.event.getPriorityLowLimit());
+    assertEquals(40, mockEventHandler.event.getPriorityHighLimit());
+    assertEquals(42, mockEventHandler.event.getPriorityLowLimit());
     scheduler.scheduleTaskEx(event);
-    Assert.assertEquals(43, mockEventHandler.event.getPriorityHighLimit());
-    Assert.assertEquals(45, mockEventHandler.event.getPriorityLowLimit());
+    assertEquals(43, mockEventHandler.event.getPriorityHighLimit());
+    assertEquals(45, mockEventHandler.event.getPriorityLowLimit());
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConcurrencyLimit() {
     MockEventHandler mockEventHandler = new MockEventHandler();
     DAG mockDag = mock(DAG.class);
@@ -118,17 +122,17 @@ public class TestDAGScheduler {
     when(mockAttempt.getTaskAttemptID()).thenReturn(TezTaskAttemptID.getInstance(tId0, 0));
     scheduler.scheduleTask(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_SCHEDULE, mockAttempt));
-    Assert.assertEquals(1, mockEventHandler.events.size());
+    assertEquals(1, mockEventHandler.events.size());
     mockAttempt = mock(TaskAttempt.class);
     when(mockAttempt.getTaskAttemptID()).thenReturn(TezTaskAttemptID.getInstance(tId0, 1));
     scheduler.scheduleTask(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_SCHEDULE, mockAttempt));
-    Assert.assertEquals(2, mockEventHandler.events.size());
+    assertEquals(2, mockEventHandler.events.size());
     mockAttempt = mock(TaskAttempt.class);
     when(mockAttempt.getTaskAttemptID()).thenReturn(TezTaskAttemptID.getInstance(tId0, 2));
     scheduler.scheduleTask(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_SCHEDULE, mockAttempt));
-    Assert.assertEquals(3, mockEventHandler.events.size());
+    assertEquals(3, mockEventHandler.events.size());
 
     mockEventHandler.events.clear();
     List<TaskAttempt> mockAttempts = Lists.newArrayList();
@@ -143,8 +147,8 @@ public class TestDAGScheduler {
     when(mockAttempt.getTaskAttemptID()).thenReturn(TezTaskAttemptID.getInstance(tId1, requested++));
     scheduler.scheduleTask(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_SCHEDULE, mockAttempt));
-    Assert.assertEquals(scheduled+1, mockEventHandler.events.size()); // scheduled
-    Assert.assertEquals(mockAttempts.get(scheduled).getTaskAttemptID(),
+    assertEquals(scheduled+1, mockEventHandler.events.size()); // scheduled
+    assertEquals(mockAttempts.get(scheduled).getTaskAttemptID(),
         mockEventHandler.events.get(scheduled).getTaskAttemptID()); // matches order
     scheduled++;
 
@@ -153,8 +157,8 @@ public class TestDAGScheduler {
     when(mockAttempt.getTaskAttemptID()).thenReturn(TezTaskAttemptID.getInstance(tId1, requested++));
     scheduler.scheduleTask(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_SCHEDULE, mockAttempt));
-    Assert.assertEquals(scheduled+1, mockEventHandler.events.size()); // scheduled
-    Assert.assertEquals(mockAttempts.get(scheduled).getTaskAttemptID(),
+    assertEquals(scheduled+1, mockEventHandler.events.size()); // scheduled
+    assertEquals(mockAttempts.get(scheduled).getTaskAttemptID(),
         mockEventHandler.events.get(scheduled).getTaskAttemptID()); // matches order
     scheduled++;
 
@@ -163,44 +167,45 @@ public class TestDAGScheduler {
     when(mockAttempt.getTaskAttemptID()).thenReturn(TezTaskAttemptID.getInstance(tId1, requested++));
     scheduler.scheduleTask(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_SCHEDULE, mockAttempt));
-    Assert.assertEquals(scheduled, mockEventHandler.events.size()); // buffered
+    assertEquals(scheduled, mockEventHandler.events.size()); // buffered
 
     mockAttempt = mock(TaskAttempt.class);
     mockAttempts.add(mockAttempt);
     when(mockAttempt.getTaskAttemptID()).thenReturn(TezTaskAttemptID.getInstance(tId1, requested++));
     scheduler.scheduleTask(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_SCHEDULE, mockAttempt));
-    Assert.assertEquals(scheduled, mockEventHandler.events.size()); // buffered
+    assertEquals(scheduled, mockEventHandler.events.size()); // buffered
 
     scheduler.taskCompleted(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_COMPLETED, mockAttempts.get(completed++)));
-    Assert.assertEquals(scheduled+1, mockEventHandler.events.size()); // scheduled
-    Assert.assertEquals(mockAttempts.get(scheduled).getTaskAttemptID(),
-        mockEventHandler.events.get(scheduled).getTaskAttemptID()); // matches order
-    scheduled++;
-
-    scheduler.taskCompleted(new DAGEventSchedulerUpdate(
-        DAGEventSchedulerUpdate.UpdateType.TA_COMPLETED, mockAttempts.get(completed++)));
-    Assert.assertEquals(scheduled+1, mockEventHandler.events.size()); // scheduled
-    Assert.assertEquals(mockAttempts.get(scheduled).getTaskAttemptID(),
+    assertEquals(scheduled+1, mockEventHandler.events.size()); // scheduled
+    assertEquals(mockAttempts.get(scheduled).getTaskAttemptID(),
         mockEventHandler.events.get(scheduled).getTaskAttemptID()); // matches order
     scheduled++;
 
     scheduler.taskCompleted(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_COMPLETED, mockAttempts.get(completed++)));
-    Assert.assertEquals(scheduled, mockEventHandler.events.size()); // no extra scheduling
+    assertEquals(scheduled+1, mockEventHandler.events.size()); // scheduled
+    assertEquals(mockAttempts.get(scheduled).getTaskAttemptID(),
+        mockEventHandler.events.get(scheduled).getTaskAttemptID()); // matches order
+    scheduled++;
+
+    scheduler.taskCompleted(new DAGEventSchedulerUpdate(
+        DAGEventSchedulerUpdate.UpdateType.TA_COMPLETED, mockAttempts.get(completed++)));
+    assertEquals(scheduled, mockEventHandler.events.size()); // no extra scheduling
 
     mockAttempt = mock(TaskAttempt.class);
     mockAttempts.add(mockAttempt);
     when(mockAttempt.getTaskAttemptID()).thenReturn(TezTaskAttemptID.getInstance(tId1, requested++));
     scheduler.scheduleTask(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_SCHEDULE, mockAttempt));
-    Assert.assertEquals(scheduled+1, mockEventHandler.events.size()); // scheduled
-    Assert.assertEquals(mockAttempts.get(scheduled).getTaskAttemptID(),
+    assertEquals(scheduled+1, mockEventHandler.events.size()); // scheduled
+    assertEquals(mockAttempts.get(scheduled).getTaskAttemptID(),
         mockEventHandler.events.get(scheduled).getTaskAttemptID()); // matches order
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConcurrencyLimitWithKilledNonRunningTask() {
     MockEventHandler mockEventHandler = new MockEventHandler();
     DAG mockDag = mock(DAG.class);
@@ -229,8 +234,8 @@ public class TestDAGScheduler {
     when(mockAttempt.getTaskAttemptID()).thenReturn(TezTaskAttemptID.getInstance(tId0, requested++));
     scheduler.scheduleTask(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_SCHEDULE, mockAttempt));
-    Assert.assertEquals(scheduled+1, mockEventHandler.events.size()); // scheduled
-    Assert.assertEquals(mockAttempts.get(scheduled).getTaskAttemptID(),
+    assertEquals(scheduled+1, mockEventHandler.events.size()); // scheduled
+    assertEquals(mockAttempts.get(scheduled).getTaskAttemptID(),
         mockEventHandler.events.get(scheduled).getTaskAttemptID()); // matches order
     scheduled++;
 
@@ -239,19 +244,19 @@ public class TestDAGScheduler {
     when(mockAttempt.getTaskAttemptID()).thenReturn(TezTaskAttemptID.getInstance(tId0, requested++));
     scheduler.scheduleTask(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_SCHEDULE, mockAttempt));
-    Assert.assertEquals(scheduled, mockEventHandler.events.size()); // buffered
+    assertEquals(scheduled, mockEventHandler.events.size()); // buffered
 
     mockAttempt = mock(TaskAttempt.class);
     mockAttempts.add(mockAttempt);
     when(mockAttempt.getTaskAttemptID()).thenReturn(TezTaskAttemptID.getInstance(tId0, requested++));
     scheduler.scheduleTask(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_SCHEDULE, mockAttempt));
-    Assert.assertEquals(scheduled, mockEventHandler.events.size()); // buffered
+    assertEquals(scheduled, mockEventHandler.events.size()); // buffered
 
     scheduler.taskCompleted(new DAGEventSchedulerUpdate(
         DAGEventSchedulerUpdate.UpdateType.TA_COMPLETED, mockAttempts.get(1)));
-    Assert.assertEquals(scheduled, mockEventHandler.events.size()); // buffered
-    Assert.assertEquals(mockAttempts.get(0).getTaskAttemptID(),
+    assertEquals(scheduled, mockEventHandler.events.size()); // buffered
+    assertEquals(mockAttempts.get(0).getTaskAttemptID(),
         mockEventHandler.events.get(0).getTaskAttemptID()); // matches order
   }
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGSchedulerNaturalOrderControlled.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestDAGSchedulerNaturalOrderControlled.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.event.Event;
@@ -43,13 +44,15 @@ import org.apache.tez.dag.records.TezTaskAttemptID;
 import org.apache.tez.dag.records.TezTaskID;
 import org.apache.tez.dag.records.TezVertexID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 public class TestDAGSchedulerNaturalOrderControlled {
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleFlow() {
     EventHandler eventHandler = mock(EventHandler.class);
     DAG dag = createMockDag();
@@ -107,7 +110,8 @@ public class TestDAGSchedulerNaturalOrderControlled {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSourceRequestDelayed() {
     // ShuffleVertexHandler - slowstart simulation
     EventHandler eventHandler = mock(EventHandler.class);
@@ -176,7 +180,8 @@ public class TestDAGSchedulerNaturalOrderControlled {
 
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testParallelismUpdated() {
     EventHandler eventHandler = mock(EventHandler.class);
     DAG dag = createMockDag();
@@ -227,7 +232,8 @@ public class TestDAGSchedulerNaturalOrderControlled {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleRequestsForSameTask() {
     EventHandler eventHandler = mock(EventHandler.class);
     DAG dag = createMockDag();

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestEdge.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestEdge.java
@@ -18,9 +18,11 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -41,6 +43,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.io.DataInputByteBuffer;
 import org.apache.hadoop.io.Writable;
@@ -74,13 +77,14 @@ import org.apache.tez.test.EdgeManagerForTest;
 
 import com.google.common.collect.Maps;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 public class TestEdge {
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOneToOneEdgeManager() {
     EdgeManagerPluginContext mockContext = mock(EdgeManagerPluginContext.class);
     when(mockContext.getSourceVertexName()).thenReturn("Source");
@@ -95,22 +99,23 @@ public class TestEdge {
     when(mockContext.getDestinationVertexNumTasks()).thenReturn(4);
     try {
       manager.routeDataMovementEventToDestination(event, 1, 1, destinationTaskAndInputIndices);
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("1-1 source and destination task counts must match"));
+      assertTrue(e.getMessage().contains("1-1 source and destination task counts must match"));
     }
 
     // now make it consistent
     when(mockContext.getDestinationVertexNumTasks()).thenReturn(3);
     manager.routeDataMovementEventToDestination(event, 1, 1, destinationTaskAndInputIndices);
-    Assert.assertEquals(1, destinationTaskAndInputIndices.size());
-    Assert.assertEquals(1, destinationTaskAndInputIndices.entrySet().iterator().next().getKey()
+    assertEquals(1, destinationTaskAndInputIndices.size());
+    assertEquals(1, destinationTaskAndInputIndices.entrySet().iterator().next().getKey()
         .intValue());
-    Assert.assertEquals(0, destinationTaskAndInputIndices.entrySet().iterator().next().getValue()
+    assertEquals(0, destinationTaskAndInputIndices.entrySet().iterator().next().getValue()
         .get(0).intValue());
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOneToOneEdgeManagerODR() {
     EdgeManagerPluginContext mockContext = mock(EdgeManagerPluginContext.class);
     when(mockContext.getSourceVertexName()).thenReturn("Source");
@@ -125,22 +130,23 @@ public class TestEdge {
     when(mockContext.getDestinationVertexNumTasks()).thenReturn(4);
     try {
       manager.routeDataMovementEventToDestination(event, 1, 1, destinationTaskAndInputIndices);
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("1-1 source and destination task counts must match"));
+      assertTrue(e.getMessage().contains("1-1 source and destination task counts must match"));
     }
 
     // now make it consistent
     when(mockContext.getDestinationVertexNumTasks()).thenReturn(3);
     manager.routeDataMovementEventToDestination(event, 1, 1, destinationTaskAndInputIndices);
-    Assert.assertEquals(1, destinationTaskAndInputIndices.size());
-    Assert.assertEquals(1, destinationTaskAndInputIndices.entrySet().iterator().next().getKey()
+    assertEquals(1, destinationTaskAndInputIndices.size());
+    assertEquals(1, destinationTaskAndInputIndices.entrySet().iterator().next().getKey()
         .intValue());
-    Assert.assertEquals(0, destinationTaskAndInputIndices.entrySet().iterator().next().getValue()
+    assertEquals(0, destinationTaskAndInputIndices.entrySet().iterator().next().getValue()
         .get(0).intValue());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testScatterGatherManager() {
     EdgeManagerPluginContext mockContext = mock(EdgeManagerPluginContext.class);
     when(mockContext.getSourceVertexName()).thenReturn("Source");
@@ -151,10 +157,10 @@ public class TestEdge {
     when(mockContext.getDestinationVertexNumTasks()).thenReturn(-1);
     try {
       manager.getNumSourceTaskPhysicalOutputs(0);
-      Assert.fail();
+      fail();
     } catch (IllegalArgumentException e) {
       e.printStackTrace();
-      Assert.assertTrue(e.getMessage()
+      assertTrue(e.getMessage()
           .contains("ScatterGather edge manager must have destination vertex task parallelism specified"));
     }
     when(mockContext.getDestinationVertexNumTasks()).thenReturn(0);
@@ -162,7 +168,8 @@ public class TestEdge {
   }
 
   @SuppressWarnings({ "rawtypes" })
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCompositeEventHandling() throws TezException {
     EventHandler eventHandler = mock(EventHandler.class);
     EdgeProperty edgeProp = EdgeProperty.create(DataMovementType.SCATTER_GATHER,
@@ -226,7 +233,7 @@ public class TestEdge {
       assertEquals(srcTAID.getTaskID().getId(), dmEvent.getTargetIndex());
       byte[] res = new byte[dmEvent.getUserPayload().limit() - dmEvent.getUserPayload().position()];
       dmEvent.getUserPayload().slice().get(res);
-      assertTrue(Arrays.equals("bytes".getBytes(), res));
+      assertArrayEquals("bytes".getBytes(), res);
     }
   }
 
@@ -273,7 +280,8 @@ public class TestEdge {
     return taskAttemptID;
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidPhysicalInputCount() throws Exception {
     EventHandler mockEventHandler = mock(EventHandler.class);
     Edge edge = new Edge(EdgeProperty.create(
@@ -290,14 +298,15 @@ public class TestEdge {
     edge.initialize();
     try {
       edge.getDestinationSpec(0);
-      Assert.fail();
+      fail();
     } catch (AMUserCodeException e) {
       e.printStackTrace();
       assertTrue(e.getCause().getMessage().contains("PhysicalInputCount should not be negative"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidPhysicalOutputCount() throws Exception {
     EventHandler mockEventHandler = mock(EventHandler.class);
     Edge edge = new Edge(EdgeProperty.create(
@@ -314,14 +323,15 @@ public class TestEdge {
     edge.initialize();
     try {
       edge.getSourceSpec(0);
-      Assert.fail();
+      fail();
     } catch (AMUserCodeException e) {
       e.printStackTrace();
       assertTrue(e.getCause().getMessage().contains("PhysicalOutputCount should not be negative"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidConsumerNumber() throws Exception {
     EventHandler mockEventHandler = mock(EventHandler.class);
     Edge edge = new Edge(EdgeProperty.create(
@@ -341,14 +351,15 @@ public class TestEdge {
           new EventMetaData(EventProducerConsumerType.INPUT, "v2", "v1",
               TezTaskAttemptID.getInstance(TezTaskID.getInstance(v2Id, 1), 1)));
       edge.sendTezEventToSourceTasks(ireEvent);
-      Assert.fail();
+      fail();
     } catch (AMUserCodeException e) {
       e.printStackTrace();
       assertTrue(e.getCause().getMessage().contains("ConsumerTaskNum must be positive"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidSourceTaskIndex() throws Exception {
     EventHandler mockEventHandler = mock(EventHandler.class);
     Edge edge = new Edge(EdgeProperty.create(
@@ -368,7 +379,7 @@ public class TestEdge {
           new EventMetaData(EventProducerConsumerType.INPUT, "v2", "v1",
               TezTaskAttemptID.getInstance(TezTaskID.getInstance(v2Id, 1), 1)));
       edge.sendTezEventToSourceTasks(ireEvent);
-      Assert.fail();
+      fail();
     } catch (AMUserCodeException e) {
       e.printStackTrace();
       assertTrue(e.getCause().getMessage().contains("SourceTaskIndex should not be negative"));
@@ -481,7 +492,8 @@ public class TestEdge {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEdgeManagerPluginCtxGetVertexGroupName() throws TezException {
     EdgeManagerPluginDescriptor edgeManagerDescriptor =
       EdgeManagerPluginDescriptor.create(EdgeManagerForTest.class.getName());

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestImmediateStartVertexManager.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestImmediateStartVertexManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anySet;
 import static org.mockito.Mockito.anyString;
@@ -30,6 +31,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.dag.api.EdgeManagerPluginDescriptor;
 import org.apache.tez.dag.api.EdgeProperty;
@@ -42,15 +44,16 @@ import org.apache.tez.dag.api.event.VertexState;
 import org.apache.tez.dag.api.event.VertexStateUpdate;
 import org.apache.tez.runtime.api.TaskAttemptIdentifier;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 public class TestImmediateStartVertexManager {
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasic() {
     HashMap<String, EdgeProperty> mockInputVertices =
         new HashMap<String, EdgeProperty>();
@@ -113,7 +116,7 @@ public class TestImmediateStartVertexManager {
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3,
         VertexState.CONFIGURED));
     verify(mockContext, times(1)).scheduleTasks(anyList());
-    Assert.assertEquals(4, scheduledTasks.size());
+    assertEquals(4, scheduledTasks.size());
 
     // simulate race between onVertexStarted and notifications
     scheduledTasks.clear();
@@ -128,7 +131,7 @@ public class TestImmediateStartVertexManager {
     raceManager.initialize();
     raceManager.onVertexStarted(emptyCompletions);
     verify(mockContext, times(2)).scheduleTasks(anyList());
-    Assert.assertEquals(4, scheduledTasks.size());
+    assertEquals(4, scheduledTasks.size());
   }
 
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestRootInputVertexManager.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestRootInputVertexManager.java
@@ -21,8 +21,9 @@ package org.apache.tez.dag.app.dag.impl;
 import static org.apache.tez.dag.app.dag.impl.RootInputVertexManager.TEZ_ROOT_INPUT_VERTEX_MANAGER_ENABLE_SLOW_START;
 import static org.apache.tez.dag.app.dag.impl.RootInputVertexManager.TEZ_ROOT_INPUT_VERTEX_MANAGER_MAX_SRC_FRACTION;
 import static org.apache.tez.dag.app.dag.impl.RootInputVertexManager.TEZ_ROOT_INPUT_VERTEX_MANAGER_MIN_SRC_FRACTION;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.doAnswer;
@@ -36,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.common.TezUtils;
@@ -57,8 +59,8 @@ import org.apache.tez.runtime.api.events.InputDataInformationEvent;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -66,7 +68,8 @@ public class TestRootInputVertexManager {
 
   List<TaskAttemptIdentifier> emptyCompletions = null;
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEventsFromMultipleInputs() throws IOException {
 
     VertexManagerPluginContext context = mock(VertexManagerPluginContext.class);
@@ -102,7 +105,8 @@ public class TestRootInputVertexManager {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConfigureFromMultipleInputs() throws IOException {
 
     VertexManagerPluginContext context = mock(VertexManagerPluginContext.class);
@@ -138,7 +142,8 @@ public class TestRootInputVertexManager {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRootInputVertexManagerSlowStart() {
     Configuration conf = new Configuration();
     RootInputVertexManager manager = null;
@@ -188,8 +193,8 @@ public class TestRootInputVertexManager {
         VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2,
         VertexState.CONFIGURED));
-    Assert.assertEquals(manager.pendingTasks.size(), 0);
-    Assert.assertEquals(scheduledTasks.size(), 3); // all tasks scheduled
+    assertEquals(manager.pendingTasks.size(), 0);
+    assertEquals(scheduledTasks.size(), 3); // all tasks scheduled
 
     when(mockContext.getVertexNumTasks(mockSrcVertexId1)).thenReturn(2);
     when(mockContext.getVertexNumTasks(mockSrcVertexId2)).thenReturn(2);
@@ -197,27 +202,27 @@ public class TestRootInputVertexManager {
     try {
       // source vertex have some tasks. min < 0.
       manager = createRootInputVertexManager(conf, mockContext, -0.1f, 0.0f);
-      Assert.assertTrue(false); // should not come here
+      fail(); // should not come here
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "Invalid values for slowStartMinFraction"));
     }
 
     try {
       // source vertex have some tasks. max > 1.
       manager = createRootInputVertexManager(conf, mockContext, 0.0f, 95.0f);
-      Assert.assertTrue(false); // should not come here
+      fail(); // should not come here
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "Invalid values for slowStartMinFraction"));
     }
 
     try {
       // source vertex have some tasks. min > max
       manager = createRootInputVertexManager(conf, mockContext, 0.5f, 0.3f);
-      Assert.assertTrue(false); // should not come here
+      fail(); // should not come here
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "Invalid values for slowStartMinFraction"));
     }
 
@@ -234,9 +239,9 @@ public class TestRootInputVertexManager {
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2,
         VertexState.CONFIGURED));
 
-    Assert.assertEquals(3, manager.pendingTasks.size());
-    Assert.assertEquals(numTasks*2, manager.totalNumSourceTasks);
-    Assert.assertEquals(0, manager.numSourceTasksCompleted);
+    assertEquals(3, manager.pendingTasks.size());
+    assertEquals(numTasks*2, manager.totalNumSourceTasks);
+    assertEquals(0, manager.numSourceTasksCompleted);
     float completedTasksThreshold = 0.975f * numTasks;
     // Finish all tasks before exceeding the threshold
     for (String mockSrcVertex : new String[] { mockSrcVertexId1,
@@ -252,20 +257,20 @@ public class TestRootInputVertexManager {
       }
     }
     // Since we haven't exceeded the threshold, all tasks are still pending
-    Assert.assertEquals(manager.totalTasksToSchedule,
+    assertEquals(manager.totalTasksToSchedule,
         manager.pendingTasks.size());
-    Assert.assertEquals(0, scheduledTasks.size()); // no tasks scheduled
+    assertEquals(0, scheduledTasks.size()); // no tasks scheduled
 
     // Cross the threshold min/max threshold to schedule all tasks
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 0));
-    Assert.assertEquals(3, manager.pendingTasks.size());
-    Assert.assertEquals(0, scheduledTasks.size());
+    assertEquals(3, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size());
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 0));
-    Assert.assertEquals(0, manager.pendingTasks.size());
+    assertEquals(0, manager.pendingTasks.size());
     // all tasks scheduled
-    Assert.assertEquals(manager.totalTasksToSchedule, scheduledTasks.size());
+    assertEquals(manager.totalTasksToSchedule, scheduledTasks.size());
 
     // reset vertices for next test
     when(mockContext.getVertexNumTasks(mockSrcVertexId1)).thenReturn(2);
@@ -274,16 +279,16 @@ public class TestRootInputVertexManager {
     // source vertex have some tasks. min, max, 0
     manager = createRootInputVertexManager(conf, mockContext, 0.0f, 0.0f);
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertEquals(manager.totalTasksToSchedule, 3);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 0);
+    assertEquals(manager.totalTasksToSchedule, 3);
+    assertEquals(manager.numSourceTasksCompleted, 0);
     // all source vertices need to be configured
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1,
         VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2,
         VertexState.CONFIGURED));
-    Assert.assertEquals(manager.totalNumSourceTasks, 4);
-    Assert.assertEquals(manager.pendingTasks.size(), 0);
-    Assert.assertEquals(scheduledTasks.size(), 3); // all tasks scheduled
+    assertEquals(manager.totalNumSourceTasks, 4);
+    assertEquals(manager.pendingTasks.size(), 0);
+    assertEquals(scheduledTasks.size(), 3); // all tasks scheduled
 
     // min, max > 0 and min, max
     manager = createRootInputVertexManager(conf, mockContext, 0.25f, 0.25f);
@@ -292,23 +297,23 @@ public class TestRootInputVertexManager {
         VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2,
         VertexState.CONFIGURED));
-    Assert.assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
-    Assert.assertEquals(manager.totalNumSourceTasks, 4);
+    assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
+    assertEquals(manager.totalNumSourceTasks, 4);
     // task completion from non-bipartite stage does nothing
-    Assert.assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
-    Assert.assertEquals(manager.totalNumSourceTasks, 4);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 0);
+    assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
+    assertEquals(manager.totalNumSourceTasks, 4);
+    assertEquals(manager.numSourceTasksCompleted, 0);
     // task completion on only 1 SG edge does nothing
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 0));
-    Assert.assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
-    Assert.assertEquals(manager.totalNumSourceTasks, 4);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 1);
+    assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
+    assertEquals(manager.totalNumSourceTasks, 4);
+    assertEquals(manager.numSourceTasksCompleted, 1);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 0));
-    Assert.assertEquals(manager.pendingTasks.size(), 0);
-    Assert.assertEquals(scheduledTasks.size(), 3); // all tasks scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 2);
+    assertEquals(manager.pendingTasks.size(), 0);
+    assertEquals(scheduledTasks.size(), 3); // all tasks scheduled
+    assertEquals(manager.numSourceTasksCompleted, 2);
 
     // min, max > 0 and min, max, absolute max 1.0
     manager = createRootInputVertexManager(conf, mockContext, 1.0f, 1.0f);
@@ -317,29 +322,29 @@ public class TestRootInputVertexManager {
         VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2,
         VertexState.CONFIGURED));
-    Assert.assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
-    Assert.assertEquals(manager.totalNumSourceTasks, 4);
+    assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
+    assertEquals(manager.totalNumSourceTasks, 4);
     // task completion from non-bipartite stage does nothing
-    Assert.assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
-    Assert.assertEquals(manager.totalNumSourceTasks, 4);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 0);
+    assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
+    assertEquals(manager.totalNumSourceTasks, 4);
+    assertEquals(manager.numSourceTasksCompleted, 0);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 0));
-    Assert.assertEquals(manager.pendingTasks.size(), 3);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 1);
+    assertEquals(manager.pendingTasks.size(), 3);
+    assertEquals(manager.numSourceTasksCompleted, 1);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 1));
-    Assert.assertEquals(manager.pendingTasks.size(), 3);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 2);
+    assertEquals(manager.pendingTasks.size(), 3);
+    assertEquals(manager.numSourceTasksCompleted, 2);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 0));
-    Assert.assertEquals(manager.pendingTasks.size(), 3);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 3);
+    assertEquals(manager.pendingTasks.size(), 3);
+    assertEquals(manager.numSourceTasksCompleted, 3);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 1));
-    Assert.assertEquals(manager.pendingTasks.size(), 0);
-    Assert.assertEquals(scheduledTasks.size(), 3); // all tasks scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 4);
+    assertEquals(manager.pendingTasks.size(), 0);
+    assertEquals(scheduledTasks.size(), 3); // all tasks scheduled
+    assertEquals(manager.numSourceTasksCompleted, 4);
 
     // min, max > 0 and min, max
     manager = createRootInputVertexManager(conf, mockContext, 1.0f, 1.0f);
@@ -348,29 +353,29 @@ public class TestRootInputVertexManager {
         VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2,
         VertexState.CONFIGURED));
-    Assert.assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
-    Assert.assertEquals(manager.totalNumSourceTasks, 4);
+    assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
+    assertEquals(manager.totalNumSourceTasks, 4);
     // task completion from non-bipartite stage does nothing
-    Assert.assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
-    Assert.assertEquals(manager.totalNumSourceTasks, 4);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 0);
+    assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
+    assertEquals(manager.totalNumSourceTasks, 4);
+    assertEquals(manager.numSourceTasksCompleted, 0);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 0));
-    Assert.assertEquals(manager.pendingTasks.size(), 3);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 1);
+    assertEquals(manager.pendingTasks.size(), 3);
+    assertEquals(manager.numSourceTasksCompleted, 1);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 1));
-    Assert.assertEquals(manager.pendingTasks.size(), 3);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 2);
+    assertEquals(manager.pendingTasks.size(), 3);
+    assertEquals(manager.numSourceTasksCompleted, 2);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 0));
-    Assert.assertEquals(manager.pendingTasks.size(), 3);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 3);
+    assertEquals(manager.pendingTasks.size(), 3);
+    assertEquals(manager.numSourceTasksCompleted, 3);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 1));
-    Assert.assertEquals(manager.pendingTasks.size(), 0);
-    Assert.assertEquals(scheduledTasks.size(), 3); // all tasks scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 4);
+    assertEquals(manager.pendingTasks.size(), 0);
+    assertEquals(scheduledTasks.size(), 3); // all tasks scheduled
+    assertEquals(manager.numSourceTasksCompleted, 4);
 
     // reset vertices for next test
     when(mockContext.getVertexNumTasks(mockSrcVertexId1)).thenReturn(4);
@@ -383,39 +388,39 @@ public class TestRootInputVertexManager {
         VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2,
         VertexState.CONFIGURED));
-    Assert.assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
-    Assert.assertEquals(manager.totalNumSourceTasks, 8);
+    assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
+    assertEquals(manager.totalNumSourceTasks, 8);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 0));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 1));
-    Assert.assertEquals(manager.pendingTasks.size(), 3);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 2);
+    assertEquals(manager.pendingTasks.size(), 3);
+    assertEquals(manager.numSourceTasksCompleted, 2);
     // completion of same task again should not get counted
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 1));
-    Assert.assertEquals(manager.pendingTasks.size(), 3);
-    Assert.assertEquals(manager.numSourceTasksCompleted, 2);
+    assertEquals(manager.pendingTasks.size(), 3);
+    assertEquals(manager.numSourceTasksCompleted, 2);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 1));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 0));
-    Assert.assertEquals(manager.pendingTasks.size(), 1);
-    Assert.assertEquals(scheduledTasks.size(), 2); // 2 task scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 4);
+    assertEquals(manager.pendingTasks.size(), 1);
+    assertEquals(scheduledTasks.size(), 2); // 2 task scheduled
+    assertEquals(manager.numSourceTasksCompleted, 4);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 2));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 2));
-    Assert.assertEquals(manager.pendingTasks.size(), 0);
-    Assert.assertEquals(scheduledTasks.size(), 1); // 1 tasks scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 6);
+    assertEquals(manager.pendingTasks.size(), 0);
+    assertEquals(scheduledTasks.size(), 1); // 1 tasks scheduled
+    assertEquals(manager.numSourceTasksCompleted, 6);
     scheduledTasks.clear();
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 3)); // we are done. no action
-    Assert.assertEquals(manager.pendingTasks.size(), 0);
-    Assert.assertEquals(scheduledTasks.size(), 0); // no task scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 7);
+    assertEquals(manager.pendingTasks.size(), 0);
+    assertEquals(scheduledTasks.size(), 0); // no task scheduled
+    assertEquals(manager.numSourceTasksCompleted, 7);
 
     // min, max > and min < max
     manager = createRootInputVertexManager(conf, mockContext, 0.25f, 1.0f);
@@ -424,8 +429,8 @@ public class TestRootInputVertexManager {
         VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2,
         VertexState.CONFIGURED));
-    Assert.assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
-    Assert.assertEquals(manager.totalNumSourceTasks, 8);
+    assertEquals(manager.pendingTasks.size(), 3); // no tasks scheduled
+    assertEquals(manager.totalNumSourceTasks, 8);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 0));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
@@ -434,23 +439,23 @@ public class TestRootInputVertexManager {
         mockSrcVertexId1, 1));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 0));
-    Assert.assertEquals(manager.pendingTasks.size(), 2);
-    Assert.assertEquals(scheduledTasks.size(), 1); // 1 task scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 4);
+    assertEquals(manager.pendingTasks.size(), 2);
+    assertEquals(scheduledTasks.size(), 1); // 1 task scheduled
+    assertEquals(manager.numSourceTasksCompleted, 4);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 2));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 2));
-    Assert.assertEquals(manager.pendingTasks.size(), 1);
-    Assert.assertEquals(scheduledTasks.size(), 1); // 1 task scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 6);
+    assertEquals(manager.pendingTasks.size(), 1);
+    assertEquals(scheduledTasks.size(), 1); // 1 task scheduled
+    assertEquals(manager.numSourceTasksCompleted, 6);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 3));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 3));
-    Assert.assertEquals(manager.pendingTasks.size(), 0);
-    Assert.assertEquals(scheduledTasks.size(), 1); // no task scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 8);
+    assertEquals(manager.pendingTasks.size(), 0);
+    assertEquals(scheduledTasks.size(), 1); // no task scheduled
+    assertEquals(manager.numSourceTasksCompleted, 8);
 
     // if there is single task to schedule, it should be schedule when src
     // completed fraction is more than min slow start fraction
@@ -462,36 +467,36 @@ public class TestRootInputVertexManager {
         VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2,
         VertexState.CONFIGURED));
-    Assert.assertEquals(manager.pendingTasks.size(), 1); // no tasks scheduled
-    Assert.assertEquals(manager.totalNumSourceTasks, 8);
+    assertEquals(manager.pendingTasks.size(), 1); // no tasks scheduled
+    assertEquals(manager.totalNumSourceTasks, 8);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 0));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 1));
-    Assert.assertEquals(manager.pendingTasks.size(), 1);
-    Assert.assertEquals(scheduledTasks.size(), 0); // no task scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 2);
+    assertEquals(manager.pendingTasks.size(), 1);
+    assertEquals(scheduledTasks.size(), 0); // no task scheduled
+    assertEquals(manager.numSourceTasksCompleted, 2);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 1));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 0));
-    Assert.assertEquals(manager.pendingTasks.size(), 0);
-    Assert.assertEquals(scheduledTasks.size(), 1); // 1 task scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 4);
+    assertEquals(manager.pendingTasks.size(), 0);
+    assertEquals(scheduledTasks.size(), 1); // 1 task scheduled
+    assertEquals(manager.numSourceTasksCompleted, 4);
     scheduledTasks.clear();
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 2));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId2, 2));
-    Assert.assertEquals(manager.pendingTasks.size(), 0);
-    Assert.assertEquals(scheduledTasks.size(), 0); // no task scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 6);
+    assertEquals(manager.pendingTasks.size(), 0);
+    assertEquals(scheduledTasks.size(), 0); // no task scheduled
+    assertEquals(manager.numSourceTasksCompleted, 6);
     scheduledTasks.clear();
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(
         mockSrcVertexId1, 3)); // we are done. no action
-    Assert.assertEquals(manager.pendingTasks.size(), 0);
-    Assert.assertEquals(scheduledTasks.size(), 0); // no task scheduled
-    Assert.assertEquals(manager.numSourceTasksCompleted, 7);
+    assertEquals(manager.pendingTasks.size(), 0);
+    assertEquals(scheduledTasks.size(), 0); // no task scheduled
+    assertEquals(manager.numSourceTasksCompleted, 7);
   }
 
   @Test
@@ -520,10 +525,10 @@ public class TestRootInputVertexManager {
 
     // check initialization
     manager = createRootInputVertexManager(conf, mockContext, 0.1f, 0.1f);
-    Assert.assertEquals(0, manager.numSourceTasksCompleted);
+    assertEquals(0, manager.numSourceTasksCompleted);
     manager.onVertexStarted(Collections.singletonList(
       createTaskAttemptIdentifier(mockSrcVertexId1, 0)));
-    Assert.assertEquals(1, manager.numSourceTasksCompleted);
+    assertEquals(1, manager.numSourceTasksCompleted);
   }
 
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestTaskAttempt.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestTaskAttempt.java
@@ -18,9 +18,13 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
@@ -43,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -130,10 +135,10 @@ import org.apache.tez.serviceplugins.api.TaskCommunicator;
 
 import com.google.common.collect.Maps;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -154,12 +159,12 @@ public class TestTaskAttempt {
   ServicePluginInfo servicePluginInfo = new ServicePluginInfo()
       .setContainerLauncherName(TezConstants.getTezYarnServicePluginName());
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     MockDNSToSwitchMapping.initializeMockRackResolver();
   }
 
-  @Before
+  @BeforeEach
   public void setupTest() {
     appCtx = mock(AppContext.class);
     when(appCtx.getAMConf()).thenReturn(new Configuration());
@@ -189,7 +194,8 @@ public class TestTaskAttempt {
     when(appContext.getNodeTracker()).thenReturn(nodeTracker);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLocalityRequest() {
     TaskAttemptImpl.ScheduleTaskattemptTransition sta =
         new TaskAttemptImpl.ScheduleTaskattemptTransition();
@@ -225,11 +231,12 @@ public class TestTaskAttempt {
     assertEquals(3, taImpl.taskHosts.size());
     for (int i = 0; i < 3; i++) {
       String host = ("host" + (i + 1));
-      assertEquals(host, true, taImpl.taskHosts.contains(host));
+      assertTrue(taImpl.taskHosts.contains(host), host);
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRetriesAtSamePriorityConfig() {
 
     // Override the test defaults to setup the config change
@@ -269,19 +276,20 @@ public class TestTaskAttempt {
     sta.transition(taImpl, sEvent);
     verify(eventHandler, times(1)).handle(arg.capture());
     AMSchedulerEventTALaunchRequest launchEvent = (AMSchedulerEventTALaunchRequest) arg.getValue();
-    Assert.assertEquals(2, launchEvent.getPriority());
-    Assert.assertEquals(1, launchEvent.getLocationHint().getHosts().size());
-    Assert.assertTrue(launchEvent.getLocationHint().getHosts().contains("host1"));
+    assertEquals(2, launchEvent.getPriority());
+    assertEquals(1, launchEvent.getLocationHint().getHosts().size());
+    assertTrue(launchEvent.getLocationHint().getHosts().contains("host1"));
 
     // Verify priority for a retried attempt is the same
     sta.transition(taImplReScheduled, sEvent);
     verify(eventHandler, times(2)).handle(arg.capture());
     launchEvent = (AMSchedulerEventTALaunchRequest) arg.getValue();
-    Assert.assertEquals(2, launchEvent.getPriority());
-    Assert.assertNull(launchEvent.getLocationHint());
+    assertEquals(2, launchEvent.getPriority());
+    assertNull(launchEvent.getLocationHint());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPriority() {
     TaskAttemptImpl.ScheduleTaskattemptTransition sta =
         new TaskAttemptImpl.ScheduleTaskattemptTransition();
@@ -307,36 +315,37 @@ public class TestTaskAttempt {
     sta.transition(taImpl, sEvent);
     verify(eventHandler, times(1)).handle(arg.capture());
     AMSchedulerEventTALaunchRequest launchEvent = (AMSchedulerEventTALaunchRequest)arg.getValue();
-    Assert.assertEquals(2, launchEvent.getPriority());
+    assertEquals(2, launchEvent.getPriority());
     sta.transition(taImplReScheduled, sEvent);
     verify(eventHandler, times(2)).handle(arg.capture());
     launchEvent = (AMSchedulerEventTALaunchRequest)arg.getValue();
-    Assert.assertEquals(1, launchEvent.getPriority());
+    assertEquals(1, launchEvent.getPriority());
 
     when(sEvent.getPriorityLowLimit()).thenReturn(6);
     when(sEvent.getPriorityHighLimit()).thenReturn(4);
     sta.transition(taImpl, sEvent);
     verify(eventHandler, times(3)).handle(arg.capture());
     launchEvent = (AMSchedulerEventTALaunchRequest)arg.getValue();
-    Assert.assertEquals(5, launchEvent.getPriority());
+    assertEquals(5, launchEvent.getPriority());
     sta.transition(taImplReScheduled, sEvent);
     verify(eventHandler, times(4)).handle(arg.capture());
     launchEvent = (AMSchedulerEventTALaunchRequest)arg.getValue();
-    Assert.assertEquals(4, launchEvent.getPriority());
+    assertEquals(4, launchEvent.getPriority());
 
     when(sEvent.getPriorityLowLimit()).thenReturn(5);
     when(sEvent.getPriorityHighLimit()).thenReturn(5);
     sta.transition(taImpl, sEvent);
     verify(eventHandler, times(5)).handle(arg.capture());
     launchEvent = (AMSchedulerEventTALaunchRequest)arg.getValue();
-    Assert.assertEquals(5, launchEvent.getPriority());
+    assertEquals(5, launchEvent.getPriority());
     sta.transition(taImplReScheduled, sEvent);
     verify(eventHandler, times(6)).handle(arg.capture());
     launchEvent = (AMSchedulerEventTALaunchRequest)arg.getValue();
-    Assert.assertEquals(5, launchEvent.getPriority());
+    assertEquals(5, launchEvent.getPriority());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Tests that an attempt is made to resolve the localized hosts to racks.
   // TODO Move to the client post TEZ-125.
   public void testHostResolveAttempt() throws Exception {
@@ -382,7 +391,8 @@ public class TestTaskAttempt {
     assertEquals(0, expected.size());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Ensure the dag does not go into an error state if a attempt kill is
   // received while STARTING
   public void testLaunchFailedWhileKilling() throws Exception {
@@ -426,9 +436,7 @@ public class TestTaskAttempt {
         TaskAttemptTerminationCause.TERMINATED_BY_CLIENT));
     assertEquals(TaskAttemptStateInternal.KILL_IN_PROGRESS, taImpl.getInternalState());
     taImpl.handle(new TaskAttemptEventTezEventUpdate(taImpl.getTaskAttemptID(), Collections.EMPTY_LIST));
-    assertFalse(
-        "InternalError occurred trying to handle TA_TEZ_EVENT_UPDATE in KILL_IN_PROGRESS state",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred trying to handle TA_TEZ_EVENT_UPDATE in KILL_IN_PROGRESS state");
     // At some KILLING state.
     taImpl.handle(new TaskAttemptEventKillRequest(taskAttemptID, null,
         TaskAttemptTerminationCause.TERMINATED_BY_CLIENT));
@@ -437,7 +445,8 @@ public class TestTaskAttempt {
     assertFalse(eventHandler.internalError);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Ensure ContainerTerminating and ContainerTerminated is handled correctly by
   // the TaskAttempt
   public void testContainerTerminationWhileRunning() throws Exception {
@@ -485,14 +494,11 @@ public class TestTaskAttempt {
 
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
-    assertEquals("Task attempt is not in the STARTING state", taImpl.getState(),
-        TaskAttemptState.STARTING);
-    assertEquals("Task attempt internal state is not at SUBMITTED", taImpl.getInternalState(),
-        TaskAttemptStateInternal.SUBMITTED);
+    assertEquals(taImpl.getState(), TaskAttemptState.STARTING, "Task attempt is not in the STARTING state");
+    assertEquals(taImpl.getInternalState(), TaskAttemptStateInternal.SUBMITTED, "Task attempt internal state is not at SUBMITTED");
     // At state STARTING.
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals("Task attempt is not in the RUNNING state", taImpl.getState(),
-        TaskAttemptState.RUNNING);
+    assertEquals(taImpl.getState(), TaskAttemptState.RUNNING, "Task attempt is not in the RUNNING state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     int expectedEventsAtRunning = 5;
@@ -500,12 +506,9 @@ public class TestTaskAttempt {
 
     taImpl.handle(new TaskAttemptEventContainerTerminating(taskAttemptID,
         "Terminating", TaskAttemptTerminationCause.APPLICATION_ERROR));
-    assertFalse(
-        "InternalError occurred trying to handle TA_CONTAINER_TERMINATING",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred trying to handle TA_CONTAINER_TERMINATING");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
-    assertEquals("Task attempt is not in the  FAILED state", taImpl.getState(),
-        TaskAttemptState.FAILED);
+    assertEquals(taImpl.getState(), TaskAttemptState.FAILED, "Task attempt is not in the  FAILED state");
 
     assertEquals(1, taImpl.getDiagnostics().size());
     assertEquals("Terminating", taImpl.getDiagnostics().get(0));
@@ -543,7 +546,8 @@ public class TestTaskAttempt {
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Ensure ContainerTerminated is handled correctly by the TaskAttempt
   public void testContainerTerminatedWhileRunning() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
@@ -592,15 +596,12 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
     int expectedEventsAtRunning = 5;
     verify(eventHandler, times(expectedEventsAtRunning)).handle(arg.capture());
-    assertEquals("Task attempt is not in running state", taImpl.getState(),
-        TaskAttemptState.RUNNING);
+    assertEquals(taImpl.getState(), TaskAttemptState.RUNNING, "Task attempt is not in running state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     taImpl.handle(new TaskAttemptEventContainerTerminated(contId, taskAttemptID, "Terminated",
         TaskAttemptTerminationCause.CONTAINER_EXITED));
-    assertFalse(
-        "InternalError occurred trying to handle TA_CONTAINER_TERMINATED",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred trying to handle TA_CONTAINER_TERMINATED");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
     assertEquals("Terminated", taImpl.getDiagnostics().get(0));
     assertEquals(TaskAttemptTerminationCause.CONTAINER_EXITED, taImpl.getTerminationCause());
@@ -631,7 +632,8 @@ public class TestTaskAttempt {
     verify(eventHandler, times(expectedEventAfterTerminated)).handle(arg.capture());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Ensure ContainerTerminating and ContainerTerminated is handled correctly by
   // the TaskAttempt
   public void testContainerTerminatedAfterSuccess() throws Exception {
@@ -680,8 +682,7 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals("Task attempt is not in the RUNNING state", taImpl.getState(),
-        TaskAttemptState.RUNNING);
+    assertEquals(taImpl.getState(), TaskAttemptState.RUNNING, "Task attempt is not in the RUNNING state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     int expectedEventsAtRunning = 5;
@@ -689,8 +690,7 @@ public class TestTaskAttempt {
 
     taImpl.handle(new TaskAttemptEvent(taskAttemptID, TaskAttemptEventType.TA_DONE));
 
-    assertEquals("Task attempt is not in the  SUCCEEDED state", taImpl.getState(),
-        TaskAttemptState.SUCCEEDED);
+    assertEquals(taImpl.getState(), TaskAttemptState.SUCCEEDED, "Task attempt is not in the  SUCCEEDED state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
     assertEquals(0, taImpl.getDiagnostics().size());
 
@@ -722,7 +722,8 @@ public class TestTaskAttempt {
     assertEquals(TaskAttemptTerminationCause.UNKNOWN_ERROR, taImpl.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLastDataEventRecording() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
@@ -769,8 +770,7 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals("Task attempt is not in the RUNNING state", taImpl.getState(),
-        TaskAttemptState.RUNNING);
+    assertEquals(taImpl.getState(), TaskAttemptState.RUNNING, "Task attempt is not in the RUNNING state");
 
     long ts1 = 1024;
     long ts2 = 2048;
@@ -807,7 +807,8 @@ public class TestTaskAttempt {
     assertEquals(mockId2, taImpl.lastDataEvents.get(1).getTaskAttemptId()); // over-write earlier value
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFailure() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
@@ -855,8 +856,7 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals("Task attempt is not in the RUNNING state", taImpl.getState(),
-        TaskAttemptState.RUNNING);
+    assertEquals(taImpl.getState(), TaskAttemptState.RUNNING, "Task attempt is not in the RUNNING state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     int expectedEventsAtRunning = 6;
@@ -871,8 +871,7 @@ public class TestTaskAttempt {
         TaskFailureType.NON_FATAL, "0",
         TaskAttemptTerminationCause.APPLICATION_ERROR));
 
-    assertEquals("Task attempt is not in the  FAIL_IN_PROGRESS state", taImpl.getInternalState(),
-        TaskAttemptStateInternal.FAIL_IN_PROGRESS);
+    assertEquals(taImpl.getInternalState(), TaskAttemptStateInternal.FAIL_IN_PROGRESS, "Task attempt is not in the  FAIL_IN_PROGRESS state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
     assertEquals(1, taImpl.getDiagnostics().size());
     assertEquals("0", taImpl.getDiagnostics().get(0));
@@ -880,9 +879,7 @@ public class TestTaskAttempt {
 
     assertEquals(TaskAttemptStateInternal.FAIL_IN_PROGRESS, taImpl.getInternalState());
     taImpl.handle(new TaskAttemptEventTezEventUpdate(taImpl.getTaskAttemptID(), Collections.EMPTY_LIST));
-    assertFalse(
-        "InternalError occurred trying to handle TA_TEZ_EVENT_UPDATE in FAIL_IN_PROGRESS state",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred trying to handle TA_TEZ_EVENT_UPDATE in FAIL_IN_PROGRESS state");
 
     taImpl.handle(new TaskAttemptEventContainerTerminated(contId, taskAttemptID, "1",
         TaskAttemptTerminationCause.CONTAINER_EXITED));
@@ -914,7 +911,8 @@ public class TestTaskAttempt {
             expectedEventsAfterTerminating), SpeculatorEventTaskAttemptStatusUpdate.class, 2);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFailureFatalError() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
@@ -962,8 +960,7 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals("Task attempt is not in the RUNNING state", taImpl.getState(),
-        TaskAttemptState.RUNNING);
+    assertEquals(taImpl.getState(), TaskAttemptState.RUNNING, "Task attempt is not in the RUNNING state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     int expectedEventsAtRunning = 6;
@@ -978,8 +975,7 @@ public class TestTaskAttempt {
         TaskFailureType.FATAL, "0",
         TaskAttemptTerminationCause.APPLICATION_ERROR));
 
-    assertEquals("Task attempt is not in the  FAIL_IN_PROGRESS state", taImpl.getInternalState(),
-        TaskAttemptStateInternal.FAIL_IN_PROGRESS);
+    assertEquals(taImpl.getInternalState(), TaskAttemptStateInternal.FAIL_IN_PROGRESS, "Task attempt is not in the  FAIL_IN_PROGRESS state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
     assertEquals(1, taImpl.getDiagnostics().size());
     assertEquals("0", taImpl.getDiagnostics().get(0));
@@ -987,9 +983,7 @@ public class TestTaskAttempt {
 
     assertEquals(TaskAttemptStateInternal.FAIL_IN_PROGRESS, taImpl.getInternalState());
     taImpl.handle(new TaskAttemptEventTezEventUpdate(taImpl.getTaskAttemptID(), Collections.EMPTY_LIST));
-    assertFalse(
-        "InternalError occurred trying to handle TA_TEZ_EVENT_UPDATE in FAIL_IN_PROGRESS state",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred trying to handle TA_TEZ_EVENT_UPDATE in FAIL_IN_PROGRESS state");
 
     taImpl.handle(new TaskAttemptEventContainerTerminated(contId, taskAttemptID, "1",
         TaskAttemptTerminationCause.CONTAINER_EXITED));
@@ -1070,8 +1064,7 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals("Task attempt is not in the RUNNING state", taImpl.getState(),
-        TaskAttemptState.RUNNING);
+    assertEquals(taImpl.getState(), TaskAttemptState.RUNNING, "Task attempt is not in the RUNNING state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     when(mockClock.getTime()).thenReturn(100l);
@@ -1085,14 +1078,14 @@ public class TestTaskAttempt {
       taImpl.handle(fEvent);
       fail("Should not fail since the timestamps do not differ by progress interval config");
     } else {
-      Assert.assertEquals("Task Attempt's internal state should be RUNNING!",
-          taImpl.getInternalState(), TaskAttemptStateInternal.RUNNING);
+      assertEquals(taImpl.getInternalState(), TaskAttemptStateInternal.RUNNING, "Task Attempt's internal state should be RUNNING!");
     }
     when(mockClock.getTime()).thenReturn(200l);
     taImpl.handle(new TaskAttemptEventStatusUpdate(
         taskAttemptID, new TaskStatusUpdateEvent(null, 0.1f, null, false)));
     verify(eventHandler, atLeast(1)).handle(arg.capture());
-    Assert.assertTrue("This should have been an attempt failed event!", arg.getValue() instanceof TaskAttemptEventAttemptFailed);
+    assertInstanceOf(TaskAttemptEventAttemptFailed.class, arg.getValue(),
+        "This should have been an attempt failed event!");
   }
 
   @Test
@@ -1140,7 +1133,7 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals("Task attempt is not in the RUNNING state", taImpl.getState(), TaskAttemptState.RUNNING);
+    assertEquals(taImpl.getState(), TaskAttemptState.RUNNING, "Task attempt is not in the RUNNING state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     TezCounters counters = new TezCounters();
@@ -1160,7 +1153,8 @@ public class TestTaskAttempt {
     assertEquals(2, taImpl.getCounters().findCounter("group", "counter").getValue());
   }
 
-  @Test (timeout = 60000L)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 60000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testProgressAfterSubmit() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
@@ -1215,11 +1209,11 @@ public class TestTaskAttempt {
     if (arg.getValue() instanceof  TaskAttemptEvent) {
       taImpl.handle((TaskAttemptEvent) arg.getValue());
     }
-    Assert.assertEquals("Task Attempt's internal state should be SUBMITTED!",
-        taImpl.getInternalState(), TaskAttemptStateInternal.SUBMITTED);
+    assertEquals(taImpl.getInternalState(), TaskAttemptStateInternal.SUBMITTED, "Task Attempt's internal state should be SUBMITTED!");
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNoProgressFail() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
@@ -1268,8 +1262,7 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals("Task attempt is not in the RUNNING state", taImpl.getState(),
-        TaskAttemptState.RUNNING);
+    assertEquals(taImpl.getState(), TaskAttemptState.RUNNING, "Task attempt is not in the RUNNING state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     when(mockClock.getTime()).thenReturn(100l);
@@ -1300,14 +1293,14 @@ public class TestTaskAttempt {
     assertEquals(TaskFailureType.NON_FATAL, fEvent.getTaskFailureType());
     taImpl.handle(fEvent);
 
-    assertEquals("Task attempt is not in the  FAIL_IN_PROGRESS state", taImpl.getInternalState(),
-        TaskAttemptStateInternal.FAIL_IN_PROGRESS);
+    assertEquals(taImpl.getInternalState(), TaskAttemptStateInternal.FAIL_IN_PROGRESS, "Task attempt is not in the  FAIL_IN_PROGRESS state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
     assertEquals(1, taImpl.getDiagnostics().size());
     assertEquals(TaskAttemptTerminationCause.NO_PROGRESS, taImpl.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEventSerializingHash() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     TezDAGID dagID = TezDAGID.getInstance(appId, 1);
@@ -1333,10 +1326,11 @@ public class TestTaskAttempt {
     assertEquals(taEventFail11.getSerializingHash(), tEventKill1.getSerializingHash());
     assertEquals(taEventKill21.getSerializingHash(), tEventFail2.getSerializingHash());
     // events from different tasks may not have the same value
-    assertFalse(tEventFail1.getSerializingHash() == tEventFail2.getSerializingHash());
+    assertNotEquals(tEventFail1.getSerializingHash(), tEventFail2.getSerializingHash());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCompletedAtSubmitted() throws ServicePluginException {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
@@ -1382,8 +1376,7 @@ public class TestTaskAttempt {
 
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
-    assertEquals("Task attempt is not in the RUNNING state", taImpl.getState(),
-        TaskAttemptState.STARTING);
+    assertEquals(taImpl.getState(), TaskAttemptState.STARTING, "Task attempt is not in the RUNNING state");
 
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
@@ -1396,8 +1389,7 @@ public class TestTaskAttempt {
 
     taImpl.handle(new TaskAttemptEvent(taskAttemptID, TaskAttemptEventType.TA_DONE));
 
-    assertEquals("Task attempt is not in the  SUCCEEDED state", taImpl.getState(),
-        TaskAttemptState.SUCCEEDED);
+    assertEquals(taImpl.getState(), TaskAttemptState.SUCCEEDED, "Task attempt is not in the  SUCCEEDED state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
     assertEquals(0, taImpl.getDiagnostics().size());
 
@@ -1418,7 +1410,8 @@ public class TestTaskAttempt {
             expectedEventsAfterTerminating), DAGEventCounterUpdate.class, 1);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSuccess() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
@@ -1466,8 +1459,7 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals("Task attempt is not in the RUNNING state", taImpl.getState(),
-        TaskAttemptState.RUNNING);
+    assertEquals(taImpl.getState(), TaskAttemptState.RUNNING, "Task attempt is not in the RUNNING state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     int expectedEventsAtRunning = 6;
@@ -1481,8 +1473,7 @@ public class TestTaskAttempt {
 
     taImpl.handle(new TaskAttemptEvent(taskAttemptID, TaskAttemptEventType.TA_DONE));
 
-    assertEquals("Task attempt is not in the  SUCCEEDED state", taImpl.getState(),
-        TaskAttemptState.SUCCEEDED);
+    assertEquals(taImpl.getState(), TaskAttemptState.SUCCEEDED, "Task attempt is not in the  SUCCEEDED state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
     assertEquals(0, taImpl.getDiagnostics().size());
 
@@ -1505,7 +1496,8 @@ public class TestTaskAttempt {
             expectedEventsAfterTerminating), SpeculatorEventTaskAttemptStatusUpdate.class, 2);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Ensure Container Preemption race with task completion is handled correctly by
   // the TaskAttempt
   public void testContainerPreemptedAfterSuccess() throws Exception {
@@ -1555,8 +1547,7 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals("Task attempt is not in the RUNNING state", taImpl.getState(),
-        TaskAttemptState.RUNNING);
+    assertEquals(taImpl.getState(), TaskAttemptState.RUNNING, "Task attempt is not in the RUNNING state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     int expectedEventsAtRunning = 5;
@@ -1564,8 +1555,7 @@ public class TestTaskAttempt {
 
     taImpl.handle(new TaskAttemptEvent(taskAttemptID, TaskAttemptEventType.TA_DONE));
 
-    assertEquals("Task attempt is not in the  SUCCEEDED state", taImpl.getState(),
-        TaskAttemptState.SUCCEEDED);
+    assertEquals(taImpl.getState(), TaskAttemptState.SUCCEEDED, "Task attempt is not in the  SUCCEEDED state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
 
     assertEquals(0, taImpl.getDiagnostics().size());
@@ -1598,7 +1588,8 @@ public class TestTaskAttempt {
     assertEquals(TaskAttemptTerminationCause.UNKNOWN_ERROR, taImpl.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Ensure node failure on Successful Non-Leaf tasks cause them to be marked as KILLED
   public void testNodeFailedNonLeafVertex() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
@@ -1647,8 +1638,7 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals("Task attempt is not in the RUNNING state", TaskAttemptState.RUNNING,
-        taImpl.getState());
+    assertEquals(TaskAttemptState.RUNNING, taImpl.getState(), "Task attempt is not in the RUNNING state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     int expectedEventsAtRunning = 5;
@@ -1656,8 +1646,7 @@ public class TestTaskAttempt {
 
     taImpl.handle(new TaskAttemptEvent(taskAttemptID, TaskAttemptEventType.TA_DONE));
 
-    assertEquals("Task attempt is not in the  SUCCEEDED state", TaskAttemptState.SUCCEEDED,
-        taImpl.getState());
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(), "Task attempt is not in the  SUCCEEDED state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
     assertEquals(0, taImpl.getDiagnostics().size());
 
@@ -1680,11 +1669,10 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventNodeFailed(taskAttemptID, "NodeDecomissioned",
         TaskAttemptTerminationCause.NODE_FAILED));
     // Verify in KILLED state
-    assertEquals("Task attempt is not in the  KILLED state", TaskAttemptState.KILLED,
-        taImpl.getState());
+    assertEquals(TaskAttemptState.KILLED, taImpl.getState(), "Task attempt is not in the  KILLED state");
     // verify unregister is not invoked again
     verify(mockHeartbeatHandler, times(1)).unregister(taskAttemptID);
-    assertEquals(true, taImpl.inputFailedReported);
+    assertTrue(taImpl.inputFailedReported);
     // Verify one event to the Task informing it about FAILURE. No events to scheduler. Counter event.
     int expectedEventsNodeFailure = expectedEventsAfterTerminating + 2;
     arg = ArgumentCaptor.forClass(Event.class);
@@ -1694,18 +1682,16 @@ public class TestTaskAttempt {
             expectedEventsNodeFailure), TaskEventTAKilled.class, 1);
 
     // Verify still in KILLED state
-    assertEquals("Task attempt is not in the  KILLED state", TaskAttemptState.KILLED,
-        taImpl.getState());
+    assertEquals(TaskAttemptState.KILLED, taImpl.getState(), "Task attempt is not in the  KILLED state");
     assertEquals(TaskAttemptTerminationCause.NODE_FAILED, taImpl.getTerminationCause());
 
     assertEquals(TaskAttemptStateInternal.KILLED, taImpl.getInternalState());
     taImpl.handle(new TaskAttemptEventTezEventUpdate(taImpl.getTaskAttemptID(), Collections.EMPTY_LIST));
-    assertFalse(
-        "InternalError occurred trying to handle TA_TEZ_EVENT_UPDATE in KILLED state",
-        eventHandler.internalError);
+    assertFalse(eventHandler.internalError, "InternalError occurred trying to handle TA_TEZ_EVENT_UPDATE in KILLED state");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Ensure node failure on Successful Leaf tasks do not cause them to be marked as KILLED
   public void testNodeFailedLeafVertex() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
@@ -1754,8 +1740,7 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals("Task attempt is not in the RUNNING state", TaskAttemptState.RUNNING,
-        taImpl.getState());
+    assertEquals(TaskAttemptState.RUNNING, taImpl.getState(), "Task attempt is not in the RUNNING state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     int expectedEventsAtRunning = 5;
@@ -1763,8 +1748,7 @@ public class TestTaskAttempt {
 
     taImpl.handle(new TaskAttemptEvent(taskAttemptID, TaskAttemptEventType.TA_DONE));
 
-    assertEquals("Task attempt is not in the  SUCCEEDED state", TaskAttemptState.SUCCEEDED,
-        taImpl.getState());
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(), "Task attempt is not in the  SUCCEEDED state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
     assertEquals(0, taImpl.getDiagnostics().size());
 
@@ -1792,15 +1776,15 @@ public class TestTaskAttempt {
     verify(eventHandler, times(expectedEventsNodeFailure)).handle(arg.capture());
 
     // Verify still in SUCCEEDED state
-    assertEquals("Task attempt is not in the  SUCCEEDED state", TaskAttemptState.SUCCEEDED,
-        taImpl.getState());
+    assertEquals(TaskAttemptState.SUCCEEDED, taImpl.getState(), "Task attempt is not in the  SUCCEEDED state");
     // verify unregister is not invoked again
     verify(mockHeartbeatHandler, times(1)).unregister(taskAttemptID);
     // error cause remains as default value
     assertEquals(TaskAttemptTerminationCause.UNKNOWN_ERROR, taImpl.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Verifies that multiple TooManyFetchFailures are handled correctly by the
   // TaskAttempt.
   public void testMultipleOutputFailed() throws Exception {
@@ -1855,8 +1839,7 @@ public class TestTaskAttempt {
     verify(mockHeartbeatHandler).register(taskAttemptID);
     taImpl.handle(new TaskAttemptEvent(taskAttemptID,
         TaskAttemptEventType.TA_DONE));
-    assertEquals("Task attempt is not in succeeded state", taImpl.getState(),
-        TaskAttemptState.SUCCEEDED);
+    assertEquals(taImpl.getState(), TaskAttemptState.SUCCEEDED, "Task attempt is not in succeeded state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
 
     int expectedEventsTillSucceeded = 8;
@@ -1886,13 +1869,11 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventOutputFailed(taskAttemptID, tzEvent, 11));
 
     // failure threshold not met. state is SUCCEEDED
-    assertEquals("Task attempt is not in succeeded state", taImpl.getState(),
-        TaskAttemptState.SUCCEEDED);
+    assertEquals(taImpl.getState(), TaskAttemptState.SUCCEEDED, "Task attempt is not in succeeded state");
 
     // sending same error again doesnt change anything
     taImpl.handle(new TaskAttemptEventOutputFailed(taskAttemptID, tzEvent, 11));
-    assertEquals("Task attempt is not in succeeded state", taImpl.getState(),
-        TaskAttemptState.SUCCEEDED);
+    assertEquals(taImpl.getState(), TaskAttemptState.SUCCEEDED, "Task attempt is not in succeeded state");
     // default value of error cause
     assertEquals(TaskAttemptTerminationCause.UNKNOWN_ERROR, taImpl.getTerminationCause());
 
@@ -1909,7 +1890,7 @@ public class TestTaskAttempt {
     when(mockDAG.getVertex(destVertexID)).thenReturn(destVertex);
     taImpl.handle(new TaskAttemptEventOutputFailed(taskAttemptID, tzEvent, 11));
 
-    assertEquals("Task attempt is not in FAILED state", TaskAttemptState.FAILED, taImpl.getState());
+    assertEquals(TaskAttemptState.FAILED, taImpl.getState(), "Task attempt is not in FAILED state");
     assertEquals(TaskAttemptTerminationCause.OUTPUT_LOST, taImpl.getTerminationCause());
     // verify unregister is not invoked again
     verify(mockHeartbeatHandler, times(1)).unregister(taskAttemptID);
@@ -1918,9 +1899,9 @@ public class TestTaskAttempt {
     finishEvent = (TaskAttemptFinishedEvent)histEvent.getHistoryEvent();
     assertEquals(TaskFailureType.NON_FATAL, finishEvent.getTaskFailureType());
     long newFinishTime = finishEvent.getFinishTime();
-    Assert.assertEquals(finishTime, newFinishTime);
+    assertEquals(finishTime, newFinishTime);
 
-    assertEquals(true, taImpl.inputFailedReported);
+    assertTrue(taImpl.inputFailedReported);
     int expectedEventsAfterFetchFailure = expectedEventsTillSucceeded + 2;
     arg = ArgumentCaptor.forClass(Event.class);
     verify(eventHandler, times(expectedEventsAfterFetchFailure)).handle(arg.capture());
@@ -1931,11 +1912,8 @@ public class TestTaskAttempt {
     assertEquals(TaskFailureType.NON_FATAL, failedEvent.getTaskFailureType());
 
     taImpl.handle(new TaskAttemptEventOutputFailed(taskAttemptID, tzEvent, 1));
-    assertEquals("Task attempt is not in FAILED state, still",
-        taImpl.getState(), TaskAttemptState.FAILED);
-    assertFalse(
-        "InternalError occurred trying to handle TA_TOO_MANY_FETCH_FAILURES",
-        eventHandler.internalError);
+    assertEquals(taImpl.getState(), TaskAttemptState.FAILED, "Task attempt is not in FAILED state, still");
+    assertFalse(eventHandler.internalError, "InternalError occurred trying to handle TA_TOO_MANY_FETCH_FAILURES");
     // No new events.
     verify(eventHandler, times(expectedEventsAfterFetchFailure)).handle(
         arg.capture());
@@ -1957,8 +1935,7 @@ public class TestTaskAttempt {
     taImpl2.handle(new TaskAttemptEventStartedRemotely(taskAttemptID2));
     verify(mockHeartbeatHandler).register(taskAttemptID2);
     taImpl2.handle(new TaskAttemptEvent(taskAttemptID2, TaskAttemptEventType.TA_DONE));
-    assertEquals("Task attempt is not in succeeded state", taImpl2.getState(),
-        TaskAttemptState.SUCCEEDED);
+    assertEquals(taImpl2.getState(), TaskAttemptState.SUCCEEDED, "Task attempt is not in succeeded state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID2);
 
     mockReEvent = InputReadErrorEvent.create("", 1, 1);
@@ -1971,8 +1948,7 @@ public class TestTaskAttempt {
     //This should fail even when MAX_ALLOWED_OUTPUT_FAILURES_FRACTION is within limits, as
     // MAX_ALLOWED_OUTPUT_FAILURES has crossed the limit.
     taImpl2.handle(new TaskAttemptEventOutputFailed(taskAttemptID2, tzEvent, 8));
-    assertEquals("Task attempt is not in failed state", taImpl2.getState(),
-        TaskAttemptState.FAILED);
+    assertEquals(taImpl2.getState(), TaskAttemptState.FAILED, "Task attempt is not in failed state");
     assertEquals(TaskAttemptTerminationCause.OUTPUT_LOST, taImpl2.getTerminationCause());
     // verify unregister is not invoked again
     verify(mockHeartbeatHandler, times(1)).unregister(taskAttemptID2);
@@ -2000,8 +1976,7 @@ public class TestTaskAttempt {
     taImpl3.handle(new TaskAttemptEventStartedRemotely(taskAttemptID3));
     verify(mockHeartbeatHandler).register(taskAttemptID3);
     taImpl3.handle(new TaskAttemptEvent(taskAttemptID3, TaskAttemptEventType.TA_DONE));
-    assertEquals("Task attempt is not in succeeded state", taImpl3.getState(),
-        TaskAttemptState.SUCCEEDED);
+    assertEquals(taImpl3.getState(), TaskAttemptState.SUCCEEDED, "Task attempt is not in succeeded state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID3);
 
     mockReEvent = InputReadErrorEvent.create("", 1, 1);
@@ -2015,23 +1990,21 @@ public class TestTaskAttempt {
     when(destVertex.getRunningTasks()).thenReturn(1000);
     // time deadline not exceeded for a couple of read error events
     taImpl3.handle(new TaskAttemptEventOutputFailed(taskAttemptID3, tzEvent, 1000));
-    assertEquals("Task attempt is not in succeeded state", taImpl3.getState(),
-        TaskAttemptState.SUCCEEDED);
+    assertEquals(taImpl3.getState(), TaskAttemptState.SUCCEEDED, "Task attempt is not in succeeded state");
     when(mockClock.getTime()).thenReturn(1500L);
     taImpl3.handle(new TaskAttemptEventOutputFailed(taskAttemptID3, tzEvent, 1000));
-    assertEquals("Task attempt is not in succeeded state", taImpl3.getState(),
-        TaskAttemptState.SUCCEEDED);
+    assertEquals(taImpl3.getState(), TaskAttemptState.SUCCEEDED, "Task attempt is not in succeeded state");
     // exceed the time threshold
     when(mockClock.getTime()).thenReturn(2001L);
     taImpl3.handle(new TaskAttemptEventOutputFailed(taskAttemptID3, tzEvent, 1000));
-    assertEquals("Task attempt is not in FAILED state", taImpl3.getState(),
-        TaskAttemptState.FAILED);
+    assertEquals(taImpl3.getState(), TaskAttemptState.FAILED, "Task attempt is not in FAILED state");
     assertEquals(TaskAttemptTerminationCause.OUTPUT_LOST, taImpl3.getTerminationCause());
     // verify unregister is not invoked again
     verify(mockHeartbeatHandler, times(1)).unregister(taskAttemptID3);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testTAFailureBasedOnRunningTasks() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
@@ -2084,8 +2057,7 @@ public class TestTaskAttempt {
     verify(mockHeartbeatHandler).register(taskAttemptID);
     taImpl.handle(new TaskAttemptEvent(taskAttemptID,
         TaskAttemptEventType.TA_DONE));
-    assertEquals("Task attempt is not in succeeded state", taImpl.getState(),
-        TaskAttemptState.SUCCEEDED);
+    assertEquals(taImpl.getState(), TaskAttemptState.SUCCEEDED, "Task attempt is not in succeeded state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
 
     int expectedEventsTillSucceeded = 8;
@@ -2115,11 +2087,12 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventOutputFailed(taskAttemptID, tzEvent, 11));
 
     // failure threshold is met due to running tasks. state is FAILED
-    assertEquals("Task attempt is not in FAILED state", TaskAttemptState.FAILED, taImpl.getState());
+    assertEquals(TaskAttemptState.FAILED, taImpl.getState(), "Task attempt is not in FAILED state");
   }
 
   @SuppressWarnings("deprecation")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testKilledInNew() throws ServicePluginException {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
@@ -2159,13 +2132,13 @@ public class TestTaskAttempt {
         taListener, taskConf, new SystemClock(),
         mockHeartbeatHandler, appCtx, false,
         resource, createFakeContainerContext(), true);
-    Assert.assertEquals(TaskAttemptStateInternal.NEW, taImpl.getInternalState());
+    assertEquals(TaskAttemptStateInternal.NEW, taImpl.getInternalState());
     taImpl.handle(new TaskAttemptEventKillRequest(taImpl.getTaskAttemptID(), "kill it",
         TaskAttemptTerminationCause.TERMINATED_BY_CLIENT));
-    Assert.assertEquals(TaskAttemptStateInternal.KILLED, taImpl.getInternalState());
+    assertEquals(TaskAttemptStateInternal.KILLED, taImpl.getInternalState());
 
-    Assert.assertEquals(0, taImpl.taskAttemptStartedEventLogged);
-    Assert.assertEquals(1, taImpl.taskAttemptFinishedEventLogged);
+    assertEquals(0, taImpl.taskAttemptStartedEventLogged);
+    assertEquals(1, taImpl.taskAttemptFinishedEventLogged);
   }
 
   @Test
@@ -2207,10 +2180,10 @@ public class TestTaskAttempt {
     TaskAttemptEventOutputFailed outputFailedEvent =
         new TaskAttemptEventOutputFailed(sourceAttempt.getTaskAttemptID(), tezEvent, 11);
 
-    Assert.assertEquals(TaskAttemptStateInternal.NEW, sourceAttempt.getInternalState());
+    assertEquals(TaskAttemptStateInternal.NEW, sourceAttempt.getInternalState());
     TaskAttemptStateInternal resultState = new TaskAttemptImpl.OutputReportedFailedTransition()
         .transition(sourceAttempt, outputFailedEvent);
-    Assert.assertEquals(expectedState, resultState);
+    assertEquals(expectedState, resultState);
   }
 
   @Test
@@ -2240,7 +2213,7 @@ public class TestTaskAttempt {
 
     // mapper task succeeded earlier
     sourceAttempt.handle(new TaskAttemptEvent(sourceAttempt.getTaskAttemptID(), TaskAttemptEventType.TA_DONE));
-    Assert.assertEquals(TaskAttemptStateInternal.SUCCEEDED, sourceAttempt.getInternalState());
+    assertEquals(TaskAttemptStateInternal.SUCCEEDED, sourceAttempt.getInternalState());
 
     // the event is propagated to map task's event handler
     TezEvent tezEvent = new TezEvent(inputReadErrorEvent1, mockMeta);
@@ -2250,7 +2223,7 @@ public class TestTaskAttempt {
         new TaskAttemptImpl.OutputReportedFailedTransition().transition(sourceAttempt, outputFailedEvent);
     // SUCCEEDED, as we haven't reached the host limit fraction
     // active nodes: 8, failed hosts: 1, fraction 0.125 (< 0.2)
-    Assert.assertEquals(TaskAttemptStateInternal.SUCCEEDED, resultState);
+    assertEquals(TaskAttemptStateInternal.SUCCEEDED, resultState);
 
     // the second event is propagated to map task's event handler
     TezEvent tezEvent2 = new TezEvent(inputReadErrorEvent2, mockMeta);
@@ -2261,7 +2234,7 @@ public class TestTaskAttempt {
 
     // now it's marked as FAILED
     // active nodes: 8, failed hosts: 2, fraction 0.25 (> 0.2)
-    Assert.assertEquals(TaskAttemptStateInternal.FAILED, resultState2);
+    assertEquals(TaskAttemptStateInternal.FAILED, resultState2);
   }
 
   @Test
@@ -2329,7 +2302,7 @@ public class TestTaskAttempt {
         return;
       }
     }
-    Assert.fail(
+    fail(
         String.format("Haven't found counter update %s=%d, instead seen: %s", counter, expectedValue, counterUpdates));
   }
 
@@ -2337,7 +2310,7 @@ public class TestTaskAttempt {
       List<DAGEventCounterUpdate.CounterIncrementalUpdate> counterUpdates, DAGCounter counter) {
     for (DAGEventCounterUpdate.CounterIncrementalUpdate update : counterUpdates) {
       if (update.getCounterKey().equals(counter)) {
-        Assert.fail(
+        fail(
             String.format("Found counter update %s=%d, which is not expected", counter, update.getIncrementValue()));
       }
     }
@@ -2353,9 +2326,7 @@ public class TestTaskAttempt {
         ret = e;
       }
     }
-    assertEquals(
-        "Mismatch in num occurences of event: " + eventClass.getCanonicalName(),
-        expectedOccurences, count);
+    assertEquals(expectedOccurences, count, "Mismatch in num occurences of event: " + eventClass.getCanonicalName());
     return ret;
   }
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestTaskAttempt.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestTaskAttempt.java
@@ -1154,7 +1154,7 @@ public class TestTaskAttempt {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 60000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testProgressAfterSubmit() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(1, 2);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(
@@ -1262,7 +1262,7 @@ public class TestTaskAttempt {
     taImpl.handle(new TaskAttemptEventSchedule(taskAttemptID, 0, 0));
     taImpl.handle(new TaskAttemptEventSubmitted(taskAttemptID, contId));
     taImpl.handle(new TaskAttemptEventStartedRemotely(taskAttemptID));
-    assertEquals(taImpl.getState(), TaskAttemptState.RUNNING, "Task attempt is not in the RUNNING state");
+    assertEquals(TaskAttemptState.RUNNING, taImpl.getState(), "Task attempt is not in the RUNNING state");
     verify(mockHeartbeatHandler).register(taskAttemptID);
 
     when(mockClock.getTime()).thenReturn(100l);
@@ -1293,7 +1293,8 @@ public class TestTaskAttempt {
     assertEquals(TaskFailureType.NON_FATAL, fEvent.getTaskFailureType());
     taImpl.handle(fEvent);
 
-    assertEquals(taImpl.getInternalState(), TaskAttemptStateInternal.FAIL_IN_PROGRESS, "Task attempt is not in the  FAIL_IN_PROGRESS state");
+    assertEquals(TaskAttemptStateInternal.FAIL_IN_PROGRESS, taImpl.getInternalState(),
+        "Task attempt is not in the  FAIL_IN_PROGRESS state");
     verify(mockHeartbeatHandler).unregister(taskAttemptID);
     assertEquals(1, taImpl.getDiagnostics().size());
     assertEquals(TaskAttemptTerminationCause.NO_PROGRESS, taImpl.getTerminationCause());
@@ -1687,7 +1688,8 @@ public class TestTaskAttempt {
 
     assertEquals(TaskAttemptStateInternal.KILLED, taImpl.getInternalState());
     taImpl.handle(new TaskAttemptEventTezEventUpdate(taImpl.getTaskAttemptID(), Collections.EMPTY_LIST));
-    assertFalse(eventHandler.internalError, "InternalError occurred trying to handle TA_TEZ_EVENT_UPDATE in KILLED state");
+    assertFalse(eventHandler.internalError,
+        "InternalError occurred trying to handle TA_TEZ_EVENT_UPDATE in KILLED state");
   }
 
   @Test
@@ -2302,16 +2304,14 @@ public class TestTaskAttempt {
         return;
       }
     }
-    fail(
-        String.format("Haven't found counter update %s=%d, instead seen: %s", counter, expectedValue, counterUpdates));
+    fail(String.format("Haven't found counter update %s=%d, instead seen: %s", counter, expectedValue, counterUpdates));
   }
 
   private void assertCounterIncrementalUpdateNotFound(
       List<DAGEventCounterUpdate.CounterIncrementalUpdate> counterUpdates, DAGCounter counter) {
     for (DAGEventCounterUpdate.CounterIncrementalUpdate update : counterUpdates) {
       if (update.getCounterKey().equals(counter)) {
-        fail(
-            String.format("Found counter update %s=%d, which is not expected", counter, update.getIncrementValue()));
+        fail(String.format("Found counter update %s=%d, which is not expected", counter, update.getIncrementValue()));
       }
     }
   }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestTaskImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestTaskImpl.java
@@ -18,10 +18,12 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
@@ -30,6 +32,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.Credentials;
@@ -78,6 +81,7 @@ import org.apache.tez.dag.app.dag.event.TaskEventTASucceeded;
 import org.apache.tez.dag.app.dag.event.TaskEventTermination;
 import org.apache.tez.dag.app.dag.event.TaskEventType;
 import org.apache.tez.dag.app.dag.event.VertexEventType;
+import org.apache.tez.dag.app.dag.impl.VertexImpl.VertexConfigImpl;
 import org.apache.tez.dag.app.rm.container.AMContainer;
 import org.apache.tez.dag.app.rm.node.AMNodeEventType;
 import org.apache.tez.dag.history.DAGHistoryEvent;
@@ -98,9 +102,9 @@ import org.apache.tez.runtime.api.impl.EventMetaData.EventProducerConsumerType;
 import org.apache.tez.runtime.api.impl.TaskSpec;
 import org.apache.tez.runtime.api.impl.TezEvent;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -148,7 +152,7 @@ public class TestTaskImpl {
   }
   private TestEventHandler eventHandler;
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf = new Configuration();
     conf.setInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS, 4);
@@ -308,7 +312,7 @@ public class TestTaskImpl {
     if (verifyState) {
       assertTaskRunningState();
     }
-    Assert.assertEquals(failedAttempts + 1, mockTask.failedAttempts);
+    assertEquals(failedAttempts + 1, mockTask.failedAttempts);
     verify(mockTask.getVertex(), times(failedAttempts + 1)).incrementFailedTaskAttemptCount();
   }
 
@@ -351,14 +355,16 @@ public class TestTaskImpl {
     assertEquals(TaskState.SUCCEEDED, mockTask.getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInit() {
     LOG.info("--- START: testInit ---");
     assertTaskNewState();
     assert (mockTask.getAttemptList().size() == 0);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   /**
    * {@link TaskState#NEW}->{@link TaskState#SCHEDULED}
    */
@@ -368,7 +374,8 @@ public class TestTaskImpl {
     scheduleTaskAttempt(taskId);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   /**
    * {@link TaskState#SCHEDULED}->{@link TaskState#KILL_WAIT}
    */
@@ -382,7 +389,8 @@ public class TestTaskImpl {
   /**
    * {@link TaskState#RUNNING}->{@link TaskState#KILLED}
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testKillRunningTask() {
     LOG.info("--- START: testKillRunningTask ---");
     TezTaskID taskId = getNewTaskID();
@@ -394,7 +402,8 @@ public class TestTaskImpl {
     verifyOutgoingEvents(eventHandler.events, VertexEventType.V_TASK_COMPLETED);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTooManyFailedAttempts() {
     LOG.info("--- START: testTooManyFailedAttempts ---");
     TezTaskID taskId = getNewTaskID();
@@ -418,7 +427,8 @@ public class TestTaskImpl {
     verifyOutgoingEvents(eventHandler.events, VertexEventType.V_TASK_COMPLETED);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTooManyAttempts() {
     LOG.info("--- START: testTooManyAttempts ---");
 
@@ -442,7 +452,8 @@ public class TestTaskImpl {
     verifyOutgoingEvents(eventHandler.events, VertexEventType.V_TASK_COMPLETED);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFailedAttemptWithFatalError() {
     LOG.info("--- START: testFailedAttemptWithFatalError ---");
     TezTaskID taskId = getNewTaskID();
@@ -456,7 +467,8 @@ public class TestTaskImpl {
     verifyOutgoingEvents(eventHandler.events, VertexEventType.V_TASK_COMPLETED);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testKillRunningTaskPreviousKilledAttempts() {
     LOG.info("--- START: testKillRunningTaskPreviousKilledAttempts ---");
     TezTaskID taskId = getNewTaskID();
@@ -474,7 +486,8 @@ public class TestTaskImpl {
   /**
    * {@link TaskState#RUNNING}->{@link TaskState#KILLED}
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testKillRunningTaskButAttemptSucceeds() {
     LOG.info("--- START: testKillRunningTaskButAttemptSucceeds ---");
     TezTaskID taskId = getNewTaskID();
@@ -488,7 +501,8 @@ public class TestTaskImpl {
   /**
    * {@link TaskState#RUNNING}->{@link TaskState#KILLED}
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testKillRunningTaskButAttemptFails() {
     LOG.info("--- START: testKillRunningTaskButAttemptFails ---");
     TezTaskID taskId = getNewTaskID();
@@ -499,7 +513,8 @@ public class TestTaskImpl {
     assertEquals(TaskStateInternal.KILLED, mockTask.getInternalState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   /**
    * Kill attempt
    * {@link TaskState#SCHEDULED}->{@link TaskState#SCHEDULED}
@@ -511,10 +526,11 @@ public class TestTaskImpl {
     TezTaskAttemptID lastTAId = mockTask.getLastAttempt().getTaskAttemptID();
     killScheduledTaskAttempt(mockTask.getLastAttempt().getTaskAttemptID());
     // last killed attempt should be causal TA of next attempt
-    Assert.assertEquals(lastTAId, mockTask.getLastAttempt().getSchedulingCausalTA());
+    assertEquals(lastTAId, mockTask.getLastAttempt().getSchedulingCausalTA());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   /**
    * Launch attempt
    * {@link TaskState#SCHEDULED}->{@link TaskState#RUNNING}
@@ -526,7 +542,8 @@ public class TestTaskImpl {
     launchTaskAttempt(mockTask.getLastAttempt().getTaskAttemptID());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   /**
    * Kill running attempt
    * {@link TaskState#RUNNING}->{@link TaskState#RUNNING}
@@ -539,10 +556,11 @@ public class TestTaskImpl {
     launchTaskAttempt(mockTask.getLastAttempt().getTaskAttemptID());
     killRunningTaskAttempt(mockTask.getLastAttempt().getTaskAttemptID(), TaskState.RUNNING);
     // last killed attempt should be causal TA of next attempt
-    Assert.assertEquals(lastTAId, mockTask.getLastAttempt().getSchedulingCausalTA());
+    assertEquals(lastTAId, mockTask.getLastAttempt().getSchedulingCausalTA());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   /**
    * Kill running attempt
    * {@link TaskState#RUNNING}->{@link TaskState#RUNNING}
@@ -562,7 +580,8 @@ public class TestTaskImpl {
   /**
    * {@link TaskState#KILLED}->{@link TaskState#KILLED}
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testKilledAttemptAtTaskKilled() {
     LOG.info("--- START: testKilledAttemptAtTaskKilled ---");
     TezTaskID taskId = getNewTaskID();
@@ -583,7 +602,8 @@ public class TestTaskImpl {
   /**
    * {@link TaskState#FAILED}->{@link TaskState#FAILED}
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testKilledAttemptAtTaskFailed() {
     LOG.info("--- START: testKilledAttemptAtTaskFailed ---");
     TezTaskID taskId = getNewTaskID();
@@ -601,7 +621,8 @@ public class TestTaskImpl {
 
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFetchedEventsModifyUnderlyingList() {
     // Tests to ensure that adding an event to a task, does not affect the
     // result of past getTaskAttemptTezEvents calls.
@@ -623,7 +644,8 @@ public class TestTaskImpl {
     assertEquals(6, fetchedList.size());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskProgress() {
     LOG.info("--- START: testTaskProgress ---");
 
@@ -662,14 +684,14 @@ public class TestTaskImpl {
     assert (mockTask.getProgress() == progress);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFailureDuringTaskAttemptCommit() {
     TezTaskID taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
     launchTaskAttempt(mockTask.getLastAttempt().getTaskAttemptID());
     updateAttemptState(mockTask.getLastAttempt(), TaskAttemptState.RUNNING);
-    assertTrue("First attempt should commit",
-        mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()));
+    assertTrue(mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()), "First attempt should commit");
 
     // During the task attempt commit there is an exception which causes
     // the attempt to fail
@@ -681,13 +703,11 @@ public class TestTaskImpl {
     assertEquals(2, mockTask.getAttemptList().size());
     assertEquals(1, mockTask.failedAttempts);
     // last failed attempt should be the causal TA
-    Assert.assertEquals(lastTAId, mockTask.getLastAttempt().getSchedulingCausalTA());
+    assertEquals(lastTAId, mockTask.getLastAttempt().getSchedulingCausalTA());
 
-    assertFalse("First attempt should not commit",
-        mockTask.canCommit(mockTask.getAttemptList().get(0).getTaskAttemptID()));
+    assertFalse(mockTask.canCommit(mockTask.getAttemptList().get(0).getTaskAttemptID()), "First attempt should not commit");
     updateAttemptState(mockTask.getLastAttempt(), TaskAttemptState.RUNNING);
-    assertTrue("Second attempt should commit",
-        mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()));
+    assertTrue(mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()), "Second attempt should commit");
 
     updateAttemptState(mockTask.getLastAttempt(), TaskAttemptState.SUCCEEDED);
     mockTask.handle(createTaskTASucceededEvent(mockTask.getLastAttempt().getTaskAttemptID()));
@@ -696,19 +716,18 @@ public class TestTaskImpl {
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEventBacklogDuringTaskAttemptCommit() {
     TezTaskID taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
     assertEquals(TaskState.SCHEDULED, mockTask.getState());
     // simulate
     // task in scheduled state due to event backlog - real task done and calling canCommit
-    assertFalse("Commit should return false to make running task wait",
-        mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()));
+    assertFalse(mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()), "Commit should return false to make running task wait");
     launchTaskAttempt(mockTask.getLastAttempt().getTaskAttemptID());
     updateAttemptState(mockTask.getLastAttempt(), TaskAttemptState.RUNNING);
-    assertTrue("Task state in AM is running now. Can commit.",
-        mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()));
+    assertTrue(mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()), "Task state in AM is running now. Can commit.");
 
     updateAttemptState(mockTask.getLastAttempt(), TaskAttemptState.SUCCEEDED);
     mockTask.handle(createTaskTASucceededEvent(mockTask.getLastAttempt().getTaskAttemptID()));
@@ -717,7 +736,8 @@ public class TestTaskImpl {
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testChangeCommitTaskAttempt() {
     TezTaskID taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -733,12 +753,10 @@ public class TestTaskImpl {
     assertEquals(2, mockTask.getAttemptList().size());
 
     // previous running attempt should be the casual TA of this speculative attempt
-    Assert.assertEquals(lastTAId, mockTask.getLastAttempt().getSchedulingCausalTA());
+    assertEquals(lastTAId, mockTask.getLastAttempt().getSchedulingCausalTA());
 
-    assertTrue("Second attempt should commit",
-        mockTask.canCommit(mockTask.getAttemptList().get(1).getTaskAttemptID()));
-    assertFalse("First attempt should not commit",
-        mockTask.canCommit(mockTask.getAttemptList().get(0).getTaskAttemptID()));
+    assertTrue(mockTask.canCommit(mockTask.getAttemptList().get(1).getTaskAttemptID()), "Second attempt should commit");
+    assertFalse(mockTask.canCommit(mockTask.getAttemptList().get(0).getTaskAttemptID()), "First attempt should not commit");
 
     // During the task attempt commit there is an exception which causes
     // the second attempt to fail
@@ -747,10 +765,8 @@ public class TestTaskImpl {
 
     assertEquals(2, mockTask.getAttemptList().size());
 
-    assertFalse("Second attempt should not commit",
-        mockTask.canCommit(mockTask.getAttemptList().get(1).getTaskAttemptID()));
-    assertTrue("First attempt should commit",
-        mockTask.canCommit(mockTask.getAttemptList().get(0).getTaskAttemptID()));
+    assertFalse(mockTask.canCommit(mockTask.getAttemptList().get(1).getTaskAttemptID()), "Second attempt should not commit");
+    assertTrue(mockTask.canCommit(mockTask.getAttemptList().get(0).getTaskAttemptID()), "First attempt should commit");
 
     updateAttemptState(mockTask.getAttemptList().get(0), TaskAttemptState.SUCCEEDED);
     mockTask.handle(createTaskTASucceededEvent(mockTask.getAttemptList().get(0).getTaskAttemptID()));
@@ -759,7 +775,8 @@ public class TestTaskImpl {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSucceedAndRetroActiveFailure() {
     TezTaskID taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -777,7 +794,7 @@ public class TestTaskImpl {
     verify(mockHistoryHandler).handle(argumentCaptor.capture());
     DAGHistoryEvent dagHistoryEvent = argumentCaptor.getValue();
     HistoryEvent historyEvent = dagHistoryEvent.getHistoryEvent();
-    assertTrue(historyEvent instanceof TaskFinishedEvent);
+    assertInstanceOf(TaskFinishedEvent.class, historyEvent);
     TaskFinishedEvent taskFinishedEvent = (TaskFinishedEvent)historyEvent;
     assertEquals(taskFinishedEvent.getFinishTime(), mockTask.getFinishTime());
 
@@ -796,19 +813,20 @@ public class TestTaskImpl {
     // The task should still be in the scheduled state
     assertTaskScheduledState();
     Event event = eventHandler.events.get(0);
-    Assert.assertEquals(AMNodeEventType.N_TA_ENDED, event.getType());
+    assertEquals(AMNodeEventType.N_TA_ENDED, event.getType());
     event = eventHandler.events.get(eventHandler.events.size()-1);
-    Assert.assertEquals(VertexEventType.V_TASK_RESCHEDULED, event.getType());
+    assertEquals(VertexEventType.V_TASK_RESCHEDULED, event.getType());
 
     // report of output read error should be the causal TA
     List<MockTaskAttemptImpl> attempts = mockTask.getAttemptList();
-    Assert.assertEquals(2, attempts.size());
+    assertEquals(2, attempts.size());
     MockTaskAttemptImpl newAttempt = attempts.get(1);
-    Assert.assertEquals(mockDestId, newAttempt.getSchedulingCausalTA());
+    assertEquals(mockDestId, newAttempt.getSchedulingCausalTA());
   }
 
   @SuppressWarnings("rawtypes")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSucceedAndRetroActiveKilled() {
     TezTaskID taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -829,10 +847,11 @@ public class TestTaskImpl {
     // The task should still be in the scheduled state
     assertTaskScheduledState();
     Event event = eventHandler.events.get(0);
-    Assert.assertEquals(VertexEventType.V_TASK_RESCHEDULED, event.getType());
+    assertEquals(VertexEventType.V_TASK_RESCHEDULED, event.getType());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDiagnostics_KillNew(){
     TezTaskID taskId = getNewTaskID();
     mockTask.handle(new TaskEventTermination(taskId, TaskAttemptTerminationCause.TERMINATED_BY_CLIENT, null));
@@ -842,7 +861,8 @@ public class TestTaskImpl {
     assertEquals(1, mockTask.taskFinishedEventLogged);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDiagnostics_Kill(){
     TezTaskID taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -851,7 +871,8 @@ public class TestTaskImpl {
     assertTrue(mockTask.getDiagnostics().get(0).contains(TaskAttemptTerminationCause.TERMINATED_AT_SHUTDOWN.name()));
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testFailedThenSpeculativeFailed() {
     conf.setInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS, 1);
     Vertex vertex = mock(Vertex.class);
@@ -886,7 +907,8 @@ public class TestTaskImpl {
     assertEquals(2, mockTask.getAttemptList().size());
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testFailedThenSpeculativeSucceeded() {
     conf.setInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS, 1);
     Vertex vertex = mock(Vertex.class);
@@ -960,7 +982,8 @@ public class TestTaskImpl {
     assertEquals(3, mockTask.getAttemptList().size());
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testKilledAttemptUpdatesDAGScheduler() {
     TezTaskID taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -999,7 +1022,8 @@ public class TestTaskImpl {
         VertexEventType.V_TASK_ATTEMPT_COMPLETED);
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testSpeculatedThenRetroactiveFailure() {
     TezTaskID taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -1045,17 +1069,18 @@ public class TestTaskImpl {
     // The task should still be in the scheduled state
     assertTaskScheduledState();
     event = eventHandler.events.get(eventHandler.events.size()-1);
-    Assert.assertEquals(VertexEventType.V_TASK_RESCHEDULED, event.getType());
+    assertEquals(VertexEventType.V_TASK_RESCHEDULED, event.getType());
 
     // There should be a new attempt, and report of output read error
     // should be the causal TA
     List<MockTaskAttemptImpl> attempts = mockTask.getAttemptList();
-    Assert.assertEquals(3, attempts.size());
+    assertEquals(3, attempts.size());
     MockTaskAttemptImpl newAttempt = attempts.get(2);
-    Assert.assertEquals(mockDestId, newAttempt.getSchedulingCausalTA());
+    assertEquals(mockDestId, newAttempt.getSchedulingCausalTA());
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testIgnoreSpeculationOnSuccessfulOriginalAttempt() {
     TezTaskID taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -1072,7 +1097,8 @@ public class TestTaskImpl {
     assertEquals(1, mockTask.getAttemptList().size());
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testIgnoreSpeculationAfterOriginalAttemptCommit() {
     TezTaskID taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -1122,11 +1148,10 @@ public class TestTaskImpl {
 
     mockTask.handle(new TaskEventTASucceeded(secondMockTaskAttempt.getTaskAttemptID()));
     mockTask.handle(new TaskEventTASucceeded(firstMockTaskAttempt.getTaskAttemptID()));
-    assertTrue("Attempts should have succeeded!",
-        firstMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.SUCCEEDED
-        && secondMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.SUCCEEDED);
-    assertEquals("Task should have no uncompleted attempts!", 0, mockTask.getUncompletedAttemptsCount());
-    assertTrue("Task should have Succeeded!", mockTask.getState() == TaskState.SUCCEEDED);
+    assertTrue(firstMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.SUCCEEDED
+        && secondMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.SUCCEEDED, "Attempts should have succeeded!");
+    assertEquals(0, mockTask.getUncompletedAttemptsCount(), "Task should have no uncompleted attempts!");
+    assertSame(mockTask.getState(), TaskState.SUCCEEDED, "Task should have Succeeded!");
     //Failing the attempt that finished after the task was marked succeeded, should not schedule another attempt
     failAttempt(firstMockTaskAttempt, 0, 0);
     assertTaskSucceededState();
@@ -1141,7 +1166,7 @@ public class TestTaskImpl {
     Configuration newConf = new Configuration(conf);
     newConf.setInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS, 1);
     Vertex vertex = mock(Vertex.class);
-    doReturn(new VertexImpl.VertexConfigImpl(newConf)).when(vertex).getVertexConfig();
+    doReturn(new VertexConfigImpl(newConf)).when(vertex).getVertexConfig();
     mockTask = new MockTaskImpl(vertexId, partition,
       eventHandler, conf, taskCommunicatorManagerInterface, clock,
       taskHeartbeatHandler, appContext, leafVertex,
@@ -1184,15 +1209,15 @@ public class TestTaskImpl {
         mock(TaskAttemptEvent.class)));
     mockTask.handle(new TaskEventTAFailed(firstMockTaskAttempt.getTaskAttemptID(), TaskFailureType.NON_FATAL,
         mock(TaskAttemptEvent.class)));
-    assertTrue("Attempts should have failed!",
-        firstMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED
-        && secondMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED);
-    assertEquals("Task should have no uncompleted attempts!", 0, mockTask.getUncompletedAttemptsCount());
-    assertTrue("Task should have failed!", mockTask.getState() == TaskState.FAILED);
+    assertTrue(firstMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED
+        && secondMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED, "Attempts should have failed!");
+    assertEquals(0, mockTask.getUncompletedAttemptsCount(), "Task should have no uncompleted attempts!");
+    assertSame(mockTask.getState(), TaskState.FAILED, "Task should have failed!");
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout = 10000L)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testSucceededLeafTaskWithRetroFailures() throws InterruptedException {
     Configuration newConf = new Configuration(conf);
     newConf.setInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS, 1);
@@ -1244,7 +1269,7 @@ public class TestTaskImpl {
     firstMockTaskAttempt.handle(outputFailedEvent);
     mockTask.handle(new TaskEventTAFailed(firstMockTaskAttempt.getTaskAttemptID(), TaskFailureType.NON_FATAL,
         mock(TaskAttemptEvent.class)));
-    Assert.assertEquals(mockTask.getInternalState(), TaskStateInternal.SUCCEEDED);
+    assertEquals(mockTask.getInternalState(), TaskStateInternal.SUCCEEDED);
   }
 
   private void failAttempt(MockTaskAttemptImpl taskAttempt, int index, int expectedIncompleteAttempts) {
@@ -1258,16 +1283,16 @@ public class TestTaskImpl {
         outputFailedEvent);
     TaskEvent tEventFail1 = new TaskEventTAFailed(taskAttempt.getTaskAttemptID(), TaskFailureType.NON_FATAL, outputFailedEvent);
     mockTask.handle(tEventFail1);
-    assertEquals("Unexpected number of incomplete attempts!",
-        expectedIncompleteAttempts, mockTask.getUncompletedAttemptsCount());
+    assertEquals(expectedIncompleteAttempts, mockTask.getUncompletedAttemptsCount(), "Unexpected number of incomplete attempts!");
   }
 
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testFailedTaskTransitionWithLaunchedAttempt() throws InterruptedException {
     Configuration newConf = new Configuration(conf);
     newConf.setInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS, 1);
     Vertex vertex = mock(Vertex.class);
-    doReturn(new VertexImpl.VertexConfigImpl(newConf)).when(vertex).getVertexConfig();
+    doReturn(new VertexConfigImpl(newConf)).when(vertex).getVertexConfig();
     mockTask = new MockTaskImpl(vertexId, partition,
         eventHandler, conf, taskCommunicatorManagerInterface, clock,
         taskHeartbeatHandler, appContext, leafVertex,
@@ -1310,17 +1335,17 @@ public class TestTaskImpl {
         mock(TaskAttemptEvent.class)));
     mockTask.handle(new TaskEventTAFailed(firstMockTaskAttempt.getTaskAttemptID(), TaskFailureType.NON_FATAL,
         mock(TaskAttemptEvent.class)));
-    assertTrue("Attempts should have failed!",
-        firstMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED
-            && secondMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED);
-    assertEquals("Task should have no uncompleted attempts!", 0, mockTask.getUncompletedAttemptsCount());
-    assertTrue("Task should have failed!", mockTask.getState() == TaskState.FAILED);
+    assertTrue(firstMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED
+            && secondMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED, "Attempts should have failed!");
+    assertEquals(0, mockTask.getUncompletedAttemptsCount(), "Task should have no uncompleted attempts!");
+    assertSame(mockTask.getState(), TaskState.FAILED, "Task should have failed!");
     mockTask.handle(createTaskTAAddSpecAttempt(mockTask.getLastAttempt().getTaskAttemptID()));
     MockTaskAttemptImpl thirdMockTaskAttempt = mockTask.getLastAttempt();
     mockTask.handle(createTaskTALauncherEvent(thirdMockTaskAttempt.getTaskAttemptID()));
   }
 
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testKilledTaskTransitionWithLaunchedAttempt() throws InterruptedException {
     TezTaskID taskId = getNewTaskID();
     scheduleTaskAttempt(taskId);
@@ -1358,7 +1383,7 @@ public class TestTaskImpl {
     firstMockTaskAttempt.handle(
         new TaskAttemptEventAttemptKilled(TezTaskAttemptID.fromString(firstMockTaskAttempt.toString()),"test",
             TaskAttemptTerminationCause.FRAMEWORK_ERROR));
-    assertEquals("Task should have been killed!", mockTask.getInternalState(), TaskStateInternal.KILLED);
+    assertEquals(mockTask.getInternalState(), TaskStateInternal.KILLED, "Task should have been killed!");
     mockTask.handle(createTaskTAAddSpecAttempt(mockTask.getLastAttempt().getTaskAttemptID()));
     MockTaskAttemptImpl thirdMockTaskAttempt = mockTask.getLastAttempt();
     mockTask.handle(createTaskTALauncherEvent(thirdMockTaskAttempt.getTaskAttemptID()));
@@ -1371,10 +1396,8 @@ public class TestTaskImpl {
 
   // TODO Add test to validate the correct commit attempt.
 
-
   /* Verifies that the specified event types, exist. Does not ensure they are the only ones, however */
-  private void verifyOutgoingEvents(List<Event> events,
-                                    Enum<?>... expectedTypes) {
+  private void verifyOutgoingEvents(List<Event> events, Enum<?>... expectedTypes) {
 
     List<Enum<?>> expectedTypeList = new LinkedList<Enum<?>>();
     for (Enum<?> expectedType : expectedTypes) {
@@ -1391,8 +1414,9 @@ public class TestTaskImpl {
         }
       }
     }
-    assertTrue("Did not find types : " + expectedTypeList
-        + " in outgoing event list", expectedTypeList.isEmpty());
+    assertTrue(
+        expectedTypeList.isEmpty(),
+        "Did not find types : " + expectedTypeList + " in outgoing event list");
   }
 
   @SuppressWarnings("rawtypes")

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestTaskImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestTaskImpl.java
@@ -705,7 +705,8 @@ public class TestTaskImpl {
     // last failed attempt should be the causal TA
     assertEquals(lastTAId, mockTask.getLastAttempt().getSchedulingCausalTA());
 
-    assertFalse(mockTask.canCommit(mockTask.getAttemptList().get(0).getTaskAttemptID()), "First attempt should not commit");
+    assertFalse(mockTask.canCommit(mockTask.getAttemptList().getFirst().getTaskAttemptID()),
+        "First attempt should not commit");
     updateAttemptState(mockTask.getLastAttempt(), TaskAttemptState.RUNNING);
     assertTrue(mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()), "Second attempt should commit");
 
@@ -724,10 +725,12 @@ public class TestTaskImpl {
     assertEquals(TaskState.SCHEDULED, mockTask.getState());
     // simulate
     // task in scheduled state due to event backlog - real task done and calling canCommit
-    assertFalse(mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()), "Commit should return false to make running task wait");
+    assertFalse(mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()),
+        "Commit should return false to make running task wait");
     launchTaskAttempt(mockTask.getLastAttempt().getTaskAttemptID());
     updateAttemptState(mockTask.getLastAttempt(), TaskAttemptState.RUNNING);
-    assertTrue(mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()), "Task state in AM is running now. Can commit.");
+    assertTrue(mockTask.canCommit(mockTask.getLastAttempt().getTaskAttemptID()),
+        "Task state in AM is running now. Can commit.");
 
     updateAttemptState(mockTask.getLastAttempt(), TaskAttemptState.SUCCEEDED);
     mockTask.handle(createTaskTASucceededEvent(mockTask.getLastAttempt().getTaskAttemptID()));
@@ -756,7 +759,8 @@ public class TestTaskImpl {
     assertEquals(lastTAId, mockTask.getLastAttempt().getSchedulingCausalTA());
 
     assertTrue(mockTask.canCommit(mockTask.getAttemptList().get(1).getTaskAttemptID()), "Second attempt should commit");
-    assertFalse(mockTask.canCommit(mockTask.getAttemptList().get(0).getTaskAttemptID()), "First attempt should not commit");
+    assertFalse(mockTask.canCommit(mockTask.getAttemptList().get(0).getTaskAttemptID()),
+        "First attempt should not commit");
 
     // During the task attempt commit there is an exception which causes
     // the second attempt to fail
@@ -765,7 +769,8 @@ public class TestTaskImpl {
 
     assertEquals(2, mockTask.getAttemptList().size());
 
-    assertFalse(mockTask.canCommit(mockTask.getAttemptList().get(1).getTaskAttemptID()), "Second attempt should not commit");
+    assertFalse(mockTask.canCommit(mockTask.getAttemptList().get(1).getTaskAttemptID()),
+        "Second attempt should not commit");
     assertTrue(mockTask.canCommit(mockTask.getAttemptList().get(0).getTaskAttemptID()), "First attempt should commit");
 
     updateAttemptState(mockTask.getAttemptList().get(0), TaskAttemptState.SUCCEEDED);
@@ -1148,10 +1153,11 @@ public class TestTaskImpl {
 
     mockTask.handle(new TaskEventTASucceeded(secondMockTaskAttempt.getTaskAttemptID()));
     mockTask.handle(new TaskEventTASucceeded(firstMockTaskAttempt.getTaskAttemptID()));
-    assertTrue(firstMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.SUCCEEDED
-        && secondMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.SUCCEEDED, "Attempts should have succeeded!");
+    assertTrue(firstMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.SUCCEEDED &&
+               secondMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.SUCCEEDED,
+        "Attempts should have succeeded!");
     assertEquals(0, mockTask.getUncompletedAttemptsCount(), "Task should have no uncompleted attempts!");
-    assertSame(mockTask.getState(), TaskState.SUCCEEDED, "Task should have Succeeded!");
+    assertSame(TaskState.SUCCEEDED, mockTask.getState(), "Task should have Succeeded!");
     //Failing the attempt that finished after the task was marked succeeded, should not schedule another attempt
     failAttempt(firstMockTaskAttempt, 0, 0);
     assertTaskSucceededState();
@@ -1209,15 +1215,16 @@ public class TestTaskImpl {
         mock(TaskAttemptEvent.class)));
     mockTask.handle(new TaskEventTAFailed(firstMockTaskAttempt.getTaskAttemptID(), TaskFailureType.NON_FATAL,
         mock(TaskAttemptEvent.class)));
-    assertTrue(firstMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED
-        && secondMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED, "Attempts should have failed!");
+    assertTrue(firstMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED &&
+               secondMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED,
+        "Attempts should have failed!");
     assertEquals(0, mockTask.getUncompletedAttemptsCount(), "Task should have no uncompleted attempts!");
-    assertSame(mockTask.getState(), TaskState.FAILED, "Task should have failed!");
+    assertSame(TaskState.FAILED, mockTask.getState(), "Task should have failed!");
   }
 
   @SuppressWarnings("rawtypes")
   @Test
-  @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSucceededLeafTaskWithRetroFailures() throws InterruptedException {
     Configuration newConf = new Configuration(conf);
     newConf.setInt(TezConfiguration.TEZ_AM_TASK_MAX_FAILED_ATTEMPTS, 1);
@@ -1269,7 +1276,7 @@ public class TestTaskImpl {
     firstMockTaskAttempt.handle(outputFailedEvent);
     mockTask.handle(new TaskEventTAFailed(firstMockTaskAttempt.getTaskAttemptID(), TaskFailureType.NON_FATAL,
         mock(TaskAttemptEvent.class)));
-    assertEquals(mockTask.getInternalState(), TaskStateInternal.SUCCEEDED);
+    assertEquals(TaskStateInternal.SUCCEEDED, mockTask.getInternalState());
   }
 
   private void failAttempt(MockTaskAttemptImpl taskAttempt, int index, int expectedIncompleteAttempts) {
@@ -1281,9 +1288,11 @@ public class TestTaskImpl {
         new TaskAttemptEventOutputFailed(mockDestId, tzEvent, 1);
     taskAttempt.handle(
         outputFailedEvent);
-    TaskEvent tEventFail1 = new TaskEventTAFailed(taskAttempt.getTaskAttemptID(), TaskFailureType.NON_FATAL, outputFailedEvent);
+    TaskEvent tEventFail1 =
+        new TaskEventTAFailed(taskAttempt.getTaskAttemptID(), TaskFailureType.NON_FATAL, outputFailedEvent);
     mockTask.handle(tEventFail1);
-    assertEquals(expectedIncompleteAttempts, mockTask.getUncompletedAttemptsCount(), "Unexpected number of incomplete attempts!");
+    assertEquals(expectedIncompleteAttempts, mockTask.getUncompletedAttemptsCount(),
+        "Unexpected number of incomplete attempts!");
   }
 
   @Test
@@ -1335,10 +1344,11 @@ public class TestTaskImpl {
         mock(TaskAttemptEvent.class)));
     mockTask.handle(new TaskEventTAFailed(firstMockTaskAttempt.getTaskAttemptID(), TaskFailureType.NON_FATAL,
         mock(TaskAttemptEvent.class)));
-    assertTrue(firstMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED
-            && secondMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED, "Attempts should have failed!");
+    assertTrue(firstMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED &&
+               secondMockTaskAttempt.getInternalState() == TaskAttemptStateInternal.FAILED,
+        "Attempts should have failed!");
     assertEquals(0, mockTask.getUncompletedAttemptsCount(), "Task should have no uncompleted attempts!");
-    assertSame(mockTask.getState(), TaskState.FAILED, "Task should have failed!");
+    assertSame(TaskState.FAILED, mockTask.getState(), "Task should have failed!");
     mockTask.handle(createTaskTAAddSpecAttempt(mockTask.getLastAttempt().getTaskAttemptID()));
     MockTaskAttemptImpl thirdMockTaskAttempt = mockTask.getLastAttempt();
     mockTask.handle(createTaskTALauncherEvent(thirdMockTaskAttempt.getTaskAttemptID()));
@@ -1383,7 +1393,7 @@ public class TestTaskImpl {
     firstMockTaskAttempt.handle(
         new TaskAttemptEventAttemptKilled(TezTaskAttemptID.fromString(firstMockTaskAttempt.toString()),"test",
             TaskAttemptTerminationCause.FRAMEWORK_ERROR));
-    assertEquals(mockTask.getInternalState(), TaskStateInternal.KILLED, "Task should have been killed!");
+    assertEquals(TaskStateInternal.KILLED, mockTask.getInternalState(), "Task should have been killed!");
     mockTask.handle(createTaskTAAddSpecAttempt(mockTask.getLastAttempt().getTaskAttemptID()));
     MockTaskAttemptImpl thirdMockTaskAttempt = mockTask.getLastAttempt();
     mockTask.handle(createTaskTALauncherEvent(thirdMockTaskAttempt.getTaskAttemptID()));
@@ -1414,9 +1424,7 @@ public class TestTaskImpl {
         }
       }
     }
-    assertTrue(
-        expectedTypeList.isEmpty(),
-        "Did not find types : " + expectedTypeList + " in outgoing event list");
+    assertTrue(expectedTypeList.isEmpty(), "Did not find types : " + expectedTypeList + " in outgoing event list");
   }
 
   @SuppressWarnings("rawtypes")

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexImpl.java
@@ -18,9 +18,14 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
@@ -49,6 +54,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
@@ -233,12 +239,12 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
 import org.mockito.internal.util.collections.Sets;
 import org.mockito.invocation.InvocationOnMock;
@@ -2906,12 +2912,12 @@ public class TestVertexImpl {
     dispatcher.start();
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     MockDNSToSwitchMapping.initializeMockRackResolver();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws TezException {
     useCustomInitializer = false;
     customInitializer = null;
@@ -2921,7 +2927,7 @@ public class TestVertexImpl {
     setupPostDagCreation(false);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     if (dispatcher.isInState(STATE.STARTED)) {
       dispatcher.await();
@@ -2948,12 +2954,12 @@ public class TestVertexImpl {
     }
     for (int i = 1; i <= vertices.size(); ++i) {
       VertexImpl v = vertices.get("vertex" + i);
-      Assert.assertEquals(expectedState, v.getState());
+      assertEquals(expectedState, v.getState());
     }
   }
 
   private void initVertex(VertexImpl v) {
-    Assert.assertEquals(VertexState.NEW, v.getState());
+    assertEquals(VertexState.NEW, v.getState());
     dispatcher.getEventHandler().handle(new VertexEvent(v.getVertexId(),
           VertexEventType.V_INIT));
     dispatcher.await();
@@ -2967,25 +2973,25 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTermination(v.getVertexId(), VertexTerminationCause.DAG_TERMINATED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.KILLED, v.getState());
-    Assert.assertEquals(v.getTerminationCause(), VertexTerminationCause.DAG_TERMINATED);
+    assertEquals(VertexState.KILLED, v.getState());
+    assertEquals(v.getTerminationCause(), VertexTerminationCause.DAG_TERMINATED);
   }
 
   private void startVertex(VertexImpl v,
       boolean checkRunningState) {
-    Assert.assertEquals(VertexState.INITED, v.getState());
+    assertEquals(VertexState.INITED, v.getState());
     dispatcher.getEventHandler().handle(new VertexEvent(v.getVertexId(),
           VertexEventType.V_START));
     dispatcher.await();
     if (checkRunningState) {
-      Assert.assertEquals(VertexState.RUNNING, v.getState());
+      assertEquals(VertexState.RUNNING, v.getState());
     }
   }
 
   private void completeAllTasksSuccessfully(Vertex v) {
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(VertexState.RUNNING, v.getState());
     Set<TezTaskID> tasks = v.getTasks().keySet();
-    Assert.assertFalse(tasks.isEmpty());
+    assertFalse(tasks.isEmpty());
     for (TezTaskID task : tasks) {
       dispatcher.getEventHandler()
           .handle(new VertexEventTaskCompleted(task, TaskState.SUCCEEDED));
@@ -2993,19 +2999,20 @@ public class TestVertexImpl {
     dispatcher.await();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexInit() throws AMUserCodeException {
     initAllVertices(VertexState.INITED);
 
     VertexImpl v3 = vertices.get("vertex3");
 
-    Assert.assertEquals("x3.y3", v3.getProcessorName());
-    Assert.assertTrue(v3.getJavaOpts().contains("foo"));
+    assertEquals("x3.y3", v3.getProcessorName());
+    assertTrue(v3.getJavaOpts().contains("foo"));
 
-    Assert.assertEquals(2, v3.getInputSpecList(0).size());
-    Assert.assertEquals(2, v3.getInputVerticesCount());
-    Assert.assertEquals(2, v3.getOutputVerticesCount());
-    Assert.assertEquals(2, v3.getOutputVerticesCount());
+    assertEquals(2, v3.getInputSpecList(0).size());
+    assertEquals(2, v3.getInputVerticesCount());
+    assertEquals(2, v3.getOutputVerticesCount());
+    assertEquals(2, v3.getOutputVerticesCount());
 
     assertTrue("vertex1".equals(v3.getInputSpecList(0).get(0)
         .getSourceVertexName())
@@ -3042,42 +3049,45 @@ public class TestVertexImpl {
         .getOutputDescriptor().getClassName()));
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNonExistVertexManager() throws TezException {
     setupPreDagCreation();
     dagPlan = createDAGPlanWithNonExistVertexManager();
     setupPostDagCreation(false);
     VertexImpl v1 = vertices.get("vertex1");
     v1.handle(new VertexEvent(v1.getVertexId(), VertexEventType.V_INIT));
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
-    Assert.assertEquals(VertexTerminationCause.INIT_FAILURE, v1.getTerminationCause());
-    Assert.assertTrue(StringUtils.join(v1.getDiagnostics(),"")
+    assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(VertexTerminationCause.INIT_FAILURE, v1.getTerminationCause());
+    assertTrue(StringUtils.join(v1.getDiagnostics(),"")
         .contains("java.lang.ClassNotFoundException: non-exist-vertexmanager"));
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNonExistInputInitializer() throws TezException {
     setupPreDagCreation();
     dagPlan = createDAGPlanWithNonExistInputInitializer();
     setupPostDagCreation(false);
     VertexImpl v1 = vertices.get("vertex1");
     v1.handle(new VertexEvent(v1.getVertexId(), VertexEventType.V_INIT));
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
-    Assert.assertEquals(VertexTerminationCause.INIT_FAILURE, v1.getTerminationCause());
-    Assert.assertTrue(StringUtils.join(v1.getDiagnostics(),"")
+    assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(VertexTerminationCause.INIT_FAILURE, v1.getTerminationCause());
+    assertTrue(StringUtils.join(v1.getDiagnostics(),"")
         .contains("java.lang.ClassNotFoundException: non-exist-input-initializer"));
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNonExistOutputCommitter() throws TezException {
     setupPreDagCreation();
     dagPlan = createDAGPlanWithNonExistOutputCommitter();
     setupPostDagCreation(false);
     VertexImpl v1 = vertices.get("vertex1");
     v1.handle(new VertexEvent(v1.getVertexId(), VertexEventType.V_INIT));
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
-    Assert.assertEquals(VertexTerminationCause.INIT_FAILURE, v1.getTerminationCause());
-    Assert.assertTrue(StringUtils.join(v1.getDiagnostics(),"")
+    assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(VertexTerminationCause.INIT_FAILURE, v1.getTerminationCause());
+    assertTrue(StringUtils.join(v1.getDiagnostics(),"")
         .contains("java.lang.ClassNotFoundException: non-exist-output-committer"));
   }
 
@@ -3089,7 +3099,8 @@ public class TestVertexImpl {
     }
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexConfigureEvent() throws Exception {
     initAllVertices(VertexState.INITED);
     TestUpdateListener listener = new TestUpdateListener();
@@ -3098,14 +3109,15 @@ public class TestVertexImpl {
             EnumSet.of(org.apache.tez.dag.api.event.VertexState.CONFIGURED),
             listener);
     // completely configured event received for vertex when it inits
-    Assert.assertEquals(1, listener.events.size());
-    Assert.assertEquals("vertex3", listener.events.get(0).getVertexName());
-    Assert.assertEquals(org.apache.tez.dag.api.event.VertexState.CONFIGURED,
+    assertEquals(1, listener.events.size());
+    assertEquals("vertex3", listener.events.get(0).getVertexName());
+    assertEquals(org.apache.tez.dag.api.event.VertexState.CONFIGURED,
         listener.events.get(0).getVertexState());
     updateTracker.unregisterForVertexUpdates("vertex3", listener);
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexConfigureEventWithReconfigure() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -3129,19 +3141,20 @@ public class TestVertexImpl {
     RootInputInitializerManagerControlled initializerManager1 = v1.getRootInputInitializerManager();
     initializerManager1.completeInputInitialization();
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v2.getState());
-    Assert.assertEquals(0, listener.events.size()); // configured event not sent
+    assertEquals(VertexState.INITED, v2.getState());
+    assertEquals(0, listener.events.size()); // configured event not sent
     startVertex(v1, true);
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v2.getState());
-    Assert.assertEquals(1, listener.events.size()); // configured event sent after VM
-    Assert.assertEquals("vertex2", listener.events.get(0).getVertexName());
-    Assert.assertEquals(org.apache.tez.dag.api.event.VertexState.CONFIGURED,
+    assertEquals(VertexState.RUNNING, v2.getState());
+    assertEquals(1, listener.events.size()); // configured event sent after VM
+    assertEquals("vertex2", listener.events.get(0).getVertexName());
+    assertEquals(org.apache.tez.dag.api.event.VertexState.CONFIGURED,
         listener.events.get(0).getVertexState());
     updateTracker.unregisterForVertexUpdates("vertex2", listener);
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexConfigureEventBadReconfigure() {
     initAllVertices(VertexState.INITED);
     VertexImpl v3 = vertices.get("vertex3");
@@ -3152,13 +3165,14 @@ public class TestVertexImpl {
     try {
       // cannot call doneReconfiguringVertex() without calling vertexReconfigurationPlanned()
       v3.doneReconfiguringVertex();
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("invoked only after vertexReconfigurationPlanned"));
+      assertTrue(e.getMessage().contains("invoked only after vertexReconfigurationPlanned"));
     }
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexConfigureEventBadSetParallelism() throws Exception {
     initAllVertices(VertexState.INITED);
     VertexImpl v3 = vertices.get("vertex3");
@@ -3169,13 +3183,14 @@ public class TestVertexImpl {
     try {
       // cannot reconfigure a fully configured vertex without first notifying
       v3.reconfigureVertex(1, null, null);
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("context.vertexReconfigurationPlanned() before re-configuring"));
+      assertTrue(e.getMessage().contains("context.vertexReconfigurationPlanned() before re-configuring"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexStart() {
     initAllVertices(VertexState.INITED);
 
@@ -3183,7 +3198,8 @@ public class TestVertexImpl {
     startVertex(v);
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexGetTAAttempts() throws Exception {
     initAllVertices(VertexState.INITED);
     VertexImpl v1 = vertices.get("vertex1");
@@ -3193,8 +3209,8 @@ public class TestVertexImpl {
     VertexImpl v3 = vertices.get("vertex3");
     VertexImpl v4 = vertices.get("vertex4");
 
-    Assert.assertEquals(VertexState.RUNNING, v4.getState());
-    Assert.assertEquals(1, v4.sourceVertices.size());
+    assertEquals(VertexState.RUNNING, v4.getState());
+    assertEquals(1, v4.sourceVertices.size());
     Edge e = v4.sourceVertices.get(v3);
     TezTaskAttemptID v3TaId = TezTaskAttemptID.getInstance(
         TezTaskID.getInstance(v3.getVertexId(), 0), 0);
@@ -3209,7 +3225,7 @@ public class TestVertexImpl {
     dispatcher.await();
     // verify all events have been put in pending.
     // this is not necessary after legacy routing has been removed
-    Assert.assertEquals(5, v4.pendingTaskEvents.size());
+    assertEquals(5, v4.pendingTaskEvents.size());
     List<ScheduleTaskRequest> taskList = new LinkedList<VertexManagerPluginContext.ScheduleTaskRequest>();
     // scheduling start to trigger edge routing to begin
     for (int i=0; i<v4.getTotalTasks(); ++i) {
@@ -3218,7 +3234,7 @@ public class TestVertexImpl {
     v4.scheduleTasks(taskList);
     dispatcher.await();
     // verify all events have been moved to taskEvents
-    Assert.assertEquals(5, v4.getOnDemandRouteEvents().size());
+    assertEquals(5, v4.getOnDemandRouteEvents().size());
     for (int i=5; i<11; ++i) {
       v4.handle(new VertexEventRouteEvent(v4.getVertexId(), Collections.singletonList(
           new TezEvent(DataMovementEvent.create(0, null),
@@ -3226,7 +3242,7 @@ public class TestVertexImpl {
     }
     dispatcher.await();
     // verify all events have been are in taskEvents
-    Assert.assertEquals(11, v4.getOnDemandRouteEvents().size());
+    assertEquals(11, v4.getOnDemandRouteEvents().size());
 
     TaskAttemptEventInfo eventInfo;
     EdgeManagerPluginOnDemand mockPlugin = mock(EdgeManagerPluginOnDemand.class);
@@ -3235,8 +3251,8 @@ public class TestVertexImpl {
     // source task id will not match. all events will return null
     when(mockPlugin.routeDataMovementEventToDestination(1, 0, 0)).thenReturn(mockRoute);
     eventInfo = v4.getTaskAttemptTezEvents(v4TaId, 0, 0, 1);
-    Assert.assertEquals(11, eventInfo.getNextFromEventId()); // all events traversed
-    Assert.assertEquals(0, eventInfo.getEvents().size()); // no events
+    assertEquals(11, eventInfo.getNextFromEventId()); // all events traversed
+    assertEquals(0, eventInfo.getEvents().size()); // no events
 
     int fromEventId = 0;
     // source task id will match. all events will be returned
@@ -3247,31 +3263,31 @@ public class TestVertexImpl {
     for (int i=0; i<11; ++i) {
       eventInfo = v4.getTaskAttemptTezEvents(v4TaId, fromEventId, 0, 1);
       fromEventId = eventInfo.getNextFromEventId();
-      Assert.assertEquals((i+1), fromEventId);
-      Assert.assertEquals(1, eventInfo.getEvents().size());
+      assertEquals((i+1), fromEventId);
+      assertEquals(1, eventInfo.getEvents().size());
     }
     eventInfo = v4.getTaskAttemptTezEvents(v4TaId, fromEventId, 0, 1);
-    Assert.assertEquals(11, eventInfo.getNextFromEventId()); // all events traversed
-    Assert.assertEquals(0, eventInfo.getEvents().size()); // no events
+    assertEquals(11, eventInfo.getNextFromEventId()); // all events traversed
+    assertEquals(0, eventInfo.getEvents().size()); // no events
 
     // ask for events with sufficient buffer. get all events in a single shot.
     fromEventId = 0;
     eventInfo = v4.getTaskAttemptTezEvents(v4TaId, fromEventId, 0, 100);
     fromEventId = eventInfo.getNextFromEventId();
-    Assert.assertEquals(11, fromEventId);
-    Assert.assertEquals(11, eventInfo.getEvents().size());
+    assertEquals(11, fromEventId);
+    assertEquals(11, eventInfo.getEvents().size());
 
     // change max events to larger value. max events does not evenly divide total events
     fromEventId = 0;
     for (int i=1; i<=2; ++i) {
       eventInfo = v4.getTaskAttemptTezEvents(v4TaId, fromEventId, 0, 5);
       fromEventId = eventInfo.getNextFromEventId();
-      Assert.assertEquals((i*5), fromEventId);
-      Assert.assertEquals(5, eventInfo.getEvents().size());
+      assertEquals((i*5), fromEventId);
+      assertEquals(5, eventInfo.getEvents().size());
     }
     eventInfo = v4.getTaskAttemptTezEvents(v4TaId, fromEventId, 0, 5);
-    Assert.assertEquals(11, eventInfo.getNextFromEventId()); // all events traversed
-    Assert.assertEquals(1, eventInfo.getEvents().size()); // remainder events
+    assertEquals(11, eventInfo.getNextFromEventId()); // all events traversed
+    assertEquals(1, eventInfo.getEvents().size()); // remainder events
 
     // return more events that dont evenly fit in max size
     mockRoute = EventRouteMetadata.create(2, new int[]{0, 0});
@@ -3283,15 +3299,16 @@ public class TestVertexImpl {
     for (int i=1; i<=4; ++i) {
       eventInfo = v4.getTaskAttemptTezEvents(v4TaId, fromEventId, 0, 5);
       fromEventId = eventInfo.getNextFromEventId();
-      Assert.assertEquals((i%2 > 0 ? (lastFromEventId+=2) : (lastFromEventId+=3)), fromEventId);
-      Assert.assertEquals(5, eventInfo.getEvents().size());
+      assertEquals((i%2 > 0 ? (lastFromEventId+=2) : (lastFromEventId+=3)), fromEventId);
+      assertEquals(5, eventInfo.getEvents().size());
     }
     eventInfo = v4.getTaskAttemptTezEvents(v4TaId, fromEventId, 0, 5);
-    Assert.assertEquals(11, eventInfo.getNextFromEventId()); // all events traversed
-    Assert.assertEquals(2, eventInfo.getEvents().size()); // remainder events
+    assertEquals(11, eventInfo.getNextFromEventId()); // all events traversed
+    assertEquals(2, eventInfo.getEvents().size()); // remainder events
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexGetTAAttemptsObsoletion() throws Exception {
     initAllVertices(VertexState.INITED);
     VertexImpl v1 = vertices.get("vertex1");
@@ -3307,8 +3324,8 @@ public class TestVertexImpl {
       taskList.add(ScheduleTaskRequest.create(i, null));
     }
     v4.scheduleTasks(taskList);
-    Assert.assertEquals(VertexState.RUNNING, v4.getState());
-    Assert.assertEquals(1, v4.sourceVertices.size());
+    assertEquals(VertexState.RUNNING, v4.getState());
+    assertEquals(1, v4.sourceVertices.size());
     Edge e = v4.sourceVertices.get(v3);
     TezTaskAttemptID v3TaId = TezTaskAttemptID.getInstance(
         TezTaskID.getInstance(v3.getVertexId(), 0), 0);
@@ -3322,7 +3339,7 @@ public class TestVertexImpl {
     }
     dispatcher.await();
     // verify all events have been are in taskEvents
-    Assert.assertEquals(11, v4.getOnDemandRouteEvents().size());
+    assertEquals(11, v4.getOnDemandRouteEvents().size());
 
     TaskAttemptEventInfo eventInfo;
     EdgeManagerPluginOnDemand mockPlugin = mock(EdgeManagerPluginOnDemand.class);
@@ -3344,9 +3361,9 @@ public class TestVertexImpl {
     int fromEventId = 0;
     eventInfo = v4.getTaskAttemptTezEvents(v4TaId, fromEventId, 0, 100);
     fromEventId = eventInfo.getNextFromEventId();
-    Assert.assertEquals(12, fromEventId);
-    Assert.assertEquals(1, eventInfo.getEvents().size());
-    Assert.assertEquals(EventType.INPUT_FAILED_EVENT, eventInfo.getEvents().get(0).getEventType());
+    assertEquals(12, fromEventId);
+    assertEquals(1, eventInfo.getEvents().size());
+    assertEquals(EventType.INPUT_FAILED_EVENT, eventInfo.getEvents().get(0).getEventType());
 
     // Let failed task send more event
     for (int i=11; i<14; ++i) {
@@ -3357,14 +3374,15 @@ public class TestVertexImpl {
     dispatcher.await();
     // 11 events + 1 INPUT_FAILED_EVENT.
     // Events sent out later by failed tasks should not be available.
-    Assert.assertEquals(12, v4.getOnDemandRouteEvents().size());
+    assertEquals(12, v4.getOnDemandRouteEvents().size());
 
     fromEventId = 0;
     eventInfo = v4.getTaskAttemptTezEvents(v4TaId, fromEventId, 0, 100);
-    Assert.assertEquals(EventType.INPUT_FAILED_EVENT, eventInfo.getEvents().get(0).getEventType());
+    assertEquals(EventType.INPUT_FAILED_EVENT, eventInfo.getEvents().get(0).getEventType());
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexGetTAAttemptsObsoletionWithPendingRoutes() throws Exception {
     initAllVertices(VertexState.INITED);
     VertexImpl v1 = vertices.get("vertex1");
@@ -3380,8 +3398,8 @@ public class TestVertexImpl {
       taskList.add(ScheduleTaskRequest.create(i, null));
     }
     v4.scheduleTasks(taskList);
-    Assert.assertEquals(VertexState.RUNNING, v4.getState());
-    Assert.assertEquals(1, v4.sourceVertices.size());
+    assertEquals(VertexState.RUNNING, v4.getState());
+    assertEquals(1, v4.sourceVertices.size());
     Edge e = v4.sourceVertices.get(v3);
     TezTaskAttemptID v3TaId = TezTaskAttemptID.getInstance(
         TezTaskID.getInstance(v3.getVertexId(), 0), 0);
@@ -3395,7 +3413,7 @@ public class TestVertexImpl {
     }
     dispatcher.await();
     // verify all events have been are in taskEvents
-    Assert.assertEquals(11, v4.getOnDemandRouteEvents().size());
+    assertEquals(11, v4.getOnDemandRouteEvents().size());
 
     TaskAttemptEventInfo eventInfo;
     EdgeManagerPluginOnDemand mockPlugin = mock(EdgeManagerPluginOnDemand.class);
@@ -3414,8 +3432,8 @@ public class TestVertexImpl {
     int fromEventId = 0;
     eventInfo = v4.getTaskAttemptTezEvents(v4TaId, fromEventId, 0, 5);
     fromEventId = eventInfo.getNextFromEventId();
-    Assert.assertEquals(2, fromEventId); // 0-1 events expanded and fit, 2nd event has pending routes
-    Assert.assertEquals(5, eventInfo.getEvents().size());
+    assertEquals(2, fromEventId); // 0-1 events expanded and fit, 2nd event has pending routes
+    assertEquals(5, eventInfo.getEvents().size());
 
     // send an input failed event
     v4.handle(new VertexEventRouteEvent(v4.getVertexId(), Collections.singletonList(
@@ -3425,44 +3443,46 @@ public class TestVertexImpl {
     // get only input failed event. all DM events obsoleted
     eventInfo = v4.getTaskAttemptTezEvents(v4TaId, fromEventId, 0, 5);
     fromEventId = eventInfo.getNextFromEventId();
-    Assert.assertEquals(12, fromEventId);
-    Assert.assertEquals(1, eventInfo.getEvents().size());
-    Assert.assertEquals(EventType.INPUT_FAILED_EVENT, eventInfo.getEvents().get(0).getEventType());
+    assertEquals(12, fromEventId);
+    assertEquals(1, eventInfo.getEvents().size());
+    assertEquals(EventType.INPUT_FAILED_EVENT, eventInfo.getEvents().get(0).getEventType());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexReconfigurePlannedAfterInit() throws Exception {
     initAllVertices(VertexState.INITED);
     VertexImpl v3 = vertices.get("vertex3");
 
     try {
       v3.vertexReconfigurationPlanned();
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("context.vertexReconfigurationPlanned() cannot be called after initialize()"));
+      assertTrue(e.getMessage().contains("context.vertexReconfigurationPlanned() cannot be called after initialize()"));
     }
   }
 
   private void checkTasks(Vertex v, int numTasks) {
-    Assert.assertEquals(numTasks, v.getTotalTasks());
+    assertEquals(numTasks, v.getTotalTasks());
     Map<TezTaskID, Task> tasks = v.getTasks();
-    Assert.assertEquals(numTasks, tasks.size());
+    assertEquals(numTasks, tasks.size());
     // check all indices
     int i = 0;
     // iteration maintains order due to linked hash map
     for(Task task : tasks.values()) {
-      Assert.assertEquals(i, task.getTaskID().getId());
+      assertEquals(i, task.getTaskID().getId());
       i++;
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexSetParallelismDecrease() throws Exception {
     VertexImpl v3 = vertices.get("vertex3");
     v3.vertexReconfigurationPlanned();
     initAllVertices(VertexState.INITED);
-    Assert.assertEquals(2, v3.getTotalTasks());
-    Assert.assertEquals(2, v3.getTasks().size());
+    assertEquals(2, v3.getTotalTasks());
+    assertEquals(2, v3.getTasks().size());
 
     VertexImpl v1 = vertices.get("vertex1");
     startVertex(vertices.get("vertex2"));
@@ -3478,18 +3498,18 @@ public class TestVertexImpl {
        v1.getName(), edgeProp);
     v3.reconfigureVertex(1, null, edgeManagerDescriptors);
     v3.doneReconfiguringVertex();
-    assertTrue(v3.sourceVertices.get(v1).getEdgeManager() instanceof
-        EdgeManagerForTest);
+    assertInstanceOf(EdgeManagerForTest.class, v3.sourceVertices.get(v1).getEdgeManager());
     checkTasks(v3, 1);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexSetParallelismIncrease() throws Exception {
     VertexImpl v3 = vertices.get("vertex3");
     v3.vertexReconfigurationPlanned();
     initAllVertices(VertexState.INITED);
-    Assert.assertEquals(2, v3.getTotalTasks());
-    Assert.assertEquals(2, v3.getTasks().size());
+    assertEquals(2, v3.getTotalTasks());
+    assertEquals(2, v3.getTasks().size());
 
     VertexImpl v1 = vertices.get("vertex1");
     startVertex(vertices.get("vertex2"));
@@ -3505,19 +3525,19 @@ public class TestVertexImpl {
        v1.getName(), edgeProp);
     v3.reconfigureVertex(10, null, edgeManagerDescriptors);
     v3.doneReconfiguringVertex();
-    assertTrue(v3.sourceVertices.get(v1).getEdgeManager() instanceof
-        EdgeManagerForTest);
+    assertInstanceOf(EdgeManagerForTest.class, v3.sourceVertices.get(v1).getEdgeManager());
     checkTasks(v3, 10);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexSetParallelismMultiple() throws Exception {
     VertexImpl v3 = vertices.get("vertex3");
     v3.vertexReconfigurationPlanned();
     initAllVertices(VertexState.INITED);
-    Assert.assertEquals(2, v3.getTotalTasks());
+    assertEquals(2, v3.getTotalTasks());
     Map<TezTaskID, Task> tasks = v3.getTasks();
-    Assert.assertEquals(2, tasks.size());
+    assertEquals(2, tasks.size());
 
     VertexImpl v1 = vertices.get("vertex1");
     startVertex(vertices.get("vertex2"));
@@ -3530,14 +3550,15 @@ public class TestVertexImpl {
     v3.doneReconfiguringVertex();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexSetParallelismMultipleFailAfterDone() throws Exception {
     VertexImpl v3 = vertices.get("vertex3");
     v3.vertexReconfigurationPlanned();
     initAllVertices(VertexState.INITED);
-    Assert.assertEquals(2, v3.getTotalTasks());
+    assertEquals(2, v3.getTotalTasks());
     Map<TezTaskID, Task> tasks = v3.getTasks();
-    Assert.assertEquals(2, tasks.size());
+    assertEquals(2, tasks.size());
 
     VertexImpl v1 = vertices.get("vertex1");
     startVertex(vertices.get("vertex2"));
@@ -3548,20 +3569,21 @@ public class TestVertexImpl {
 
     try {
       v3.reconfigureVertex(5, null, null);
-      Assert.fail();
+      fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("Vertex is fully configured but still"));
+      assertTrue(e.getMessage().contains("Vertex is fully configured but still"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexSetParallelismMultipleFailAfterSchedule() throws Exception {
     VertexImpl v3 = vertices.get("vertex3");
     v3.vertexReconfigurationPlanned();
     initAllVertices(VertexState.INITED);
-    Assert.assertEquals(2, v3.getTotalTasks());
+    assertEquals(2, v3.getTotalTasks());
     Map<TezTaskID, Task> tasks = v3.getTasks();
-    Assert.assertEquals(2, tasks.size());
+    assertEquals(2, tasks.size());
 
     VertexImpl v1 = vertices.get("vertex1");
     startVertex(vertices.get("vertex2"));
@@ -3571,20 +3593,21 @@ public class TestVertexImpl {
     v3.scheduleTasks(Collections.singletonList(ScheduleTaskRequest.create(0, null)));
     try {
       v3.reconfigureVertex(5, null, null);
-      Assert.fail();
+      fail();
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains("setParallelism cannot be called after scheduling"));
+      assertTrue(e.getMessage().contains("setParallelism cannot be called after scheduling"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexScheduleSendEvent() throws Exception {
     VertexImpl v3 = vertices.get("vertex3");
     v3.vertexReconfigurationPlanned();
     initAllVertices(VertexState.INITED);
-    Assert.assertEquals(2, v3.getTotalTasks());
+    assertEquals(2, v3.getTotalTasks());
     Map<TezTaskID, Task> tasks = v3.getTasks();
-    Assert.assertEquals(2, tasks.size());
+    assertEquals(2, tasks.size());
 
     VertexImpl v1 = vertices.get("vertex1");
     startVertex(vertices.get("vertex2"));
@@ -3595,21 +3618,22 @@ public class TestVertexImpl {
     TaskLocationHint mockLocation = mock(TaskLocationHint.class);
     v3.scheduleTasks(Collections.singletonList(ScheduleTaskRequest.create(0, mockLocation)));
     dispatcher.await();
-    Assert.assertEquals(1, taskEventDispatcher.events.size());
+    assertEquals(1, taskEventDispatcher.events.size());
     TaskEventScheduleTask event = (TaskEventScheduleTask) taskEventDispatcher.events.get(0);
-    Assert.assertEquals(mockLocation, event.getTaskLocationHint());
-    Assert.assertNotNull(event.getBaseTaskSpec());
-    Assert.assertEquals("foobar", event.getBaseTaskSpec().getTaskConf().get("abc"));
+    assertEquals(mockLocation, event.getTaskLocationHint());
+    assertNotNull(event.getBaseTaskSpec());
+    assertEquals("foobar", event.getBaseTaskSpec().getTaskConf().get("abc"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexSetParallelismFailAfterSchedule() throws Exception {
     VertexImpl v3 = vertices.get("vertex3");
     v3.vertexReconfigurationPlanned();
     initAllVertices(VertexState.INITED);
-    Assert.assertEquals(2, v3.getTotalTasks());
+    assertEquals(2, v3.getTotalTasks());
     Map<TezTaskID, Task> tasks = v3.getTasks();
-    Assert.assertEquals(2, tasks.size());
+    assertEquals(2, tasks.size());
 
     VertexImpl v1 = vertices.get("vertex1");
     startVertex(vertices.get("vertex2"));
@@ -3617,13 +3641,14 @@ public class TestVertexImpl {
     v3.scheduleTasks(Collections.singletonList(ScheduleTaskRequest.create(0, null)));
     try {
       v3.reconfigureVertex(5, null, null);
-      Assert.fail();
+      fail();
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains("setParallelism cannot be called after scheduling"));
+      assertTrue(e.getMessage().contains("setParallelism cannot be called after scheduling"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexPendingTaskEvents() {
     // Remove after bulk routing API is removed
     initAllVertices(VertexState.INITED);
@@ -3649,18 +3674,19 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventRouteEvent(v3.getVertexId(), taskEvents));
     dispatcher.await();
-    Assert.assertEquals(2, v3.pendingTaskEvents.size());
+    assertEquals(2, v3.pendingTaskEvents.size());
     v3.scheduleTasks(Collections.singletonList(ScheduleTaskRequest.create(0, null)));
     dispatcher.await();
-    Assert.assertEquals(0, v3.pendingTaskEvents.size());
+    assertEquals(0, v3.pendingTaskEvents.size());
     // send events and test that they are not buffered anymore
     dispatcher.getEventHandler().handle(
         new VertexEventRouteEvent(v3.getVertexId(), taskEvents));
     dispatcher.await();
-    Assert.assertEquals(0, v3.pendingTaskEvents.size());
+    assertEquals(0, v3.pendingTaskEvents.size());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSetCustomEdgeManager() throws Exception {
     VertexImpl v5 = vertices.get("vertex5"); // Vertex5 linked to v3 (v3 src, v5 dest)
     v5.vertexReconfigurationPlanned();
@@ -3668,8 +3694,8 @@ public class TestVertexImpl {
     Edge edge = edges.get("e4");
     EdgeManagerPlugin em = edge.getEdgeManager();
     EdgeManagerForTest originalEm = (EdgeManagerForTest) em;
-    assertTrue(Arrays.equals(edgePayload, originalEm.getEdgeManagerContext()
-        .getUserPayload().deepCopyAsArray()));
+    assertArrayEquals(edgePayload, originalEm.getEdgeManagerContext()
+        .getUserPayload().deepCopyAsArray());
 
     UserPayload userPayload = UserPayload.create(ByteBuffer.wrap(new String("foo").getBytes()));
     EdgeManagerPluginDescriptor edgeManagerDescriptor =
@@ -3690,15 +3716,16 @@ public class TestVertexImpl {
 
     EdgeManagerPlugin modifiedEdgeManager = v5Impl.sourceVertices.get(v3)
         .getEdgeManager();
-    Assert.assertNotNull(modifiedEdgeManager);
-    assertTrue(modifiedEdgeManager instanceof EdgeManagerForTest);
+    assertNotNull(modifiedEdgeManager);
+    assertInstanceOf(EdgeManagerForTest.class, modifiedEdgeManager);
 
     // Ensure initialize() is called with the correct payload
-    assertTrue(Arrays.equals(userPayload.deepCopyAsArray(),
-        ((EdgeManagerForTest) modifiedEdgeManager).getUserPayload().deepCopyAsArray()));
+    assertArrayEquals(userPayload.deepCopyAsArray(),
+        ((EdgeManagerForTest) modifiedEdgeManager).getUserPayload().deepCopyAsArray());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasicVertexCompletion() {
     initAllVertices(VertexState.INITED);
 
@@ -3711,25 +3738,26 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t1, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
-    Assert.assertEquals(1, v.getCompletedTasks());
-    Assert.assertTrue((0.5f) == v.getCompletedTaskProgress());
+    assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(1, v.getCompletedTasks());
+    assertEquals((0.5f), v.getCompletedTaskProgress());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertEquals(2, v.getCompletedTasks());
-    Assert.assertTrue((1.0f) == v.getCompletedTaskProgress());
-    Assert.assertTrue(v.initTimeRequested > 0);
-    Assert.assertTrue(v.initedTime > 0);
-    Assert.assertTrue(v.startTimeRequested > 0);
-    Assert.assertTrue(v.startedTime > 0);
-    Assert.assertTrue(v.finishTime > 0);
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(2, v.getCompletedTasks());
+    assertEquals((1.0f), v.getCompletedTaskProgress());
+    assertTrue(v.initTimeRequested > 0);
+    assertTrue(v.initedTime > 0);
+    assertTrue(v.startTimeRequested > 0);
+    assertTrue(v.startedTime > 0);
+    assertTrue(v.finishTime > 0);
   }
 
-  @Test(timeout = 5000)
-  @Ignore // FIXME fix verteximpl for this test to work
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  @Disabled // FIXME fix verteximpl for this test to work
   public void testDuplicateTaskCompletion() {
     initAllVertices(VertexState.INITED);
 
@@ -3742,20 +3770,21 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t1, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(VertexState.RUNNING, v.getState());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t1, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(VertexState.RUNNING, v.getState());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(VertexState.SUCCEEDED, v.getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexFailure() {
     initAllVertices(VertexState.INITED);
 
@@ -3767,15 +3796,16 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t1, TaskState.FAILED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.FAILED, v.getState());
-    Assert.assertEquals(VertexTerminationCause.OWN_TASK_FAILURE, v.getTerminationCause());
+    assertEquals(VertexState.FAILED, v.getState());
+    assertEquals(VertexTerminationCause.OWN_TASK_FAILURE, v.getTerminationCause());
     String diagnostics =
         StringUtils.join(v.getDiagnostics(), ",").toLowerCase(Locale.ENGLISH);
     assertTrue(diagnostics.contains("task failed"
         + ", taskid=" + t1.toString()));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexKillDiagnosticsInInit() {
     initAllVertices(VertexState.INITED);
     VertexImpl v2 = vertices.get("vertex4");
@@ -3787,7 +3817,8 @@ public class TestVertexImpl {
         "vertex received kill in inited state"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexKillDiagnosticsInRunning() {
     initAllVertices(VertexState.INITED);
     VertexImpl v3 = vertices.get("vertex3");
@@ -3799,11 +3830,12 @@ public class TestVertexImpl {
         StringUtils.join(v3.getDiagnostics(), ",").toLowerCase(Locale.ENGLISH);
     assertTrue(diagnostics.contains(
         "vertex received kill while in running state"));
-    Assert.assertEquals(VertexTerminationCause.DAG_TERMINATED, v3.getTerminationCause());
+    assertEquals(VertexTerminationCause.DAG_TERMINATED, v3.getTerminationCause());
     assertTrue(diagnostics.contains(v3.getTerminationCause().name().toLowerCase(Locale.ENGLISH)));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexKillPending() {
     initAllVertices(VertexState.INITED);
 
@@ -3813,22 +3845,23 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTermination(v.getVertexId(), VertexTerminationCause.DAG_TERMINATED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.KILLED, v.getState());
+    assertEquals(VertexState.KILLED, v.getState());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(
             TezTaskID.getInstance(v.getVertexId(), 0), TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.KILLED, v.getState());
+    assertEquals(VertexState.KILLED, v.getState());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(
             TezTaskID.getInstance(v.getVertexId(), 1), TaskState.KILLED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.KILLED, v.getState());
+    assertEquals(VertexState.KILLED, v.getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexKill() {
     initAllVertices(VertexState.INITED);
 
@@ -3838,22 +3871,23 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTermination(v.getVertexId(), VertexTerminationCause.DAG_TERMINATED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.KILLED, v.getState());
+    assertEquals(VertexState.KILLED, v.getState());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(
             TezTaskID.getInstance(v.getVertexId(), 0), TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.KILLED, v.getState());
+    assertEquals(VertexState.KILLED, v.getState());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(
             TezTaskID.getInstance(v.getVertexId(), 1), TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.KILLED, v.getState());
+    assertEquals(VertexState.KILLED, v.getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testKilledTasksHandling() {
     initAllVertices(VertexState.INITED);
 
@@ -3866,35 +3900,35 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t1, TaskState.FAILED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.FAILED, v.getState());
-    Assert.assertEquals(VertexTerminationCause.OWN_TASK_FAILURE, v.getTerminationCause());
-    Assert.assertEquals(TaskState.KILLED, v.getTask(t2).getState());
+    assertEquals(VertexState.FAILED, v.getState());
+    assertEquals(VertexTerminationCause.OWN_TASK_FAILURE, v.getTerminationCause());
+    assertEquals(TaskState.KILLED, v.getTask(t2).getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexCommitterInit() {
     initAllVertices(VertexState.INITED);
     VertexImpl v2 = vertices.get("vertex2");
-    Assert.assertNull(v2.getOutputCommitter("output"));
+    assertNull(v2.getOutputCommitter("output"));
 
     VertexImpl v6 = vertices.get("vertex6");
-    assertTrue(v6.getOutputCommitter("outputx")
-        instanceof CountingOutputCommitter);
+    assertInstanceOf(CountingOutputCommitter.class, v6.getOutputCommitter("outputx"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexManagerInit() {
     initAllVertices(VertexState.INITED);
     VertexImpl v2 = vertices.get("vertex2");
-    assertTrue(v2.getVertexManager().getPlugin()
-        instanceof ImmediateStartVertexManager);
+    assertInstanceOf(ImmediateStartVertexManager.class, v2.getVertexManager().getPlugin());
 
     VertexImpl v6 = vertices.get("vertex6");
-    assertTrue(v6.getVertexManager().getPlugin()
-        instanceof ShuffleVertexManager);
+    assertInstanceOf(ShuffleVertexManager.class, v6.getVertexManager().getPlugin());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexTaskFailure() {
     initAllVertices(VertexState.INITED);
 
@@ -3911,21 +3945,22 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t1, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(VertexState.RUNNING, v.getState());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.FAILED));
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.FAILED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.FAILED, v.getState());
-    Assert.assertEquals(VertexTerminationCause.OWN_TASK_FAILURE, v.getTerminationCause());
-    Assert.assertEquals(0, committer.commitCounter);
-    Assert.assertEquals(1, committer.abortCounter);
+    assertEquals(VertexState.FAILED, v.getState());
+    assertEquals(VertexTerminationCause.OWN_TASK_FAILURE, v.getTerminationCause());
+    assertEquals(0, committer.commitCounter);
+    assertEquals(1, committer.abortCounter);
   }
 
   @SuppressWarnings("deprecation")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexTaskAttemptProcessorFailure() throws Exception {
     initAllVertices(VertexState.INITED);
 
@@ -3950,17 +3985,18 @@ public class TestVertexImpl {
 
     ta.handle(new TaskAttemptEventSubmitted(ta.getTaskAttemptID(), contId));
     ta.handle(new TaskAttemptEventStartedRemotely(ta.getTaskAttemptID()));
-    Assert.assertEquals(TaskAttemptStateInternal.RUNNING, ta.getInternalState());
+    assertEquals(TaskAttemptStateInternal.RUNNING, ta.getInternalState());
     ta.handle(new TaskAttemptEventAttemptFailed(ta.getTaskAttemptID(), TaskAttemptEventType.TA_FAILED,
         TaskFailureType.NON_FATAL,
         "diag", TaskAttemptTerminationCause.APPLICATION_ERROR));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
-    Assert.assertEquals(TaskAttemptTerminationCause.APPLICATION_ERROR, ta.getTerminationCause());
+    assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(TaskAttemptTerminationCause.APPLICATION_ERROR, ta.getTerminationCause());
   }
 
   @SuppressWarnings("deprecation")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexTaskAttemptInputFailure() throws Exception {
     initAllVertices(VertexState.INITED);
 
@@ -3985,19 +4021,20 @@ public class TestVertexImpl {
 
     ta.handle(new TaskAttemptEventSubmitted(ta.getTaskAttemptID(), contId));
     ta.handle(new TaskAttemptEventStartedRemotely(ta.getTaskAttemptID()));
-    Assert.assertEquals(TaskAttemptStateInternal.RUNNING, ta.getInternalState());
+    assertEquals(TaskAttemptStateInternal.RUNNING, ta.getInternalState());
 
     ta.handle(new TaskAttemptEventAttemptFailed(ta.getTaskAttemptID(), TaskAttemptEventType.TA_FAILED,
         TaskFailureType.NON_FATAL,
         "diag", TaskAttemptTerminationCause.INPUT_READ_ERROR));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
-    Assert.assertEquals(TaskAttemptTerminationCause.INPUT_READ_ERROR, ta.getTerminationCause());
+    assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(TaskAttemptTerminationCause.INPUT_READ_ERROR, ta.getTerminationCause());
   }
 
 
   @SuppressWarnings("deprecation")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexTaskAttemptOutputFailure() throws Exception {
     initAllVertices(VertexState.INITED);
 
@@ -4022,17 +4059,18 @@ public class TestVertexImpl {
 
     ta.handle(new TaskAttemptEventSubmitted(ta.getTaskAttemptID(), contId));
     ta.handle(new TaskAttemptEventStartedRemotely(ta.getTaskAttemptID()));
-    Assert.assertEquals(TaskAttemptStateInternal.RUNNING, ta.getInternalState());
+    assertEquals(TaskAttemptStateInternal.RUNNING, ta.getInternalState());
 
     ta.handle(new TaskAttemptEventAttemptFailed(ta.getTaskAttemptID(), TaskAttemptEventType.TA_FAILED,
         TaskFailureType.NON_FATAL,
         "diag", TaskAttemptTerminationCause.OUTPUT_WRITE_ERROR));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
-    Assert.assertEquals(TaskAttemptTerminationCause.OUTPUT_WRITE_ERROR, ta.getTerminationCause());
+    assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(TaskAttemptTerminationCause.OUTPUT_WRITE_ERROR, ta.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSourceVertexStartHandling() {
     LOG.info("Testing testSourceVertexStartHandling");
     initAllVertices(VertexState.INITED);
@@ -4042,10 +4080,10 @@ public class TestVertexImpl {
 
     startVertex(vertices.get("vertex1"));
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v3.getState());
+    assertEquals(VertexState.INITED, v3.getState());
     long v3StartTimeRequested = v3.startTimeRequested;
-    Assert.assertEquals(1, v3.numStartedSourceVertices);
-    Assert.assertTrue(v3StartTimeRequested > 0);
+    assertEquals(1, v3.numStartedSourceVertices);
+    assertTrue(v3StartTimeRequested > 0);
     try {
       Thread.sleep(100);
     } catch (InterruptedException e) {
@@ -4054,15 +4092,16 @@ public class TestVertexImpl {
     startVertex(vertices.get("vertex2"));
     dispatcher.await();
     // start request from second source vertex overrides the value from the first source vertex
-    Assert.assertEquals(VertexState.RUNNING, v3.getState());
-    Assert.assertEquals(2, v3.numStartedSourceVertices);
-    Assert.assertTrue(v3.startTimeRequested > v3StartTimeRequested);
+    assertEquals(VertexState.RUNNING, v3.getState());
+    assertEquals(2, v3.numStartedSourceVertices);
+    assertTrue(v3.startTimeRequested > v3StartTimeRequested);
     LOG.info("Verifying v6 state " + v6.getState());
-    Assert.assertEquals(VertexState.RUNNING, v6.getState());
-    Assert.assertEquals(3, v6.getDistanceFromRoot());
+    assertEquals(VertexState.RUNNING, v6.getState());
+    assertEquals(3, v6.getDistanceFromRoot());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSourceTaskAttemptCompletionEvents() {
     LOG.info("Testing testSourceTaskAttemptCompletionEvents");
     initAllVertices(VertexState.INITED);
@@ -4075,7 +4114,7 @@ public class TestVertexImpl {
     startVertex(vertices.get("vertex2"));
     dispatcher.await();
     LOG.info("Verifying v6 state " + v6.getState());
-    Assert.assertEquals(VertexState.RUNNING, v6.getState());
+    assertEquals(VertexState.RUNNING, v6.getState());
 
     TezTaskID t1_v4 = TezTaskID.getInstance(v4.getVertexId(), 0);
     TezTaskID t2_v4 = TezTaskID.getInstance(v4.getVertexId(), 1);
@@ -4102,14 +4141,15 @@ public class TestVertexImpl {
     v5.handle(new VertexEventTaskCompleted(t2_v5, TaskState.SUCCEEDED));
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.SUCCEEDED, v4.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v5.getState());
-    Assert.assertEquals(VertexState.RUNNING, v6.getState());
-    Assert.assertEquals(4, v6.numSuccessSourceAttemptCompletions);
+    assertEquals(VertexState.SUCCEEDED, v4.getState());
+    assertEquals(VertexState.SUCCEEDED, v5.getState());
+    assertEquals(VertexState.RUNNING, v6.getState());
+    assertEquals(4, v6.numSuccessSourceAttemptCompletions);
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFailuresMaxPercentSourceTaskAttemptCompletionEvents() throws TezException {
     LOG.info("Testing testFailuresMaxPercentSourceTaskAttemptCompletionEvents");
 
@@ -4131,7 +4171,7 @@ public class TestVertexImpl {
     startVertex(vertices.get("vertex2"));
     dispatcher.await();
     LOG.info("Verifying v6 state " + v6.getState());
-    Assert.assertEquals(VertexState.RUNNING, v6.getState());
+    assertEquals(VertexState.RUNNING, v6.getState());
 
     TezTaskID t1_v4 = TezTaskID.getInstance(v4.getVertexId(), 0);
     TezTaskID t2_v4 = TezTaskID.getInstance(v4.getVertexId(), 1);
@@ -4158,13 +4198,14 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(new TaskEventTAFailed(ta1_t2_v5, TaskFailureType.NON_FATAL, null));
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.SUCCEEDED, v4.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v5.getState());
-    Assert.assertEquals(VertexState.RUNNING, v6.getState());
-    Assert.assertEquals(4, v6.numSuccessSourceAttemptCompletions);
+    assertEquals(VertexState.SUCCEEDED, v4.getState());
+    assertEquals(VertexState.SUCCEEDED, v5.getState());
+    assertEquals(VertexState.RUNNING, v6.getState());
+    assertEquals(4, v6.numSuccessSourceAttemptCompletions);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFailuresMaxPercentExceededSourceTaskAttemptCompletionEvents() throws TezException {
     LOG.info("Testing testFailuresMaxPercentSourceTaskAttemptCompletionEvents");
 
@@ -4186,7 +4227,7 @@ public class TestVertexImpl {
     startVertex(vertices.get("vertex2"));
     dispatcher.await();
     LOG.info("Verifying v6 state " + v6.getState());
-    Assert.assertEquals(VertexState.RUNNING, v6.getState());
+    assertEquals(VertexState.RUNNING, v6.getState());
 
     TezTaskID t1_v4 = TezTaskID.getInstance(v4.getVertexId(), 0);
     TezTaskID t2_v4 = TezTaskID.getInstance(v4.getVertexId(), 1);
@@ -4213,13 +4254,14 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(new TaskEventTAFailed(ta1_t2_v5, TaskFailureType.NON_FATAL, null));
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.FAILED, v4.getState());
-    Assert.assertEquals(VertexState.SUCCEEDED, v5.getState());
-    Assert.assertEquals(VertexState.RUNNING, v6.getState());
-    Assert.assertEquals(2, v6.numSuccessSourceAttemptCompletions);
+    assertEquals(VertexState.FAILED, v4.getState());
+    assertEquals(VertexState.SUCCEEDED, v5.getState());
+    assertEquals(VertexState.RUNNING, v6.getState());
+    assertEquals(2, v6.numSuccessSourceAttemptCompletions);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGEventGeneration() {
     initAllVertices(VertexState.INITED);
 
@@ -4234,13 +4276,14 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertEquals(1,
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(1,
         dagEventDispatcher.eventCount.get(
             DAGEventType.DAG_VERTEX_COMPLETED).intValue());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskReschedule() {
     // For downstream failures
     initAllVertices(VertexState.INITED);
@@ -4261,16 +4304,17 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(VertexState.RUNNING, v.getState());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t1, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(VertexState.SUCCEEDED, v.getState());
 
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTerminatingVertexForTaskComplete() throws Exception {
     setupPreDagCreation();
     dagPlan = createSamplerDAGPlan(false);
@@ -4280,7 +4324,7 @@ public class TestVertexImpl {
     startVertex(vertex);
     vertex.handle(new VertexEventTermination(vertex.getVertexId(), VertexTerminationCause.INTERNAL_ERROR));
     dispatcher.await();
-    Assert.assertTrue(vertex.inTerminalState());
+    assertTrue(vertex.inTerminalState());
     for (String diagnostic : vertex.getDiagnostics()) {
       if (diagnostic.contains("Invalid event")) {
         fail("Unexpected Invalid event transition!");
@@ -4288,7 +4332,8 @@ public class TestVertexImpl {
     }
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTerminatingVertexForVComplete() throws Exception {
     setupPreDagCreation();
     dagPlan = createSamplerDAGPlan(false);
@@ -4300,7 +4345,7 @@ public class TestVertexImpl {
     vertex.handle(new VertexEvent(
         vertex.getVertexId(), VertexEventType.V_COMPLETED));
     dispatcher.await();
-    Assert.assertTrue(vertex.inTerminalState());
+    assertTrue(vertex.inTerminalState());
     for (String diagnostic : vertex.getDiagnostics()) {
       if (diagnostic.contains("Invalid event")) {
         fail("Unexpected Invalid event transition!");
@@ -4308,7 +4353,8 @@ public class TestVertexImpl {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexSuccessToRunningAfterTaskScheduler() {
     // For downstream failures
     initAllVertices(VertexState.INITED);
@@ -4325,30 +4371,31 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertEquals(1,
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(1,
         dagEventDispatcher.eventCount.get(
             DAGEventType.DAG_VERTEX_COMPLETED).intValue());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskReschedule(t1));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(VertexState.RUNNING, v.getState());
 
-    Assert.assertEquals(1,
+    assertEquals(1,
         dagEventDispatcher.eventCount.get(
             DAGEventType.DAG_VERTEX_RERUNNING).intValue());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t1, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertEquals(2,
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(2,
         dagEventDispatcher.eventCount.get(
             DAGEventType.DAG_VERTEX_COMPLETED).intValue());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexSuccessToFailedAfterTaskScheduler() throws Exception {
     // For downstream failures
     VertexImpl v = vertices.get("vertex2");
@@ -4380,22 +4427,23 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertEquals(1,
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(1,
         dagEventDispatcher.eventCount.get(
             DAGEventType.DAG_VERTEX_COMPLETED).intValue());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskReschedule(t1));
     dispatcher.await();
-    Assert.assertEquals(VertexState.FAILED, v.getState());
+    assertEquals(VertexState.FAILED, v.getState());
 
-    Assert.assertEquals(2,
+    assertEquals(2,
         dagEventDispatcher.eventCount.get(
             DAGEventType.DAG_VERTEX_COMPLETED).intValue());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexCommit() {
     initAllVertices(VertexState.INITED);
 
@@ -4414,14 +4462,15 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertEquals(1, committer.commitCounter);
-    Assert.assertEquals(0, committer.abortCounter);
-    Assert.assertEquals(1, committer.initCounter);
-    Assert.assertEquals(1, committer.setupCounter);
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(1, committer.commitCounter);
+    assertEquals(0, committer.abortCounter);
+    assertEquals(1, committer.initCounter);
+    assertEquals(1, committer.setupCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskFailedAfterVertexSuccess() {
     initAllVertices(VertexState.INITED);
 
@@ -4429,7 +4478,7 @@ public class TestVertexImpl {
 
     startVertex(vertices.get("vertex1"));
     startVertex(vertices.get("vertex2"));
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(VertexState.RUNNING, v.getState());
     CountingOutputCommitter committer =
         (CountingOutputCommitter) v.getOutputCommitter("outputx");
 
@@ -4441,22 +4490,23 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertEquals(1, committer.commitCounter);
-    Assert.assertEquals(0, committer.abortCounter);
-    Assert.assertEquals(1, committer.initCounter);
-    Assert.assertEquals(1, committer.setupCounter);
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertEquals(1, committer.commitCounter);
+    assertEquals(0, committer.abortCounter);
+    assertEquals(1, committer.initCounter);
+    assertEquals(1, committer.setupCounter);
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.FAILED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.FAILED, v.getState());
-    Assert.assertEquals(1, committer.commitCounter);
-    Assert.assertEquals(1, committer.abortCounter);
+    assertEquals(VertexState.FAILED, v.getState());
+    assertEquals(1, committer.commitCounter);
+    assertEquals(1, committer.abortCounter);
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBadCommitter() throws Exception {
     VertexImpl v = vertices.get("vertex2");
 
@@ -4490,17 +4540,18 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.FAILED, v.getState());
-    Assert.assertEquals(VertexTerminationCause.COMMIT_FAILURE, v.getTerminationCause());
+    assertEquals(VertexState.FAILED, v.getState());
+    assertEquals(VertexTerminationCause.COMMIT_FAILURE, v.getTerminationCause());
 
-    Assert.assertEquals(1, committer.commitCounter);
+    assertEquals(1, committer.commitCounter);
 
-    Assert.assertEquals(1, committer.abortCounter);
-    Assert.assertEquals(1, committer.initCounter);
-    Assert.assertEquals(1, committer.setupCounter);
+    assertEquals(1, committer.abortCounter);
+    assertEquals(1, committer.initCounter);
+    assertEquals(1, committer.setupCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBadCommitter2() throws Exception {
     VertexImpl v = vertices.get("vertex2");
 
@@ -4534,16 +4585,17 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
       new VertexEventTaskCompleted(t2, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.FAILED, v.getState());
-    Assert.assertEquals(VertexTerminationCause.COMMIT_FAILURE, v.getTerminationCause());
-    Assert.assertEquals(1, committer.commitCounter);
+    assertEquals(VertexState.FAILED, v.getState());
+    assertEquals(VertexTerminationCause.COMMIT_FAILURE, v.getTerminationCause());
+    assertEquals(1, committer.commitCounter);
 
-    Assert.assertEquals(1, committer.abortCounter);
-    Assert.assertEquals(1, committer.initCounter);
-    Assert.assertEquals(1, committer.setupCounter);
+    assertEquals(1, committer.abortCounter);
+    assertEquals(1, committer.initCounter);
+    assertEquals(1, committer.setupCounter);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexInitWithCustomVertexManager() throws Exception {
     setupPreDagCreation();
     dagPlan = createDAGWithCustomVertexManager();
@@ -4557,68 +4609,70 @@ public class TestVertexImpl {
     initVertex(v2);
     dispatcher.await();
     // vertex should be in initializing state since parallelism is not set
-    Assert.assertEquals(-1, v1.getTotalTasks());
-    Assert.assertTrue(0.0f == v1.getCompletedTaskProgress());
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
-    Assert.assertEquals(-1, v2.getTotalTasks());
-    Assert.assertEquals(VertexState.INITIALIZING, v2.getState());
-    Assert.assertEquals(-1, v3.getTotalTasks());
-    Assert.assertEquals(VertexState.INITIALIZING, v3.getState());
+    assertEquals(-1, v1.getTotalTasks());
+    assertEquals(0.0f, v1.getCompletedTaskProgress());
+    assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertEquals(-1, v2.getTotalTasks());
+    assertEquals(VertexState.INITIALIZING, v2.getState());
+    assertEquals(-1, v3.getTotalTasks());
+    assertEquals(VertexState.INITIALIZING, v3.getState());
     // vertex should not start since parallelism is not set
     dispatcher.getEventHandler().handle(new VertexEvent(v1.getVertexId(), VertexEventType.V_START));
     dispatcher.await();
-    Assert.assertEquals(-1, v1.getTotalTasks());
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertEquals(-1, v1.getTotalTasks());
+    assertEquals(VertexState.INITIALIZING, v1.getState());
     // set the parallelism
     v1.reconfigureVertex(numTasks, null, null);
     v2.reconfigureVertex(numTasks, null, null);
     dispatcher.await();
     // parallelism set and vertex starts with pending start event
-    Assert.assertEquals(numTasks, v1.getTotalTasks());
-    Assert.assertEquals(VertexState.RUNNING, v1.getState());
+    assertEquals(numTasks, v1.getTotalTasks());
+    assertEquals(VertexState.RUNNING, v1.getState());
     // parallelism set and vertex inited
-    Assert.assertEquals(numTasks, v2.getTotalTasks());
-    Assert.assertEquals(VertexState.INITED, v2.getState());
+    assertEquals(numTasks, v2.getTotalTasks());
+    assertEquals(VertexState.INITED, v2.getState());
     // send start and vertex should run
     dispatcher.getEventHandler().handle(new VertexEvent(v2.getVertexId(), VertexEventType.V_START));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v2.getState());
+    assertEquals(VertexState.RUNNING, v2.getState());
     // v3 still initializing with source vertex started. So should start running
     // once num tasks is defined
-    Assert.assertEquals(VertexState.INITIALIZING, v3.getState());
-    Assert.assertTrue(v3.numStartedSourceVertices > 0);
+    assertEquals(VertexState.INITIALIZING, v3.getState());
+    assertTrue(v3.numStartedSourceVertices > 0);
     long v3StartTimeRequested = v3.startTimeRequested;
-    Assert.assertTrue(v3StartTimeRequested > 0);
+    assertTrue(v3StartTimeRequested > 0);
     v3.reconfigureVertex(numTasks, null, null);
     dispatcher.await();
-    Assert.assertEquals(numTasks, v3.getTotalTasks());
-    Assert.assertEquals(VertexState.RUNNING, v3.getState());
+    assertEquals(numTasks, v3.getTotalTasks());
+    assertEquals(VertexState.RUNNING, v3.getState());
     // the start time requested should remain at its original value
-    Assert.assertEquals(v3StartTimeRequested, v3.startTimeRequested);
+    assertEquals(v3StartTimeRequested, v3.startTimeRequested);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexManagerHeuristic() throws TezException {
     setupPreDagCreation();
     dagPlan = createDAGPlanWithMixedEdges("testVertexManagerHeuristic");
     setupPostDagCreation(false);
     initAllVertices(VertexState.INITED);
-    Assert.assertEquals(ImmediateStartVertexManager.class,
+    assertEquals(ImmediateStartVertexManager.class,
         vertices.get("vertex1").getVertexManager().getPlugin().getClass());
-    Assert.assertEquals(ShuffleVertexManager.class,
+    assertEquals(ShuffleVertexManager.class,
         vertices.get("vertex2").getVertexManager().getPlugin().getClass());
-    Assert.assertEquals(InputReadyVertexManager.class,
+    assertEquals(InputReadyVertexManager.class,
         vertices.get("vertex3").getVertexManager().getPlugin().getClass());
-    Assert.assertEquals(ImmediateStartVertexManager.class,
+    assertEquals(ImmediateStartVertexManager.class,
         vertices.get("vertex4").getVertexManager().getPlugin().getClass());
-    Assert.assertEquals(ImmediateStartVertexManager.class,
+    assertEquals(ImmediateStartVertexManager.class,
         vertices.get("vertex5").getVertexManager().getPlugin().getClass());
-    Assert.assertEquals(InputReadyVertexManager.class,
+    assertEquals(InputReadyVertexManager.class,
         vertices.get("vertex6").getVertexManager().getPlugin().getClass());
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexWithOneToOneSplit() throws Exception {
     // create a diamond shaped dag with 1-1 edges.
     // split the source and remaining vertices should split equally
@@ -4634,60 +4688,61 @@ public class TestVertexImpl {
     VertexImpl v5 = vertices.get("vertex5");
     initVertex(v1);
 
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertEquals(VertexState.INITIALIZING, v1.getState());
 
     // setting the edge manager should vertex1 should not INIT/START it since
     // input initialization is not complete. v5 should be inited
     EdgeManagerPluginDescriptor mockEdgeManagerDescriptor =
         EdgeManagerPluginDescriptor.create(EdgeManagerForTest.class.getName());
     Edge e = v5.sourceVertices.get(v1);
-    Assert.assertNull(e.getEdgeManager());
+    assertNull(e.getEdgeManager());
     e.setCustomEdgeManager(mockEdgeManagerDescriptor);
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
-    Assert.assertEquals(VertexState.INITED, vertices.get("vertex5").getState());
+    assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertEquals(VertexState.INITED, vertices.get("vertex5").getState());
 
     RootInputInitializerManagerControlled initializerManager1 = v1.getRootInputInitializerManager();
     List<TaskLocationHint> v1Hints = createTaskLocationHints(numTasks);
     initializerManager1.completeInputInitialization(0, numTasks, v1Hints);
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v1.getState());
-    Assert.assertEquals(numTasks, v1.getTotalTasks());
-    Assert.assertEquals(RootInputVertexManager.class.getName(), v1
+    assertEquals(VertexState.INITED, v1.getState());
+    assertEquals(numTasks, v1.getTotalTasks());
+    assertEquals(RootInputVertexManager.class.getName(), v1
         .getVertexManager().getPlugin().getClass().getName());
     for (int i=0; i < v1Hints.size(); ++i) {
-      Assert.assertEquals(v1Hints.get(i), v1.getTaskLocationHints()[i]);
+      assertEquals(v1Hints.get(i), v1.getTaskLocationHints()[i]);
     }
-    Assert.assertEquals(true, initializerManager1.hasShutDown);
+    assertTrue(initializerManager1.hasShutDown);
 
     startVertex(v1);
 
-    Assert.assertEquals(numTasks, vertices.get("vertex2").getTotalTasks());
-    Assert.assertEquals(numTasks, vertices.get("vertex3").getTotalTasks());
-    Assert.assertEquals(numTasks, vertices.get("vertex4").getTotalTasks());
+    assertEquals(numTasks, vertices.get("vertex2").getTotalTasks());
+    assertEquals(numTasks, vertices.get("vertex3").getTotalTasks());
+    assertEquals(numTasks, vertices.get("vertex4").getTotalTasks());
     // v4, v6 still initializing since edge is null
-    Assert.assertEquals(VertexState.INITIALIZING, vertices.get("vertex4").getState());
-    Assert.assertEquals(VertexState.INITIALIZING, vertices.get("vertex6").getState());
+    assertEquals(VertexState.INITIALIZING, vertices.get("vertex4").getState());
+    assertEquals(VertexState.INITIALIZING, vertices.get("vertex6").getState());
 
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex1").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex2").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex3").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex5").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex1").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex2").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex3").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex5").getState());
     // v4, v6 still initializing since edge is null
-    Assert.assertEquals(VertexState.INITIALIZING, vertices.get("vertex4").getState());
-    Assert.assertEquals(VertexState.INITIALIZING, vertices.get("vertex6").getState());
+    assertEquals(VertexState.INITIALIZING, vertices.get("vertex4").getState());
+    assertEquals(VertexState.INITIALIZING, vertices.get("vertex6").getState());
 
     mockEdgeManagerDescriptor =
         EdgeManagerPluginDescriptor.create(EdgeManagerForTest.class.getName());
     e = vertices.get("vertex6").sourceVertices.get(vertices.get("vertex4"));
-    Assert.assertNull(e.getEdgeManager());
+    assertNull(e.getEdgeManager());
     e.setCustomEdgeManager(mockEdgeManagerDescriptor);
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex4").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex6").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex4").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex6").getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexWithOneToOneSplitWhileRunning() throws Exception {
     int numTasks = 5;
     // create a diamond shaped dag with 1-1 edges.
@@ -4705,28 +4760,29 @@ public class TestVertexImpl {
     v1.vertexManager.initialize();
     startVertex(v1);
     dispatcher.await();
-    Assert.assertEquals(numTasks, vertices.get("vertex2").getTotalTasks());
-    Assert.assertEquals(numTasks, vertices.get("vertex3").getTotalTasks());
-    Assert.assertEquals(numTasks, vertices.get("vertex4").getTotalTasks());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex1").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex2").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex3").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex4").getState());
+    assertEquals(numTasks, vertices.get("vertex2").getTotalTasks());
+    assertEquals(numTasks, vertices.get("vertex3").getTotalTasks());
+    assertEquals(numTasks, vertices.get("vertex4").getTotalTasks());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex1").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex2").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex3").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex4").getState());
     // change parallelism
     int newNumTasks = 3;
     v1.reconfigureVertex(newNumTasks, null, null);
     v1.doneReconfiguringVertex();
     dispatcher.await();
-    Assert.assertEquals(newNumTasks, vertices.get("vertex2").getTotalTasks());
-    Assert.assertEquals(newNumTasks, vertices.get("vertex3").getTotalTasks());
-    Assert.assertEquals(newNumTasks, vertices.get("vertex4").getTotalTasks());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex1").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex2").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex3").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex4").getState());
+    assertEquals(newNumTasks, vertices.get("vertex2").getTotalTasks());
+    assertEquals(newNumTasks, vertices.get("vertex3").getTotalTasks());
+    assertEquals(newNumTasks, vertices.get("vertex4").getTotalTasks());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex1").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex2").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex3").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex4").getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexWithOneToOneSplitWhileInited() throws Exception {
     int numTasks = 5;
     // create a diamond shaped dag with 1-1 edges.
@@ -4743,32 +4799,33 @@ public class TestVertexImpl {
         UserGroupInformation.getCurrentUser(), v1, appContext, mock(StateChangeNotifier.class));
     v1.vertexManager.initialize();
 
-    Assert.assertEquals(numTasks, vertices.get("vertex2").getTotalTasks());
-    Assert.assertEquals(numTasks, vertices.get("vertex3").getTotalTasks());
-    Assert.assertEquals(numTasks, vertices.get("vertex4").getTotalTasks());
+    assertEquals(numTasks, vertices.get("vertex2").getTotalTasks());
+    assertEquals(numTasks, vertices.get("vertex3").getTotalTasks());
+    assertEquals(numTasks, vertices.get("vertex4").getTotalTasks());
     // change parallelism
     int newNumTasks = 3;
     v1.reconfigureVertex(newNumTasks, null, null);
     v1.doneReconfiguringVertex();
     dispatcher.await();
-    Assert.assertEquals(newNumTasks, vertices.get("vertex2").getTotalTasks());
-    Assert.assertEquals(newNumTasks, vertices.get("vertex3").getTotalTasks());
-    Assert.assertEquals(newNumTasks, vertices.get("vertex4").getTotalTasks());
-    Assert.assertEquals(VertexState.INITED, vertices.get("vertex1").getState());
-    Assert.assertEquals(VertexState.INITED, vertices.get("vertex2").getState());
-    Assert.assertEquals(VertexState.INITED, vertices.get("vertex3").getState());
-    Assert.assertEquals(VertexState.INITED, vertices.get("vertex4").getState());
+    assertEquals(newNumTasks, vertices.get("vertex2").getTotalTasks());
+    assertEquals(newNumTasks, vertices.get("vertex3").getTotalTasks());
+    assertEquals(newNumTasks, vertices.get("vertex4").getTotalTasks());
+    assertEquals(VertexState.INITED, vertices.get("vertex1").getState());
+    assertEquals(VertexState.INITED, vertices.get("vertex2").getState());
+    assertEquals(VertexState.INITED, vertices.get("vertex3").getState());
+    assertEquals(VertexState.INITED, vertices.get("vertex4").getState());
 
     startVertex(v1);
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex1").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex2").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex3").getState());
-    Assert.assertEquals(VertexState.RUNNING, vertices.get("vertex4").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex1").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex2").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex3").getState());
+    assertEquals(VertexState.RUNNING, vertices.get("vertex4").getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexVMErrorReport() throws Exception {
     int numTasks = 5;
     // create a diamond shaped dag with 1-1 edges.
@@ -4794,26 +4851,28 @@ public class TestVertexImpl {
     dispatcher.await();
 
     // failed due to exception
-    Assert.assertEquals(VertexState.FAILED, vertices.get("vertex1").getState());
-    Assert.assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE, vertices.get("vertex1")
+    assertEquals(VertexState.FAILED, vertices.get("vertex1").getState());
+    assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE, vertices.get("vertex1")
         .getTerminationCause());
-    Assert.assertTrue(Joiner.on(":").join(vertices.get("vertex1").getDiagnostics()).contains(
+    assertTrue(Joiner.on(":").join(vertices.get("vertex1").getDiagnostics()).contains(
         "context.vertexReconfigurationPlanned() before re-configuring"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidEvent() {
     VertexImpl v = vertices.get("vertex2");
     dispatcher.getEventHandler().handle(new VertexEvent(v.getVertexId(),
         VertexEventType.V_START));
     dispatcher.await();
-    Assert.assertEquals(VertexState.ERROR, v.getState());
-    Assert.assertEquals(1,
+    assertEquals(VertexState.ERROR, v.getState());
+    assertEquals(1,
         dagEventDispatcher.eventCount.get(
             DAGEventType.INTERNAL_ERROR).intValue());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexWithInitializerFailure() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -4825,36 +4884,37 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEvent(v1.getVertexId(), VertexEventType.V_INIT));
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertEquals(VertexState.INITIALIZING, v1.getState());
     RootInputInitializerManagerControlled initializerManager1 = v1.getRootInputInitializerManager();
     initializerManager1.failInputInitialization();
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
-    Assert.assertEquals(RootInputVertexManager.class.getName(), v1
+    assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(RootInputVertexManager.class.getName(), v1
         .getVertexManager().getPlugin().getClass().getName());
-    Assert.assertEquals(true, initializerManager1.hasShutDown);
-    Assert.assertTrue(StringUtils.join(v1.getDiagnostics(), ",")
+    assertTrue(initializerManager1.hasShutDown);
+    assertTrue(StringUtils.join(v1.getDiagnostics(), ",")
         .contains(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE.name()));
-    Assert.assertTrue(StringUtils.join(v1.getDiagnostics(), ",")
+    assertTrue(StringUtils.join(v1.getDiagnostics(), ",")
         .contains("MockInitializerFailed"));
 
     VertexImplWithControlledInitializerManager v2 = (VertexImplWithControlledInitializerManager) vertices.get("vertex2");
-    Assert.assertEquals(VertexState.INITIALIZING, v2.getState());
+    assertEquals(VertexState.INITIALIZING, v2.getState());
     RootInputInitializerManagerControlled initializerManager2 = v2.getRootInputInitializerManager();
     initializerManager2.failInputInitialization();
     dispatcher.await();
-    Assert.assertEquals(VertexState.FAILED, v2.getState());
-    Assert.assertEquals(RootInputVertexManager.class.getName(), v2
+    assertEquals(VertexState.FAILED, v2.getState());
+    assertEquals(RootInputVertexManager.class.getName(), v2
         .getVertexManager().getPlugin().getClass().getName());
-    Assert.assertEquals(true, initializerManager2.hasShutDown);
-    Assert.assertTrue(StringUtils.join(v1.getDiagnostics(), ",")
+    assertTrue(initializerManager2.hasShutDown);
+    assertTrue(StringUtils.join(v1.getDiagnostics(), ",")
         .contains(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE.name()));
-    Assert.assertTrue(StringUtils.join(v1.getDiagnostics(), ",")
+    assertTrue(StringUtils.join(v1.getDiagnostics(), ",")
         .contains("MockInitializerFailed"));
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testVertexWithInitializerParallelismSetTo0() throws InterruptedException, TezException {
     useCustomInitializer = true;
     customInitializer = new RootInitializerSettingParallelismTo0(null);
@@ -4885,7 +4945,7 @@ public class TestVertexImpl {
     v2.handle(new VertexEventTaskAttemptCompleted(ta1V2T1, TaskAttemptStateInternal.SUCCEEDED));
     v2.handle(new VertexEventTaskCompleted(v2t1, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v2.getState());
+    assertEquals(VertexState.SUCCEEDED, v2.getState());
 
     while (v1.getState() == VertexState.INITIALIZING || v1.getState() == VertexState.INITED) {
       // initializer thread may not have started, so call initializer.go() in the loop all the time
@@ -4896,10 +4956,11 @@ public class TestVertexImpl {
     while (v1.getState() != VertexState.SUCCEEDED) {
       Thread.sleep(10);
     }
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testInputInitializerVertexStateUpdates() throws Exception {
     // v2 running an Input initializer, which is subscribed to events on v1.
     useCustomInitializer = true;
@@ -4918,27 +4979,28 @@ public class TestVertexImpl {
 
     initVertex(v1);
     startVertex(v1);
-    Assert.assertEquals(VertexState.RUNNING, v1.getState());
+    assertEquals(VertexState.RUNNING, v1.getState());
 
     // Make v1 succeed
     for (TezTaskID taskId : v1.getTasks().keySet()) {
       v1.handle(new VertexEventTaskCompleted(taskId, TaskState.SUCCEEDED));
     }
     dispatcher.await();
-    Assert.assertEquals(VertexState.SUCCEEDED, v1.getState());
+    assertEquals(VertexState.SUCCEEDED, v1.getState());
 
     // wait for state update events are received, this is done in the state notifier thread
     initializer.waitForVertexStateUpdate();
 
-    Assert.assertEquals(org.apache.tez.dag.api.event.VertexState.CONFIGURED,
+    assertEquals(org.apache.tez.dag.api.event.VertexState.CONFIGURED,
         initializer.stateUpdates.get(0).getVertexState());
-    Assert.assertEquals(org.apache.tez.dag.api.event.VertexState.RUNNING,
+    assertEquals(org.apache.tez.dag.api.event.VertexState.RUNNING,
         initializer.stateUpdates.get(1).getVertexState());
-    Assert.assertEquals(org.apache.tez.dag.api.event.VertexState.SUCCEEDED,
+    assertEquals(org.apache.tez.dag.api.event.VertexState.SUCCEEDED,
         initializer.stateUpdates.get(2).getVertexState());
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testInputInitializerEventMultipleAttempts() throws Exception {
     useCustomInitializer = true;
     customInitializer = new EventHandlingRootInputInitializer(null);
@@ -4960,9 +5022,9 @@ public class TestVertexImpl {
     dispatcher.await();
 
     // Vertex1 start should trigger downstream vertices
-    Assert.assertEquals(VertexState.RUNNING, v1.getState());
-    Assert.assertEquals(VertexState.RUNNING, v2.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, v3.getState());
+    assertEquals(VertexState.RUNNING, v1.getState());
+    assertEquals(VertexState.RUNNING, v2.getState());
+    assertEquals(VertexState.INITIALIZING, v3.getState());
 
     ByteBuffer expected;
 
@@ -4991,14 +5053,14 @@ public class TestVertexImpl {
     dispatcher.await();
 
     // Events should not be cached in the vertex, since the initializer is running
-    Assert.assertEquals(0, v3.pendingInitializerEvents.size());
+    assertEquals(0, v3.pendingInitializerEvents.size());
 
     // Events should be cached since the tasks have not succeeded.
     // Verify that events are cached
     RootInputInitializerManager.InitializerWrapper initializerWrapper =
         v3.rootInputInitializerManager.getInitializerWrapper("input1");
-    Assert.assertEquals(1, initializerWrapper.getFirstSuccessfulAttemptMap().size());
-    Assert.assertEquals(2, initializerWrapper.getPendingEvents().get(v1.getName()).size());
+    assertEquals(1, initializerWrapper.getFirstSuccessfulAttemptMap().size());
+    assertEquals(2, initializerWrapper.getPendingEvents().get(v1.getName()).size());
 
 
     // Get all tasks of vertex1 to succeed.
@@ -5018,14 +5080,15 @@ public class TestVertexImpl {
     while (v3.getState()  != VertexState.RUNNING) {
       Thread.sleep(10);
     }
-    Assert.assertEquals(VertexState.RUNNING, v3.getState());
+    assertEquals(VertexState.RUNNING, v3.getState());
 
-    Assert.assertEquals(1, initializer.initializerEvents.size());
-    Assert.assertEquals(expected, initializer.initializerEvents.get(0).getUserPayload());
+    assertEquals(1, initializer.initializerEvents.size());
+    assertEquals(expected, initializer.initializerEvents.get(0).getUserPayload());
 
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testInputInitializerEventsMultipleSources() throws Exception {
     useCustomInitializer = true;
     customInitializer = new EventHandlingRootInputInitializer(null);
@@ -5048,9 +5111,9 @@ public class TestVertexImpl {
     dispatcher.await();
 
     // Vertex1 start should trigger downstream vertices
-    Assert.assertEquals(VertexState.RUNNING, v1.getState());
-    Assert.assertEquals(VertexState.RUNNING, v2.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, v3.getState());
+    assertEquals(VertexState.RUNNING, v1.getState());
+    assertEquals(VertexState.RUNNING, v2.getState());
+    assertEquals(VertexState.INITIALIZING, v3.getState());
 
     List<ByteBuffer> expectedPayloads = new LinkedList<ByteBuffer>();
 
@@ -5069,14 +5132,14 @@ public class TestVertexImpl {
     dispatcher.await();
 
     // Events should not be cached in the vertex, since the initializer is running
-    Assert.assertEquals(0, v3.pendingInitializerEvents.size());
+    assertEquals(0, v3.pendingInitializerEvents.size());
 
     // Events should be cached since the tasks have not succeeded.
     // Verify that events are cached
     RootInputInitializerManager.InitializerWrapper initializerWrapper =
         v3.rootInputInitializerManager.getInitializerWrapper("input1");
-    Assert.assertEquals(1, initializerWrapper.getFirstSuccessfulAttemptMap().size());
-    Assert.assertEquals(1, initializerWrapper.getPendingEvents().get(v1.getName()).size());
+    assertEquals(1, initializerWrapper.getFirstSuccessfulAttemptMap().size());
+    assertEquals(1, initializerWrapper.getPendingEvents().get(v1.getName()).size());
 
 
     // Get all tasks of vertex1 to succeed.
@@ -5089,11 +5152,11 @@ public class TestVertexImpl {
     }
     dispatcher.await();
 
-    Assert.assertEquals(1, initializer.initializerEvents.size());
+    assertEquals(1, initializer.initializerEvents.size());
 
 
     // Test written based on this
-    Assert.assertEquals(2, v2.getTotalTasks());
+    assertEquals(2, v2.getTotalTasks());
     // Generate events from v2 to v3's initializer. 1 from task 0, 2 from task 1
     for (Task task : v2.getTasks().values()) {
       TezTaskID taskId = task.getTaskID();
@@ -5114,9 +5177,9 @@ public class TestVertexImpl {
 
     // Validate queueing of these events
     // Only v2 events pending
-    Assert.assertEquals(1, initializerWrapper.getPendingEvents().keySet().size());
+    assertEquals(1, initializerWrapper.getPendingEvents().keySet().size());
     // 3 events pending
-    Assert.assertEquals(3, initializerWrapper.getPendingEvents().get(v2.getName()).size());
+    assertEquals(3, initializerWrapper.getPendingEvents().get(v2.getName()).size());
 
     // Get all tasks of vertex1 to succeed.
     for (TezTaskID taskId : v2.getTasks().keySet()) {
@@ -5134,22 +5197,23 @@ public class TestVertexImpl {
     while (v3.getState()  != VertexState.RUNNING) {
       Thread.sleep(10);
     }
-    Assert.assertEquals(VertexState.RUNNING, v3.getState());
+    assertEquals(VertexState.RUNNING, v3.getState());
 
-    Assert.assertEquals(4, initializer.initializerEvents.size());
-    Assert.assertTrue(initializer.initComplete.get());
+    assertEquals(4, initializer.initializerEvents.size());
+    assertTrue(initializer.initComplete.get());
 
-    Assert.assertEquals(2, initializerWrapper.getFirstSuccessfulAttemptMap().size());
-    Assert.assertEquals(0, initializerWrapper.getPendingEvents().get(v1.getName()).size());
+    assertEquals(2, initializerWrapper.getFirstSuccessfulAttemptMap().size());
+    assertEquals(0, initializerWrapper.getPendingEvents().get(v1.getName()).size());
 
     for (InputInitializerEvent initializerEvent : initializer.initializerEvents) {
       expectedPayloads.remove(initializerEvent.getUserPayload());
     }
-    Assert.assertEquals(0, expectedPayloads.size());
+    assertEquals(0, expectedPayloads.size());
 
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testInputInitializerEventNoDirectConnection() throws Exception {
     useCustomInitializer = true;
     customInitializer = new EventHandlingRootInputInitializer(null);
@@ -5171,9 +5235,9 @@ public class TestVertexImpl {
     dispatcher.await();
 
     // Vertex1 start should trigger downstream vertices
-    Assert.assertEquals(VertexState.RUNNING, v1.getState());
-    Assert.assertEquals(VertexState.RUNNING, v2.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, v3.getState());
+    assertEquals(VertexState.RUNNING, v1.getState());
+    assertEquals(VertexState.RUNNING, v2.getState());
+    assertEquals(VertexState.INITIALIZING, v3.getState());
 
     // Genrate events from v1 to v3's InputInitializer
     InputInitializerEvent event = InputInitializerEvent.create("vertex3", "input1", null);
@@ -5188,14 +5252,14 @@ public class TestVertexImpl {
     dispatcher.await();
 
     // Events should not be cached in the vertex, since the initializer is running
-    Assert.assertEquals(0, v3.pendingInitializerEvents.size());
+    assertEquals(0, v3.pendingInitializerEvents.size());
 
     // Events should be cached since the tasks have not succeeded.
     // Verify that events are cached
     RootInputInitializerManager.InitializerWrapper initializerWrapper =
         v3.rootInputInitializerManager.getInitializerWrapper("input1");
-    Assert.assertEquals(1, initializerWrapper.getFirstSuccessfulAttemptMap().size());
-    Assert.assertEquals(1, initializerWrapper.getPendingEvents().get(v1.getName()).size());
+    assertEquals(1, initializerWrapper.getFirstSuccessfulAttemptMap().size());
+    assertEquals(1, initializerWrapper.getPendingEvents().get(v1.getName()).size());
 
     // Get all tasks of vertex1 to succeed.
     for (TezTaskID taskId : v1.getTasks().keySet()) {
@@ -5214,22 +5278,23 @@ public class TestVertexImpl {
       Thread.sleep(10);
     }
 
-    Assert.assertEquals(VertexState.RUNNING, v3.getState());
+    assertEquals(VertexState.RUNNING, v3.getState());
 
-    Assert.assertEquals(1, initializerWrapper.getFirstSuccessfulAttemptMap().size());
-    Assert.assertEquals(0, initializerWrapper.getPendingEvents().get(v1.getName()).size());
+    assertEquals(1, initializerWrapper.getFirstSuccessfulAttemptMap().size());
+    assertEquals(0, initializerWrapper.getPendingEvents().get(v1.getName()).size());
 
-    Assert.assertTrue(initializer.eventReceived.get());
-    Assert.assertEquals(3, initializer.stateUpdates.size());
-    Assert.assertEquals(org.apache.tez.dag.api.event.VertexState.CONFIGURED,
+    assertTrue(initializer.eventReceived.get());
+    assertEquals(3, initializer.stateUpdates.size());
+    assertEquals(org.apache.tez.dag.api.event.VertexState.CONFIGURED,
         initializer.stateUpdates.get(0).getVertexState());
-    Assert.assertEquals(org.apache.tez.dag.api.event.VertexState.RUNNING,
+    assertEquals(org.apache.tez.dag.api.event.VertexState.RUNNING,
         initializer.stateUpdates.get(1).getVertexState());
-    Assert.assertEquals(org.apache.tez.dag.api.event.VertexState.SUCCEEDED,
+    assertEquals(org.apache.tez.dag.api.event.VertexState.SUCCEEDED,
         initializer.stateUpdates.get(2).getVertexState());
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testInputInitializerEventsAtNew() throws Exception {
     useCustomInitializer = true;
     customInitializer = new EventHandlingRootInputInitializer(null);
@@ -5251,9 +5316,9 @@ public class TestVertexImpl {
     dispatcher.await();
 
     // Vertex2 has not been INITED, so the rest of the vertices should be in state NEW.
-    Assert.assertEquals(VertexState.RUNNING, v1.getState());
-    Assert.assertEquals(VertexState.NEW, v2.getState());
-    Assert.assertEquals(VertexState.NEW, v3.getState());
+    assertEquals(VertexState.RUNNING, v1.getState());
+    assertEquals(VertexState.NEW, v2.getState());
+    assertEquals(VertexState.NEW, v3.getState());
 
     // Genrate events from v1 to v3's InputInitializer
     InputInitializerEvent event = InputInitializerEvent.create("vertex3", "input1", null);
@@ -5268,7 +5333,7 @@ public class TestVertexImpl {
     dispatcher.await();
 
     // Events should be cached in the vertex, since the Initializer has not started
-    Assert.assertEquals(1, v3.pendingInitializerEvents.size());
+    assertEquals(1, v3.pendingInitializerEvents.size());
 
     // Get Vertex1 to succeed before Vertex2 is INITED. Contrived case ? This is likely a tiny race.
     for (TezTaskID taskId : v1.getTasks().keySet()) {
@@ -5284,8 +5349,8 @@ public class TestVertexImpl {
     dispatcher.await();
 
     // Events should still be cached in the vertex
-    Assert.assertEquals(1, v3.pendingInitializerEvents.size());
-    Assert.assertEquals(VertexState.NEW, v3.getState());
+    assertEquals(1, v3.pendingInitializerEvents.size());
+    assertEquals(VertexState.NEW, v3.getState());
 
     // Move processing along. INIT the remaining root level vertex.
     initVertex(v2);
@@ -5299,23 +5364,24 @@ public class TestVertexImpl {
     while (v3.getState()  != VertexState.RUNNING) {
       Thread.sleep(10);
     }
-    Assert.assertEquals(VertexState.RUNNING, v3.getState());
+    assertEquals(VertexState.RUNNING, v3.getState());
     // Events should have been cleared from the vertex.
-    Assert.assertEquals(0, v3.pendingInitializerEvents.size());
+    assertEquals(0, v3.pendingInitializerEvents.size());
 
     // KK Add checks to validate thte RootInputManager doesn't remember the events either
 
-    Assert.assertTrue(initializer.eventReceived.get());
-    Assert.assertEquals(3, initializer.stateUpdates.size());
-    Assert.assertEquals(org.apache.tez.dag.api.event.VertexState.CONFIGURED,
+    assertTrue(initializer.eventReceived.get());
+    assertEquals(3, initializer.stateUpdates.size());
+    assertEquals(org.apache.tez.dag.api.event.VertexState.CONFIGURED,
         initializer.stateUpdates.get(0).getVertexState());
-    Assert.assertEquals(org.apache.tez.dag.api.event.VertexState.RUNNING,
+    assertEquals(org.apache.tez.dag.api.event.VertexState.RUNNING,
         initializer.stateUpdates.get(1).getVertexState());
-    Assert.assertEquals(org.apache.tez.dag.api.event.VertexState.SUCCEEDED,
+    assertEquals(org.apache.tez.dag.api.event.VertexState.SUCCEEDED,
         initializer.stateUpdates.get(2).getVertexState());
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testInputInitializerEvents() throws Exception {
     useCustomInitializer = true;
     customInitializer = new EventHandlingRootInputInitializer(null);
@@ -5332,16 +5398,16 @@ public class TestVertexImpl {
 
     initVertex(v1);
     startVertex(v1);
-    Assert.assertEquals(VertexState.RUNNING, v1.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, v2.getState());
+    assertEquals(VertexState.RUNNING, v1.getState());
+    assertEquals(VertexState.INITIALIZING, v2.getState());
     dispatcher.await();
 
     // Wait for the initializer to be invoked - which may be a separate thread.
     while (!initializer.initStarted.get()) {
       Thread.sleep(10);
     }
-    Assert.assertFalse(initializer.eventReceived.get());
-    Assert.assertFalse(initializer.initComplete.get());
+    assertFalse(initializer.eventReceived.get());
+    assertFalse(initializer.initComplete.get());
 
 
     // Signal the initializer by sending an event - via vertex1
@@ -5357,13 +5423,13 @@ public class TestVertexImpl {
     dispatcher.await();
 
     // Events should not be cached in the vertex, since the initializer is running
-    Assert.assertEquals(0, v2.pendingInitializerEvents.size());
+    assertEquals(0, v2.pendingInitializerEvents.size());
 
     // Verify that events are cached
     RootInputInitializerManager.InitializerWrapper initializerWrapper =
         v2.rootInputInitializerManager.getInitializerWrapper("input1");
-    Assert.assertEquals(1, initializerWrapper.getFirstSuccessfulAttemptMap().size());
-    Assert.assertEquals(1, initializerWrapper.getPendingEvents().get(v1.getName()).size());
+    assertEquals(1, initializerWrapper.getFirstSuccessfulAttemptMap().size());
+    assertEquals(1, initializerWrapper.getPendingEvents().get(v1.getName()).size());
 
     for (TezTaskID taskId : v1.getTasks().keySet()) {
       TezTaskAttemptID taskAttemptId = TezTaskAttemptID.getInstance(taskId, 0);
@@ -5387,11 +5453,12 @@ public class TestVertexImpl {
     }
 
     // Verify the events are no longer cached, but attempts are remembered
-    Assert.assertEquals(1, initializerWrapper.getFirstSuccessfulAttemptMap().size());
-    Assert.assertEquals(0, initializerWrapper.getPendingEvents().get(v1.getName()).size());
+    assertEquals(1, initializerWrapper.getFirstSuccessfulAttemptMap().size());
+    assertEquals(0, initializerWrapper.getPendingEvents().get(v1.getName()).size());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   /**
    * Ref: TEZ-1494
    * If broadcast, one-to-one or custom edges are present in source, tasks should not start until
@@ -5425,11 +5492,11 @@ public class TestVertexImpl {
     initVertex(m7);
     initVertex(m8);
     initVertex(m9);
-    assertTrue(m7.getState().equals(VertexState.INITED));
-    assertTrue(m9.getState().equals(VertexState.INITED));
-    assertTrue(m5.getState().equals(VertexState.INITED));
-    assertTrue(m8.getState().equals(VertexState.INITED));
-    assertTrue(m5.getVertexManager().getPlugin() instanceof ImmediateStartVertexManager);
+    assertEquals(m7.getState(), VertexState.INITED);
+    assertEquals(m9.getState(), VertexState.INITED);
+    assertEquals(m5.getState(), VertexState.INITED);
+    assertEquals(m8.getState(), VertexState.INITED);
+    assertInstanceOf(ImmediateStartVertexManager.class, m5.getVertexManager().getPlugin());
 
     //Start M9
     dispatcher.getEventHandler().handle(new VertexEvent(m9.getVertexId(),
@@ -5441,28 +5508,28 @@ public class TestVertexImpl {
     dispatcher.await();
 
     //R3 should be in running state
-    assertTrue(r3.getState().equals(VertexState.RUNNING));
+    assertEquals(r3.getState(), VertexState.RUNNING);
 
     //Let us start M7; M5 should start not start as it is dependent on M8 as well
     dispatcher.getEventHandler().handle(new VertexEvent(m7.getVertexId(),VertexEventType.V_START));
     dispatcher.await();
 
     //M5 should be in INITED state, as it depends on M8
-    assertTrue(m5.getState().equals(VertexState.INITED));
+    assertEquals(m5.getState(), VertexState.INITED);
     for(Task task : m5.getTasks().values()) {
-      assertTrue(task.getState().equals(TaskState.NEW));
+      assertEquals(task.getState(), TaskState.NEW);
     }
 
     //Let us start M8; M5 should start now
     dispatcher.getEventHandler().handle(new VertexEvent(m8.getVertexId(),VertexEventType.V_START));
     dispatcher.await();
 
-    assertTrue(m9.getState().equals(VertexState.SUCCEEDED));
+    assertEquals(m9.getState(), VertexState.SUCCEEDED);
 
     //M5 in running state. All source vertices have started and are configured
-    assertTrue(m5.getState().equals(VertexState.RUNNING));
+    assertEquals(m5.getState(), VertexState.RUNNING);
     for(Task task : m5.getTasks().values()) {
-      assertTrue(task.getState().equals(TaskState.SCHEDULED));
+      assertEquals(task.getState(), TaskState.SCHEDULED);
     }
   }
 
@@ -5693,7 +5760,8 @@ public class TestVertexImpl {
     return dag;
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexWithMultipleInitializers1() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -5706,7 +5774,7 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEvent(v1.getVertexId(), VertexEventType.V_INIT));
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertEquals(VertexState.INITIALIZING, v1.getState());
 
     RootInputInitializerManagerControlled initializerManager1 = v1.getRootInputInitializerManager();
     List<TaskLocationHint> v1Hints = createTaskLocationHints(5);
@@ -5714,16 +5782,17 @@ public class TestVertexImpl {
     // Complete initializer which sets parallelism first
     initializerManager1.completeInputInitialization(0, 5, v1Hints);
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
-    Assert.assertEquals(1, v1.numInitializerCompletionsHandled);
+    assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertEquals(1, v1.numInitializerCompletionsHandled);
     // Complete second initializer
     initializerManager1.completeInputInitialization(1);
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v1.getState());
-    Assert.assertEquals(2, v1.numInitializerCompletionsHandled);
+    assertEquals(VertexState.INITED, v1.getState());
+    assertEquals(2, v1.numInitializerCompletionsHandled);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexWithMultipleInitializers2() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -5736,7 +5805,7 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEvent(v1.getVertexId(), VertexEventType.V_INIT));
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertEquals(VertexState.INITIALIZING, v1.getState());
 
     RootInputInitializerManagerControlled initializerManager1 = v1.getRootInputInitializerManager();
     List<TaskLocationHint> v1Hints = createTaskLocationHints(5);
@@ -5744,16 +5813,17 @@ public class TestVertexImpl {
     // Complete initializer which does not set parallelism
     initializerManager1.completeInputInitialization(1);
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
-    Assert.assertEquals(1, v1.numInitializerCompletionsHandled);
+    assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertEquals(1, v1.numInitializerCompletionsHandled);
     // Complete second initializer which sets parallelism
     initializerManager1.completeInputInitialization(0, 5, v1Hints);
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v1.getState());
-    Assert.assertEquals(2, v1.numInitializerCompletionsHandled);
+    assertEquals(VertexState.INITED, v1.getState());
+    assertEquals(2, v1.numInitializerCompletionsHandled);
   }
 
-  @Test(timeout = 500000)
+  @Test
+  @Timeout(value = 500000, unit = TimeUnit.MILLISECONDS)
   public void testVertexWithInitializerSuccess() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -5765,23 +5835,23 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEvent(v1.getVertexId(), VertexEventType.V_INIT));
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertEquals(VertexState.INITIALIZING, v1.getState());
     RootInputInitializerManagerControlled initializerManager1 = v1.getRootInputInitializerManager();
     List<TaskLocationHint> v1Hints = createTaskLocationHints(5);
     initializerManager1.completeInputInitialization(0, 5, v1Hints);
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v1.getState());
-    Assert.assertEquals(5, v1.getTotalTasks());
-    Assert.assertEquals(RootInputVertexManager.class.getName(), v1
+    assertEquals(VertexState.INITED, v1.getState());
+    assertEquals(5, v1.getTotalTasks());
+    assertEquals(RootInputVertexManager.class.getName(), v1
         .getVertexManager().getPlugin().getClass().getName());
     for (int i=0; i < v1Hints.size(); ++i) {
-      Assert.assertEquals(v1Hints.get(i), v1.getTaskLocationHints()[i]);
+      assertEquals(v1Hints.get(i), v1.getTaskLocationHints()[i]);
     }
-    Assert.assertEquals(true, initializerManager1.hasShutDown);
+    assertTrue(initializerManager1.hasShutDown);
     for (int i = 0; i < 5; i++) {
       List<InputSpec> inputSpecs = v1.getInputSpecList(i);
-      Assert.assertEquals(1, inputSpecs.size());
-      Assert.assertEquals(1, inputSpecs.get(0).getPhysicalEdgeCount());
+      assertEquals(1, inputSpecs.size());
+      assertEquals(1, inputSpecs.get(0).getPhysicalEdgeCount());
     }
 
     List<ScheduleTaskRequest> taskList = new LinkedList<VertexManagerPluginContext.ScheduleTaskRequest>();
@@ -5793,14 +5863,14 @@ public class TestVertexImpl {
     dispatcher.await();
     // check all tasks get their events
     for (int i=0; i<v1.getTotalTasks(); ++i) {
-      Assert.assertEquals(
+      assertEquals(
           1,
           v1.getTaskAttemptTezEvents(TezTaskAttemptID.getInstance(v1.getTask(i).getTaskID(), 0),
               0, 0, 100).getEvents().size());
     }
 
     VertexImplWithControlledInitializerManager v2 = (VertexImplWithControlledInitializerManager) vertices.get("vertex2");
-    Assert.assertEquals(VertexState.INITIALIZING, v2.getState());
+    assertEquals(VertexState.INITIALIZING, v2.getState());
 
     // non-task events don't get buffered
     List<TezEvent> events = Lists.newLinkedList();
@@ -5822,14 +5892,14 @@ public class TestVertexImpl {
     List<TaskLocationHint> v2Hints = createTaskLocationHints(10);
     initializerManager2.completeInputInitialization(0, 10, v2Hints);
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v2.getState());
-    Assert.assertEquals(10, v2.getTotalTasks());
-    Assert.assertEquals(RootInputVertexManager.class.getName(), v2
+    assertEquals(VertexState.INITED, v2.getState());
+    assertEquals(10, v2.getTotalTasks());
+    assertEquals(RootInputVertexManager.class.getName(), v2
         .getVertexManager().getPlugin().getClass().getName());
     for (int i=0; i < v2Hints.size(); ++i) {
-      Assert.assertEquals(v2Hints.get(i), v2.getTaskLocationHints()[i]);
+      assertEquals(v2Hints.get(i), v2.getTaskLocationHints()[i]);
     }
-    Assert.assertEquals(true, initializerManager2.hasShutDown);
+    assertTrue(initializerManager2.hasShutDown);
 
     // scheduling start to trigger edge routing to begin
     taskList = new LinkedList<VertexManagerPluginContext.ScheduleTaskRequest>();
@@ -5841,19 +5911,20 @@ public class TestVertexImpl {
     dispatcher.await();
     // check all tasks get their events
     for (int i=0; i<v2.getTotalTasks(); ++i) {
-      Assert.assertEquals(
+      assertEquals(
           ((i==0) ? 2 : 1),
           v2.getTaskAttemptTezEvents(TezTaskAttemptID.getInstance(v2.getTask(i).getTaskID(), 0),
               0, 0, 100).getEvents().size());
     }
     for (int i = 0; i < 10; i++) {
       List<InputSpec> inputSpecs = v1.getInputSpecList(i);
-      Assert.assertEquals(1, inputSpecs.size());
-      Assert.assertEquals(1, inputSpecs.get(0).getPhysicalEdgeCount());
+      assertEquals(1, inputSpecs.size());
+      assertEquals(1, inputSpecs.get(0).getPhysicalEdgeCount());
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexWithInitializerSuccessLegacyRouting() throws Exception {
     // Remove after legacy routing is removed
     useCustomInitializer = true;
@@ -5866,29 +5937,29 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEvent(v1.getVertexId(), VertexEventType.V_INIT));
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertEquals(VertexState.INITIALIZING, v1.getState());
     RootInputInitializerManagerControlled initializerManager1 = v1.getRootInputInitializerManager();
     List<TaskLocationHint> v1Hints = createTaskLocationHints(5);
     initializerManager1.completeInputInitialization(0, 5, v1Hints);
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v1.getState());
-    Assert.assertEquals(5, v1.getTotalTasks());
-    Assert.assertEquals(RootInputVertexManager.class.getName(), v1
+    assertEquals(VertexState.INITED, v1.getState());
+    assertEquals(5, v1.getTotalTasks());
+    assertEquals(RootInputVertexManager.class.getName(), v1
         .getVertexManager().getPlugin().getClass().getName());
     for (int i=0; i < v1Hints.size(); ++i) {
-      Assert.assertEquals(v1Hints.get(i), v1.getTaskLocationHints()[i]);
+      assertEquals(v1Hints.get(i), v1.getTaskLocationHints()[i]);
     }
-    Assert.assertEquals(true, initializerManager1.hasShutDown);
+    assertTrue(initializerManager1.hasShutDown);
     for (int i = 0; i < 5; i++) {
       List<InputSpec> inputSpecs = v1.getInputSpecList(i);
-      Assert.assertEquals(1, inputSpecs.size());
-      Assert.assertEquals(1, inputSpecs.get(0).getPhysicalEdgeCount());
+      assertEquals(1, inputSpecs.size());
+      assertEquals(1, inputSpecs.get(0).getPhysicalEdgeCount());
     }
     // task events get buffered
-    Assert.assertEquals(5, v1.pendingTaskEvents.size());
+    assertEquals(5, v1.pendingTaskEvents.size());
 
     VertexImplWithControlledInitializerManager v2 = (VertexImplWithControlledInitializerManager) vertices.get("vertex2");
-    Assert.assertEquals(VertexState.INITIALIZING, v2.getState());
+    assertEquals(VertexState.INITIALIZING, v2.getState());
 
     // non-task events don't get buffered
     List<TezEvent> events = Lists.newLinkedList();
@@ -5905,31 +5976,32 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventRouteEvent(v2.getVertexId(), events));
     dispatcher.await();
-    Assert.assertEquals(1, v2.pendingTaskEvents.size());
+    assertEquals(1, v2.pendingTaskEvents.size());
 
     RootInputInitializerManagerControlled initializerManager2 = v2.getRootInputInitializerManager();
     List<TaskLocationHint> v2Hints = createTaskLocationHints(10);
     initializerManager2.completeInputInitialization(0, 10, v2Hints);
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v2.getState());
-    Assert.assertEquals(10, v2.getTotalTasks());
-    Assert.assertEquals(RootInputVertexManager.class.getName(), v2
+    assertEquals(VertexState.INITED, v2.getState());
+    assertEquals(10, v2.getTotalTasks());
+    assertEquals(RootInputVertexManager.class.getName(), v2
         .getVertexManager().getPlugin().getClass().getName());
     for (int i=0; i < v2Hints.size(); ++i) {
-      Assert.assertEquals(v2Hints.get(i), v2.getTaskLocationHints()[i]);
+      assertEquals(v2Hints.get(i), v2.getTaskLocationHints()[i]);
     }
-    Assert.assertEquals(true, initializerManager2.hasShutDown);
+    assertTrue(initializerManager2.hasShutDown);
     // task events get buffered
-    Assert.assertEquals(11, v2.pendingTaskEvents.size());
+    assertEquals(11, v2.pendingTaskEvents.size());
     for (int i = 0; i < 10; i++) {
       List<InputSpec> inputSpecs = v1.getInputSpecList(i);
-      Assert.assertEquals(1, inputSpecs.size());
-      Assert.assertEquals(1, inputSpecs.get(0).getPhysicalEdgeCount());
+      assertEquals(1, inputSpecs.size());
+      assertEquals(1, inputSpecs.get(0).getPhysicalEdgeCount());
     }
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexWithInputDistributor() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -5942,29 +6014,30 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEvent(v1.getVertexId(), VertexEventType.V_INIT));
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, v2.getState());
+    assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertEquals(VertexState.INITIALIZING, v2.getState());
     RootInputInitializerManagerControlled initializerManager1 = v1.getRootInputInitializerManager();
     byte[] payload = new byte[0];
     initializerManager1.completeInputDistribution(payload);
     dispatcher.await();
     // edge is still null so its initializing
-    Assert.assertEquals(VertexState.INITIALIZING, v1.getState());
-    Assert.assertEquals(true, initializerManager1.hasShutDown);
-    Assert.assertEquals(2, v1.getTotalTasks());
-    Assert.assertArrayEquals(payload,
+    assertEquals(VertexState.INITIALIZING, v1.getState());
+    assertTrue(initializerManager1.hasShutDown);
+    assertEquals(2, v1.getTotalTasks());
+    assertArrayEquals(payload,
         v1.getInputSpecList(0).get(0).getInputDescriptor().getUserPayload().deepCopyAsArray());
     EdgeManagerPluginDescriptor mockEdgeManagerDescriptor =
         EdgeManagerPluginDescriptor.create(EdgeManagerForTest.class.getName());
     Edge e = v2.sourceVertices.get(v1);
-    Assert.assertNull(e.getEdgeManager());
+    assertNull(e.getEdgeManager());
     e.setCustomEdgeManager(mockEdgeManagerDescriptor);
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v1.getState());
-    Assert.assertEquals(VertexState.INITED, v2.getState());
+    assertEquals(VertexState.INITED, v1.getState());
+    assertEquals(VertexState.INITED, v2.getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexRootInputSpecUpdateAll() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -5977,24 +6050,25 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEvent(v3.getVertexId(), VertexEventType.V_INIT));
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, v3.getState());
+    assertEquals(VertexState.INITIALIZING, v3.getState());
     RootInputInitializerManagerControlled initializerManager1 = v3.getRootInputInitializerManager();
     initializerManager1.completeInputInitialization();
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v3.getState());
-    Assert.assertEquals(expectedNumTasks, v3.getTotalTasks());
-    Assert.assertEquals(RootInputSpecUpdaterVertexManager.class.getName(), v3.getVertexManager()
+    assertEquals(VertexState.INITED, v3.getState());
+    assertEquals(expectedNumTasks, v3.getTotalTasks());
+    assertEquals(RootInputSpecUpdaterVertexManager.class.getName(), v3.getVertexManager()
         .getPlugin().getClass().getName());
-    Assert.assertEquals(true, initializerManager1.hasShutDown);
+    assertTrue(initializerManager1.hasShutDown);
 
     for (int i = 0; i < expectedNumTasks; i++) {
       List<InputSpec> inputSpecs = v3.getInputSpecList(i);
-      Assert.assertEquals(1, inputSpecs.size());
-      Assert.assertEquals(4, inputSpecs.get(0).getPhysicalEdgeCount());
+      assertEquals(1, inputSpecs.size());
+      assertEquals(4, inputSpecs.get(0).getPhysicalEdgeCount());
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexRootInputSpecUpdatePerTask() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -6007,20 +6081,20 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEvent(v4.getVertexId(), VertexEventType.V_INIT));
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, v4.getState());
+    assertEquals(VertexState.INITIALIZING, v4.getState());
     RootInputInitializerManagerControlled initializerManager1 = v4.getRootInputInitializerManager();
     initializerManager1.completeInputInitialization();
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v4.getState());
-    Assert.assertEquals(expectedNumTasks, v4.getTotalTasks());
-    Assert.assertEquals(RootInputSpecUpdaterVertexManager.class.getName(), v4.getVertexManager()
+    assertEquals(VertexState.INITED, v4.getState());
+    assertEquals(expectedNumTasks, v4.getTotalTasks());
+    assertEquals(RootInputSpecUpdaterVertexManager.class.getName(), v4.getVertexManager()
         .getPlugin().getClass().getName());
-    Assert.assertEquals(true, initializerManager1.hasShutDown);
+    assertTrue(initializerManager1.hasShutDown);
 
     for (int i = 0; i < expectedNumTasks; i++) {
       List<InputSpec> inputSpecs = v4.getInputSpecList(i);
-      Assert.assertEquals(1, inputSpecs.size());
-      Assert.assertEquals(i + 1, inputSpecs.get(0).getPhysicalEdgeCount());
+      assertEquals(1, inputSpecs.size());
+      assertEquals(i + 1, inputSpecs.get(0).getPhysicalEdgeCount());
     }
   }
 
@@ -6035,7 +6109,8 @@ public class TestVertexImpl {
     return locationHints;
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexWithNoTasks() {
     TezVertexID vId = null;
     try {
@@ -6052,12 +6127,12 @@ public class TestVertexImpl {
       vertices.put(v.getName(), v);
       v.handle(new VertexEvent(vId, VertexEventType.V_INIT));
       dispatcher.await();
-      Assert.assertEquals(VertexState.INITED, v.getState());
-      Assert.assertTrue(0.0f == v.getCompletedTaskProgress());
+      assertEquals(VertexState.INITED, v.getState());
+      assertEquals(0.0f, v.getCompletedTaskProgress());
       v.handle(new VertexEvent(vId, VertexEventType.V_START));
       dispatcher.await();
-      Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-      Assert.assertTrue(1.0f == v.getCompletedTaskProgress());
+      assertEquals(VertexState.SUCCEEDED, v.getState());
+      assertEquals(1.0f, v.getCompletedTaskProgress());
     } finally {
       if (vId != null) {
         vertexIdMap.remove(vId);
@@ -6065,7 +6140,8 @@ public class TestVertexImpl {
     }
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testVertexNoTasksTerminated() {
     TezVertexID vId = null;
     try {
@@ -6082,14 +6158,14 @@ public class TestVertexImpl {
       vertexIdMap.put(vId, v);
       vertices.put(v.getName(), v);
       v.handle(new VertexEvent(vId, VertexEventType.V_INIT));
-      Assert.assertEquals(VertexState.INITED, v.getState());
+      assertEquals(VertexState.INITED, v.getState());
       v.handle(new VertexEvent(vId, VertexEventType.V_START));
-      Assert.assertEquals(VertexState.RUNNING, v.getState());
+      assertEquals(VertexState.RUNNING, v.getState());
       v.handle(new VertexEventTermination(vId, VertexTerminationCause.OTHER_VERTEX_FAILURE));
-      Assert.assertEquals(VertexState.TERMINATING, v.getState());
+      assertEquals(VertexState.TERMINATING, v.getState());
       v.handle(new VertexEvent(vId, VertexEventType.V_COMPLETED));
-      Assert.assertEquals(VertexState.KILLED, v.getState());
-      Assert.assertTrue(1.0f == v.getCompletedTaskProgress());
+      assertEquals(VertexState.KILLED, v.getState());
+      assertEquals(1.0f, v.getCompletedTaskProgress());
     } finally {
       if (vId != null) {
         vertexIdMap.remove(vId);
@@ -6307,7 +6383,8 @@ public class TestVertexImpl {
     }
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexGroupInput() throws TezException {
     setupPreDagCreation();
     dagPlan = createVertexGroupDAGPlan();
@@ -6323,18 +6400,19 @@ public class TestVertexImpl {
         VertexEventType.V_INIT));
     dispatcher.await();
 
-    Assert.assertNull(vA.getGroupInputSpecList());
-    Assert.assertNull(vB.getGroupInputSpecList());
+    assertNull(vA.getGroupInputSpecList());
+    assertNull(vB.getGroupInputSpecList());
 
     List<GroupInputSpec> groupInSpec = vC.getGroupInputSpecList();
-    Assert.assertEquals(1, groupInSpec.size());
-    Assert.assertEquals("Group", groupInSpec.get(0).getGroupName());
+    assertEquals(1, groupInSpec.size());
+    assertEquals("Group", groupInSpec.get(0).getGroupName());
     assertTrue(groupInSpec.get(0).getGroupVertices().contains("A"));
     assertTrue(groupInSpec.get(0).getGroupVertices().contains("B"));
     groupInSpec.get(0).getMergedInputDescriptor().getClassName().equals("Group.class");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testStartWithUninitializedCustomEdge() throws Exception {
     // Race when a source vertex manages to start before the target vertex has
     // been initialized
@@ -6352,20 +6430,20 @@ public class TestVertexImpl {
       VertexEventType.V_START));
 
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, vA.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, vB.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, vC.getState());
+    assertEquals(VertexState.INITIALIZING, vA.getState());
+    assertEquals(VertexState.INITIALIZING, vB.getState());
+    assertEquals(VertexState.INITIALIZING, vC.getState());
 
     // setting the edge manager should vA to start
     EdgeManagerPluginDescriptor mockEdgeManagerDescriptor =
         EdgeManagerPluginDescriptor.create(EdgeManagerForTest.class.getName());
     Edge e = vC.sourceVertices.get(vA);
-    Assert.assertNull(e.getEdgeManager());
+    assertNull(e.getEdgeManager());
     e.setCustomEdgeManager(mockEdgeManagerDescriptor);
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, vA.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, vB.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, vC.getState());
+    assertEquals(VertexState.RUNNING, vA.getState());
+    assertEquals(VertexState.INITIALIZING, vB.getState());
+    assertEquals(VertexState.INITIALIZING, vC.getState());
 
     EdgeProperty edgeProp = EdgeProperty.create(mockEdgeManagerDescriptor,
         DataSourceType.PERSISTED, SchedulingType.SEQUENTIAL, OutputDescriptor.create("Out"),
@@ -6375,15 +6453,16 @@ public class TestVertexImpl {
     vC.reconfigureVertex(2, vertexLocationHint, edges);
 
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, vA.getState());
-    Assert.assertEquals(VertexState.RUNNING, vB.getState());
-    Assert.assertEquals(VertexState.RUNNING, vC.getState());
-    Assert.assertNotNull(vA.getTask(0));
-    Assert.assertNotNull(vB.getTask(0));
-    Assert.assertNotNull(vC.getTask(0));
+    assertEquals(VertexState.RUNNING, vA.getState());
+    assertEquals(VertexState.RUNNING, vB.getState());
+    assertEquals(VertexState.RUNNING, vC.getState());
+    assertNotNull(vA.getTask(0));
+    assertNotNull(vB.getTask(0));
+    assertNotNull(vC.getTask(0));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexConfiguredDoneByVMBeforeEdgeDefined() throws Exception {
     // Race when a source vertex manages to start before the target vertex has
     // been initialized
@@ -6414,25 +6493,25 @@ public class TestVertexImpl {
       VertexEventType.V_START));
 
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITIALIZING, vA.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, vB.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, vC.getState());
+    assertEquals(VertexState.INITIALIZING, vA.getState());
+    assertEquals(VertexState.INITIALIZING, vB.getState());
+    assertEquals(VertexState.INITIALIZING, vC.getState());
 
     // setting the edge manager should vA to start
     EdgeManagerPluginDescriptor mockEdgeManagerDescriptor =
         EdgeManagerPluginDescriptor.create(EdgeManagerForTest.class.getName());
     Edge e = vC.sourceVertices.get(vA);
-    Assert.assertNull(e.getEdgeManager());
+    assertNull(e.getEdgeManager());
     e.setCustomEdgeManager(mockEdgeManagerDescriptor);
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, vA.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, vB.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, vC.getState());
+    assertEquals(VertexState.RUNNING, vA.getState());
+    assertEquals(VertexState.INITIALIZING, vB.getState());
+    assertEquals(VertexState.INITIALIZING, vC.getState());
 
     // vB is not configured yet. Edge to C is not configured. So it should not send configured event
     // even thought VM says its doneConfiguring vertex
     vB.doneReconfiguringVertex();
-    Assert.assertEquals(0, listener.events.size());
+    assertEquals(0, listener.events.size());
 
     // complete configuration and verify getting configured signal from vB
     EdgeProperty edgeProp = EdgeProperty.create(mockEdgeManagerDescriptor,
@@ -6443,21 +6522,22 @@ public class TestVertexImpl {
     vC.reconfigureVertex(2, vertexLocationHint, edges);
 
     dispatcher.await();
-    Assert.assertEquals(1, listener.events.size());
-    Assert.assertEquals(vB.getName(), listener.events.get(0).getVertexName());
-    Assert.assertEquals(org.apache.tez.dag.api.event.VertexState.CONFIGURED,
+    assertEquals(1, listener.events.size());
+    assertEquals(vB.getName(), listener.events.get(0).getVertexName());
+    assertEquals(org.apache.tez.dag.api.event.VertexState.CONFIGURED,
         listener.events.get(0).getVertexState());
     updateTracker.unregisterForVertexUpdates(vB.getName(), listener);
 
-    Assert.assertEquals(VertexState.RUNNING, vA.getState());
-    Assert.assertEquals(VertexState.RUNNING, vB.getState());
-    Assert.assertEquals(VertexState.RUNNING, vC.getState());
-    Assert.assertNotNull(vA.getTask(0));
-    Assert.assertNotNull(vB.getTask(0));
-    Assert.assertNotNull(vC.getTask(0));
+    assertEquals(VertexState.RUNNING, vA.getState());
+    assertEquals(VertexState.RUNNING, vB.getState());
+    assertEquals(VertexState.RUNNING, vC.getState());
+    assertNotNull(vA.getTask(0));
+    assertNotNull(vB.getTask(0));
+    assertNotNull(vC.getTask(0));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInitStartRace() throws TezException {
     // Race when a source vertex manages to start before the target vertex has
     // been initialized
@@ -6475,12 +6555,13 @@ public class TestVertexImpl {
       VertexEventType.V_START));
 
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, vA.getState());
-    Assert.assertEquals(VertexState.RUNNING, vB.getState());
-    Assert.assertEquals(VertexState.RUNNING, vC.getState());
+    assertEquals(VertexState.RUNNING, vA.getState());
+    assertEquals(VertexState.RUNNING, vB.getState());
+    assertEquals(VertexState.RUNNING, vC.getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInitStartRace2() throws TezException {
     // Race when a source vertex manages to start before the target vertex has
     // been initialized
@@ -6502,12 +6583,13 @@ public class TestVertexImpl {
         VertexEventType.V_START));
 
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, vA.getState());
-    Assert.assertEquals(VertexState.RUNNING, vB.getState());
-    Assert.assertEquals(VertexState.RUNNING, vC.getState());
+    assertEquals(VertexState.RUNNING, vA.getState());
+    assertEquals(VertexState.RUNNING, vB.getState());
+    assertEquals(VertexState.RUNNING, vC.getState());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTez2684() throws IOException, TezException {
     setupPreDagCreation();
     dagPlan = createSamplerDAGPlan2();
@@ -6523,31 +6605,32 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(new VertexEvent(vA.getVertexId(),
         VertexEventType.V_START));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, vA.getState());
-    Assert.assertEquals(VertexState.NEW, vB.getState());
-    Assert.assertEquals(VertexState.NEW, vC.getState());
+    assertEquals(VertexState.RUNNING, vA.getState());
+    assertEquals(VertexState.NEW, vB.getState());
+    assertEquals(VertexState.NEW, vC.getState());
 
     //vB init
     dispatcher.getEventHandler().handle(new VertexEvent(vB.getVertexId(),
         VertexEventType.V_INIT));
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, vB.getState());
-    Assert.assertEquals(VertexState.INITED, vC.getState());
+    assertEquals(VertexState.INITED, vB.getState());
+    assertEquals(VertexState.INITED, vC.getState());
 
     //Send VertexManagerEvent
     long[] sizes = new long[]{(100_000_000L)};
     Event vmEvent = getVertexManagerEvent(sizes, 1_060_000_000L, vB);
     sendTaskGeneratedEvent(vmEvent, EventProducerConsumerType.INPUT, vC, vB);
-    Assert.assertEquals(VertexState.INITED, vC.getState());
+    assertEquals(VertexState.INITED, vC.getState());
 
     //vB start
     dispatcher.getEventHandler().handle(new VertexEvent(vB.getVertexId(), VertexEventType.V_START));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, vC.getState());
+    assertEquals(VertexState.RUNNING, vC.getState());
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexGraceParallelism() throws IOException, TezException {
     setupPreDagCreation();
     dagPlan = createDAGPlanForGraceParallelism();
@@ -6558,19 +6641,19 @@ public class TestVertexImpl {
     VertexImpl vC = vertices.get("C");
 
     initVertex(vA);
-    Assert.assertEquals(VertexState.INITED, vA.getState());
-    Assert.assertEquals(VertexState.INITED, vB.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, vC.getState());
+    assertEquals(VertexState.INITED, vA.getState());
+    assertEquals(VertexState.INITED, vB.getState());
+    assertEquals(VertexState.INITIALIZING, vC.getState());
 
     long[] sizes = new long[]{(100_000_000L)};
     Event vmEvent = getVertexManagerEvent(sizes, 1_060_000_000L, vC);
     sendTaskGeneratedEvent(vmEvent, EventProducerConsumerType.OUTPUT, vB, vC);
-    Assert.assertEquals(VertexState.INITIALIZING, vC.getState());
+    assertEquals(VertexState.INITIALIZING, vC.getState());
 
     startVertex(vA);
     completeAllTasksSuccessfully(vA);
-    Assert.assertEquals(VertexState.SUCCEEDED, vA.getState());
-    Assert.assertEquals(VertexState.RUNNING, vC.getState());
+    assertEquals(VertexState.SUCCEEDED, vA.getState());
+    assertEquals(VertexState.RUNNING, vC.getState());
   }
 
   private void sendTaskGeneratedEvent(Event event, EventProducerConsumerType generator,
@@ -6614,7 +6697,8 @@ public class TestVertexImpl {
     return vmEvent;
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVMEventBeforeVertexInitialized() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -6671,7 +6755,8 @@ public class TestVertexImpl {
     assertEquals(2, InvocationCountingVertexManager.numVmEventsReceived.get());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionFromVM_Initialize() throws TezException {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -6684,13 +6769,14 @@ public class TestVertexImpl {
         VertexEventType.V_INIT));
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(VertexState.FAILED, v1.getState());
     String diagnostics = StringUtils.join(v1.getDiagnostics(), ",");
-    Assert.assertTrue(diagnostics.contains(VMExceptionLocation.Initialize.name()));
-    Assert.assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE, v1.getTerminationCause());
+    assertTrue(diagnostics.contains(VMExceptionLocation.Initialize.name()));
+    assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE, v1.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionFromVM_OnRootVertexInitialized() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -6706,15 +6792,16 @@ public class TestVertexImpl {
     RootInputInitializerManagerControlled initializerManager1 = v1.getRootInputInitializerManager();
     initializerManager1.completeInputInitialization();
     dispatcher.await();
-    Assert.assertEquals(VertexManagerWithException.class, v1.vertexManager.getPlugin().getClass());
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
-    Assert.assertTrue(initializerManager1.hasShutDown);
+    assertEquals(VertexManagerWithException.class, v1.vertexManager.getPlugin().getClass());
+    assertEquals(VertexState.FAILED, v1.getState());
+    assertTrue(initializerManager1.hasShutDown);
     String diagnostics = StringUtils.join(v1.getDiagnostics(), ",");
-    Assert.assertTrue(diagnostics.contains(VMExceptionLocation.OnRootVertexInitialized.name()));
-    Assert.assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE, v1.getTerminationCause());
+    assertTrue(diagnostics.contains(VMExceptionLocation.OnRootVertexInitialized.name()));
+    assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE, v1.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionFromVM_OnVertexStarted() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -6734,14 +6821,15 @@ public class TestVertexImpl {
         VertexEventType.V_START));
     dispatcher.await();
 
-    Assert.assertEquals(VertexManagerWithException.class, v1.vertexManager.getPlugin().getClass());
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(VertexManagerWithException.class, v1.vertexManager.getPlugin().getClass());
+    assertEquals(VertexState.FAILED, v1.getState());
     String diagnostics = StringUtils.join(v1.getDiagnostics(), ",");
-    Assert.assertTrue(diagnostics.contains(VMExceptionLocation.OnVertexStarted.name()));
-    Assert.assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE, v1.getTerminationCause());
+    assertTrue(diagnostics.contains(VMExceptionLocation.OnVertexStarted.name()));
+    assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE, v1.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionFromVM_OnSourceTaskCompleted() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -6769,15 +6857,16 @@ public class TestVertexImpl {
         TaskAttemptStateInternal.SUCCEEDED));
     dispatcher.await();
 
-    Assert.assertEquals(VertexManagerWithException.class, v1.vertexManager.getPlugin().getClass());
-    Assert.assertEquals(VertexManagerWithException.class, v2.vertexManager.getPlugin().getClass());
-    Assert.assertEquals(VertexState.FAILED, v2.getState());
+    assertEquals(VertexManagerWithException.class, v1.vertexManager.getPlugin().getClass());
+    assertEquals(VertexManagerWithException.class, v2.vertexManager.getPlugin().getClass());
+    assertEquals(VertexState.FAILED, v2.getState());
     String diagnostics = StringUtils.join(v2.getDiagnostics(), ",");
-    Assert.assertTrue(diagnostics.contains(VMExceptionLocation.OnSourceTaskCompleted.name()));
-    Assert.assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE, v2.getTerminationCause());
+    assertTrue(diagnostics.contains(VMExceptionLocation.OnSourceTaskCompleted.name()));
+    assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE, v2.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionFromVM_OnVertexManagerEventReceived() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -6800,12 +6889,13 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(new VertexEventRouteEvent(v1.getVertexId(), Lists.newArrayList(tezEvent)));
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(VertexState.FAILED, v1.getState());
     String diagnostics = StringUtils.join(v1.getDiagnostics(), ",");
-    Assert.assertTrue(diagnostics.contains(VMExceptionLocation.OnVertexManagerEventReceived.name()));
+    assertTrue(diagnostics.contains(VMExceptionLocation.OnVertexManagerEventReceived.name()));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionFromVM_OnVertexManagerVertexStateUpdated() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -6822,16 +6912,17 @@ public class TestVertexImpl {
     RootInputInitializerManagerControlled initializerManager1 = v1.getRootInputInitializerManager();
     initializerManager1.completeInputInitialization();
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v2.getState());
+    assertEquals(VertexState.INITED, v2.getState());
     startVertex(v1, false);
     dispatcher.await();
-    Assert.assertEquals(VertexState.FAILED, v2.getState());
+    assertEquals(VertexState.FAILED, v2.getState());
     String diagnostics = StringUtils.join(v2.getDiagnostics(), ",");
     assertTrue(diagnostics.contains(VMExceptionLocation.OnVertexManagerVertexStateUpdated.name()));
-    Assert.assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE, v2.getTerminationCause());
+    assertEquals(VertexTerminationCause.AM_USERCODE_FAILURE, v2.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionFromII_Initialize() throws InterruptedException, TezException {
     useCustomInitializer = true;
     customInitializer = new EventHandlingRootInputInitializer(null, IIExceptionLocation.Initialize);
@@ -6851,11 +6942,12 @@ public class TestVertexImpl {
 
     String diagnostics = StringUtils.join(v1.getDiagnostics(), ",");
     assertTrue(diagnostics.contains(IIExceptionLocation.Initialize.name()));
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
-    Assert.assertEquals(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE, v1.getTerminationCause());
+    assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE, v1.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionFromII_InitFailedAfterInitialized() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -6868,18 +6960,19 @@ public class TestVertexImpl {
     RootInputInitializerManagerControlled initializerManager1 = v1.getRootInputInitializerManager();
     initializerManager1.completeInputInitialization(0);
     dispatcher.await();
-    Assert.assertEquals(VertexState.INITED, v1.getState());
+    assertEquals(VertexState.INITED, v1.getState());
     String errorMsg = "ErrorWhenInitFailureAtInited";
     dispatcher.getEventHandler().handle(new VertexEventRootInputFailed(v1.getVertexId(), "input1",
         new AMUserCodeException(Source.InputInitializer, new Exception(errorMsg))));
     dispatcher.await();
     String diagnostics = StringUtils.join(v1.getDiagnostics(), ",");
     assertTrue(diagnostics.contains(errorMsg));
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
-    Assert.assertEquals(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE, v1.getTerminationCause());
+    assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE, v1.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionFromII_InitFailedAfterRunning() throws Exception {
     useCustomInitializer = true;
     setupPreDagCreation();
@@ -6893,18 +6986,19 @@ public class TestVertexImpl {
     initializerManager1.completeInputInitialization(0);
     dispatcher.await();
     startVertex(v1);
-    Assert.assertEquals(VertexState.RUNNING, v1.getState());
+    assertEquals(VertexState.RUNNING, v1.getState());
     String errorMsg = "ErrorWhenInitFailureAtRunning";
     dispatcher.getEventHandler().handle(new VertexEventRootInputFailed(v1.getVertexId(), "input1",
         new AMUserCodeException(Source.InputInitializer, new Exception(errorMsg))));
     dispatcher.await();
     String diagnostics = StringUtils.join(v1.getDiagnostics(), ",");
     assertTrue(diagnostics.contains(errorMsg));
-    Assert.assertEquals(VertexState.FAILED, v1.getState());
-    Assert.assertEquals(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE, v1.getTerminationCause());
+    assertEquals(VertexState.FAILED, v1.getState());
+    assertEquals(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE, v1.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionFromII_HandleInputInitializerEvent() throws Exception {
     useCustomInitializer = true;
     customInitializer = new EventHandlingRootInputInitializer(null, IIExceptionLocation.HandleInputInitializerEvent);
@@ -6921,16 +7015,16 @@ public class TestVertexImpl {
 
     initVertex(v1);
     startVertex(v1);
-    Assert.assertEquals(VertexState.RUNNING, v1.getState());
-    Assert.assertEquals(VertexState.INITIALIZING, v2.getState());
+    assertEquals(VertexState.RUNNING, v1.getState());
+    assertEquals(VertexState.INITIALIZING, v2.getState());
     dispatcher.await();
 
     // Wait for the initializer to be invoked - which may be a separate thread.
     while (!initializer.initStarted.get()) {
       Thread.sleep(10);
     }
-    Assert.assertFalse(initializer.eventReceived.get());
-    Assert.assertFalse(initializer.initComplete.get());
+    assertFalse(initializer.eventReceived.get());
+    assertFalse(initializer.initComplete.get());
 
     // Signal the initializer by sending an event - via vertex1
     InputInitializerEvent event = InputInitializerEvent.create("vertex2", "input1", null);
@@ -6950,11 +7044,12 @@ public class TestVertexImpl {
     // it would cause v2 fail as its II throw exception in handleInputInitializerEvent
     String diagnostics = StringUtils.join(v2.getDiagnostics(), ",");
     assertTrue(diagnostics.contains(IIExceptionLocation.HandleInputInitializerEvent.name()));
-    Assert.assertEquals(VertexState.FAILED, v2.getState());
-    Assert.assertEquals(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE, v2.getTerminationCause());
+    assertEquals(VertexState.FAILED, v2.getState());
+    assertEquals(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE, v2.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionFromII_OnVertexStateUpdated() throws InterruptedException, TezException {
     useCustomInitializer = true;
     customInitializer = new EventHandlingRootInputInitializer(null, IIExceptionLocation.OnVertexStateUpdated);
@@ -6976,14 +7071,15 @@ public class TestVertexImpl {
     }
     startVertex(v1);  // v2 would get the state update from v1
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v1.getState());
-    Assert.assertEquals(VertexState.FAILED, v2.getState());
+    assertEquals(VertexState.RUNNING, v1.getState());
+    assertEquals(VertexState.FAILED, v2.getState());
     String diagnostics = StringUtils.join(v2.getDiagnostics(), ",");
     assertTrue(diagnostics.contains(IIExceptionLocation.OnVertexStateUpdated.name()));
-    Assert.assertEquals(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE, v2.getTerminationCause());
+    assertEquals(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE, v2.getTerminationCause());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionFromII_InitSucceededAfterInitFailure() throws InterruptedException, TezException {
     useCustomInitializer = true;
     customInitializer = new EventHandlingRootInputInitializer(null, IIExceptionLocation.OnVertexStateUpdated);
@@ -7008,14 +7104,15 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(new VertexEventRootInputInitialized(
         v2.getVertexId(), "input1", null));
 
-    Assert.assertEquals(VertexState.RUNNING, v1.getState());
-    Assert.assertEquals(VertexState.FAILED, v2.getState());
+    assertEquals(VertexState.RUNNING, v1.getState());
+    assertEquals(VertexState.FAILED, v2.getState());
     String diagnostics = StringUtils.join(v2.getDiagnostics(), ",");
     assertTrue(diagnostics.contains(IIExceptionLocation.OnVertexStateUpdated.name()));
-    Assert.assertEquals(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE, v2.getTerminationCause());
+    assertEquals(VertexTerminationCause.ROOT_INPUT_INIT_FAILURE, v2.getTerminationCause());
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCompletedStatsCache() {
     initAllVertices(VertexState.INITED);
     VertexImpl v = vertices.get("vertex2");
@@ -7032,18 +7129,19 @@ public class TestVertexImpl {
     VertexStatistics stats = v.getStatistics();
 
     //Ensure that task 0 is available in completed stats cache
-    Assert.assertTrue(v.completedTasksStatsCache.taskSet.get(0));
+    assertTrue(v.completedTasksStatsCache.taskSet.get(0));
 
     //Reschedule task 0
     dispatcher.getEventHandler().handle(new VertexEventTaskReschedule(t1));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(VertexState.RUNNING, v.getState());
 
     //cache should be cleared
-    Assert.assertTrue(v.completedTasksStatsCache.taskSet.cardinality() == 0);
+    assertEquals(0, v.completedTasksStatsCache.taskSet.cardinality());
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRouteEvent_RecoveredEvent() throws IOException {
     doReturn(historyEventHandler).when(appContext).getHistoryHandler();
     doReturn(true).when(appContext).isRecoveryEnabled();
@@ -7068,7 +7166,7 @@ public class TestVertexImpl {
 
     v3.scheduleTasks(Lists.newArrayList(ScheduleTaskRequest.create(0, null)));
     dispatcher.await();
-    assertTrue(v3.pendingTaskEvents.size() == 0);
+    assertEquals(0, v3.pendingTaskEvents.size());
     // recovery events is not only handled one time
 //    argCaptor = ArgumentCaptor.forClass(DAGHistoryEvent.class);
 //    verify(historyEventHandler, atLeast(1)).handle(argCaptor.capture());
@@ -7084,7 +7182,7 @@ public class TestVertexImpl {
         actualTimes ++;
       }
     }
-    Assert.assertEquals(actualTimes, expectedTimes);
+    assertEquals(actualTimes, expectedTimes);
   }
 
   @InterfaceAudience.Private
@@ -7390,7 +7488,8 @@ public class TestVertexImpl {
     void setContext(InputInitializerContext context);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCounterLimits() {
     initAllVertices(VertexState.INITED);
 
@@ -7412,35 +7511,36 @@ public class TestVertexImpl {
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t1, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.RUNNING, v.getState());
-    Assert.assertEquals(1, v.getCompletedTasks());
-    Assert.assertTrue((0.5f) == v.getCompletedTaskProgress());
+    assertEquals(VertexState.RUNNING, v.getState());
+    assertEquals(1, v.getCompletedTasks());
+    assertEquals((0.5f), v.getCompletedTaskProgress());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskCompleted(t2, TaskState.SUCCEEDED));
     dispatcher.await();
-    Assert.assertEquals(VertexState.FAILED, v.getState());
-    Assert.assertEquals(2, v.getCompletedTasks());
+    assertEquals(VertexState.FAILED, v.getState());
+    assertEquals(2, v.getCompletedTasks());
 
     System.out.println(v.getDiagnostics());
-    Assert.assertTrue("Diagnostics should contain counter limits error message",
-        StringUtils.join(v.getDiagnostics(), ",").contains("Counters limit exceeded"));
+    assertTrue(StringUtils.join(v.getDiagnostics(), ",").contains("Counters limit exceeded"), "Diagnostics should contain counter limits error message");
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFirstTaskStartTime() {
     VertexImpl v = vertices.get("vertex1");
-    Assert.assertEquals(v.getFirstTaskStartTime(), -1);
+    assertEquals(v.getFirstTaskStartTime(), -1);
     v.reportTaskStartTime(100);
-    Assert.assertEquals(v.getFirstTaskStartTime(), 100);
+    assertEquals(v.getFirstTaskStartTime(), 100);
     v.reportTaskStartTime(50);
-    Assert.assertEquals(v.getFirstTaskStartTime(), 50);
+    assertEquals(v.getFirstTaskStartTime(), 50);
     v.reportTaskStartTime(200);
-    Assert.assertEquals(v.getFirstTaskStartTime(), 50);
+    assertEquals(v.getFirstTaskStartTime(), 50);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLastTaskFinishTime() {
     NodeId nid = NodeId.newInstance("127.0.0.1", 0);
     ContainerId contId = ContainerId.newContainerId(appAttemptId, 3);
@@ -7469,7 +7569,7 @@ public class TestVertexImpl {
     TaskAttemptImpl taskAttempt0 = (TaskAttemptImpl) task0.getAttempt(taskAttemptId0);
     TaskAttemptImpl taskAttempt1 = (TaskAttemptImpl) task1.getAttempt(taskAttemptId1);
 
-    Assert.assertEquals(v.getLastTaskFinishTime(), -1);
+    assertEquals(v.getLastTaskFinishTime(), -1);
 
     taskAttempt0.handle(new TaskAttemptEventSchedule(taskAttemptId0, 0, 0));
     taskAttempt0.handle(new TaskAttemptEventSubmitted(taskAttemptId0, contId));
@@ -7477,7 +7577,7 @@ public class TestVertexImpl {
     taskAttempt0.handle(new TaskAttemptEvent(taskAttemptId0, TaskAttemptEventType.TA_DONE));
     //task0.handle(new TaskEventTAUpdate(taskAttemptId0, TaskEventType.T_ATTEMPT_SUCCEEDED));
 
-    Assert.assertEquals(v.getLastTaskFinishTime(), -1);
+    assertEquals(v.getLastTaskFinishTime(), -1);
 
     taskAttempt1.handle(new TaskAttemptEventSchedule(taskAttemptId1, 0, 0));
     taskAttempt1.handle(new TaskAttemptEventSubmitted(taskAttemptId1, contId));
@@ -7487,11 +7587,12 @@ public class TestVertexImpl {
 
     dispatcher.await();
 
-    Assert.assertEquals(VertexState.SUCCEEDED, v.getState());
-    Assert.assertTrue(v.getLastTaskFinishTime() > 0);
+    assertEquals(VertexState.SUCCEEDED, v.getState());
+    assertTrue(v.getLastTaskFinishTime() > 0);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPickupDagLocalResourceOnScheduleTask() {
     initAllVertices(VertexState.INITED);
     VertexImpl v1 = vertices.get("vertex1");
@@ -7502,11 +7603,11 @@ public class TestVertexImpl {
     ta0.handle(new TaskAttemptEventSchedule(taskAttemptId0, 1, 1));
 
     dispatcher.await();
-    Assert.assertEquals(1, amSchedulerEventDispatcher.events.size());
+    assertEquals(1, amSchedulerEventDispatcher.events.size());
     AMSchedulerEventTALaunchRequest launchRequestEvent = (AMSchedulerEventTALaunchRequest) amSchedulerEventDispatcher.events.get(0);
     Map<String, LocalResource> localResourceMap = launchRequestEvent.getContainerContext().getLocalResources();
-    Assert.assertTrue(localResourceMap.containsKey("dag lr"));
-    Assert.assertTrue(localResourceMap.containsKey("vertex lr"));
+    assertTrue(localResourceMap.containsKey("dag lr"));
+    assertTrue(localResourceMap.containsKey("vertex lr"));
   }
 
   @Test

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexImpl.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexImpl.java
@@ -4428,18 +4428,14 @@ public class TestVertexImpl {
         new VertexEventTaskCompleted(t2, TaskState.SUCCEEDED));
     dispatcher.await();
     assertEquals(VertexState.SUCCEEDED, v.getState());
-    assertEquals(1,
-        dagEventDispatcher.eventCount.get(
-            DAGEventType.DAG_VERTEX_COMPLETED).intValue());
+    assertEquals(1, dagEventDispatcher.eventCount.get(DAGEventType.DAG_VERTEX_COMPLETED).intValue());
 
     dispatcher.getEventHandler().handle(
         new VertexEventTaskReschedule(t1));
     dispatcher.await();
     assertEquals(VertexState.FAILED, v.getState());
 
-    assertEquals(2,
-        dagEventDispatcher.eventCount.get(
-            DAGEventType.DAG_VERTEX_COMPLETED).intValue());
+    assertEquals(2, dagEventDispatcher.eventCount.get(DAGEventType.DAG_VERTEX_COMPLETED).intValue());
   }
 
   @Test
@@ -7522,7 +7518,8 @@ public class TestVertexImpl {
     assertEquals(2, v.getCompletedTasks());
 
     System.out.println(v.getDiagnostics());
-    assertTrue(StringUtils.join(v.getDiagnostics(), ",").contains("Counters limit exceeded"), "Diagnostics should contain counter limits error message");
+    assertTrue(StringUtils.join(v.getDiagnostics(), ",").contains("Counters limit exceeded"),
+        "Diagnostics should contain counter limits error message");
 
   }
 
@@ -7530,13 +7527,13 @@ public class TestVertexImpl {
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFirstTaskStartTime() {
     VertexImpl v = vertices.get("vertex1");
-    assertEquals(v.getFirstTaskStartTime(), -1);
+    assertEquals(-1, v.getFirstTaskStartTime());
     v.reportTaskStartTime(100);
-    assertEquals(v.getFirstTaskStartTime(), 100);
+    assertEquals(100, v.getFirstTaskStartTime());
     v.reportTaskStartTime(50);
-    assertEquals(v.getFirstTaskStartTime(), 50);
+    assertEquals(50, v.getFirstTaskStartTime());
     v.reportTaskStartTime(200);
-    assertEquals(v.getFirstTaskStartTime(), 50);
+    assertEquals(50, v.getFirstTaskStartTime());
   }
 
   @Test
@@ -7569,7 +7566,7 @@ public class TestVertexImpl {
     TaskAttemptImpl taskAttempt0 = (TaskAttemptImpl) task0.getAttempt(taskAttemptId0);
     TaskAttemptImpl taskAttempt1 = (TaskAttemptImpl) task1.getAttempt(taskAttemptId1);
 
-    assertEquals(v.getLastTaskFinishTime(), -1);
+    assertEquals(-1, v.getLastTaskFinishTime());
 
     taskAttempt0.handle(new TaskAttemptEventSchedule(taskAttemptId0, 0, 0));
     taskAttempt0.handle(new TaskAttemptEventSubmitted(taskAttemptId0, contId));
@@ -7577,7 +7574,7 @@ public class TestVertexImpl {
     taskAttempt0.handle(new TaskAttemptEvent(taskAttemptId0, TaskAttemptEventType.TA_DONE));
     //task0.handle(new TaskEventTAUpdate(taskAttemptId0, TaskEventType.T_ATTEMPT_SUCCEEDED));
 
-    assertEquals(v.getLastTaskFinishTime(), -1);
+    assertEquals(-1, v.getLastTaskFinishTime());
 
     taskAttempt1.handle(new TaskAttemptEventSchedule(taskAttemptId1, 0, 0));
     taskAttempt1.handle(new TaskAttemptEventSubmitted(taskAttemptId1, contId));

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexImpl2.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexImpl2.java
@@ -18,9 +18,9 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.Credentials;
@@ -63,15 +64,16 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Contains additional tests for VertexImpl. Please avoid adding class parameters.
  */
 public class TestVertexImpl2 {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskLoggingOptsPerLogger() {
 
     Configuration conf = new TezConfiguration();
@@ -105,7 +107,8 @@ public class TestVertexImpl2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskLoggingOptsSimple() {
 
     Configuration conf = new TezConfiguration();
@@ -138,7 +141,8 @@ public class TestVertexImpl2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSpecificLoggingOpts() {
 
     String vertexName = "testvertex";
@@ -204,7 +208,8 @@ public class TestVertexImpl2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSpecificLoggingOpts2() {
 
     String vertexName = "testvertex";
@@ -270,7 +275,8 @@ public class TestVertexImpl2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNullExecutionContexts() {
 
     ExecutionContextTestInfoHolder info = new ExecutionContextTestInfoHolder(null, null);
@@ -281,7 +287,8 @@ public class TestVertexImpl2 {
     assertEquals(0, vertexWrapper.vertex.taskCommunicatorIdentifier);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDefaultExecContextViaDag() {
     VertexExecutionContext defaultExecContext = VertexExecutionContext.create(
         ExecutionContextTestInfoHolder
@@ -299,7 +306,8 @@ public class TestVertexImpl2 {
     assertEquals(2, vertexWrapper.vertex.taskCommunicatorIdentifier);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexExecutionContextOnly() {
     VertexExecutionContext vertexExecutionContext = VertexExecutionContext.create(
         ExecutionContextTestInfoHolder
@@ -317,7 +325,8 @@ public class TestVertexImpl2 {
     assertEquals(1, vertexWrapper.vertex.taskCommunicatorIdentifier);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexExecutionContextOverride() {
     VertexExecutionContext defaultExecContext = VertexExecutionContext.create(
         ExecutionContextTestInfoHolder
@@ -532,9 +541,9 @@ public class TestVertexImpl2 {
               dagConf);
 
       if (checkVertexOnlyConf) {
-        Assert.assertEquals("xyz1", vertex.vertexOnlyConf.get("abc1"));
-        Assert.assertEquals("bar2", vertex.vertexOnlyConf.get("foo1"));
-        Assert.assertEquals("bar", vertex.vertexOnlyConf.get("foo"));
+        assertEquals("xyz1", vertex.vertexOnlyConf.get("abc1"));
+        assertEquals("bar2", vertex.vertexOnlyConf.get("foo1"));
+        assertEquals("bar", vertex.vertexOnlyConf.get("foo"));
       }
 
     }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexManager.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexManager.java
@@ -18,10 +18,10 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -72,8 +73,9 @@ import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -86,7 +88,7 @@ public class TestVertexManager {
   EventHandler mockHandler;
   ArgumentCaptor<VertexEventInputDataInformation> requestCaptor;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mockAppContext = mock(AppContext.class, RETURNS_DEEP_STUBS);
     execService = mock(ListeningExecutorService.class);
@@ -128,7 +130,8 @@ public class TestVertexManager {
                                         List<Event> events) throws Exception {}
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexManagerPluginCtorAccessUserPayload() throws IOException, TezException {
     byte[] randomUserPayload = {1,2,3};
     UserPayload userPayload = UserPayload.create(ByteBuffer.wrap(randomUserPayload));
@@ -140,7 +143,8 @@ public class TestVertexManager {
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOnRootVertexInitialized() throws Exception {
     Configuration conf = new Configuration();
     VertexManager vm =
@@ -176,7 +180,8 @@ public class TestVertexManager {
    * custom vertex manager generates events only when both i1 and i2 are initialized.
    * @throws Exception
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOnRootVertexInitialized2() throws Exception {
     VertexManager vm =
         new VertexManager(
@@ -215,7 +220,8 @@ public class TestVertexManager {
     assertEquals(Sets.newHashSet("input1","input2"), edgeVertexSet);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVMPluginCtxGetInputVertexGroup() throws Exception {
     VertexManager vm =
       new VertexManager(VertexManagerPluginDescriptor.create(CustomVertexManager.class.getName()),
@@ -235,7 +241,8 @@ public class TestVertexManager {
     assertTrue(groups.get(group).contains(v2));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSendCustomProcessorEvent() throws Exception {
     VertexManager vm =
       new VertexManager(VertexManagerPluginDescriptor.create(CustomVertexManager.class.getName()),

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexStats.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/impl/TestVertexStats.java
@@ -18,29 +18,35 @@
  */
 package org.apache.tez.dag.app.dag.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.tez.dag.api.oldrecords.TaskState;
 import org.apache.tez.dag.records.TezDAGID;
 import org.apache.tez.dag.records.TezTaskID;
 import org.apache.tez.dag.records.TezVertexID;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestVertexStats {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasicStats() {
     VertexStats stats = new VertexStats();
-    Assert.assertEquals(-1, stats.firstTaskStartTime);
-    Assert.assertEquals(-1, stats.lastTaskFinishTime);
-    Assert.assertEquals(-1, stats.minTaskDuration);
-    Assert.assertEquals(-1, stats.maxTaskDuration);
-    Assert.assertTrue(-1 == stats.avgTaskDuration);
-    Assert.assertEquals(0, stats.getFirstTasksToStart().size());
-    Assert.assertEquals(0, stats.getLastTasksToFinish().size());
-    Assert.assertEquals(0, stats.getShortestDurationTasks().size());
-    Assert.assertEquals(0, stats.getLongestDurationTasks().size());
+    assertEquals(-1, stats.firstTaskStartTime);
+    assertEquals(-1, stats.lastTaskFinishTime);
+    assertEquals(-1, stats.minTaskDuration);
+    assertEquals(-1, stats.maxTaskDuration);
+    assertEquals(-1, stats.avgTaskDuration);
+    assertEquals(0, stats.getFirstTasksToStart().size());
+    assertEquals(0, stats.getLastTasksToFinish().size());
+    assertEquals(0, stats.getShortestDurationTasks().size());
+    assertEquals(0, stats.getLongestDurationTasks().size());
 
     TezVertexID tezVertexID = TezVertexID.getInstance(
         TezDAGID.getInstance(
@@ -54,108 +60,108 @@ public class TestVertexStats {
 
     stats.updateStats(new TaskReportImpl(tezTaskID1,
         TaskState.SUCCEEDED, 1, 100, 200));
-    Assert.assertEquals(100, stats.firstTaskStartTime);
-    Assert.assertEquals(200, stats.lastTaskFinishTime);
-    Assert.assertEquals(100, stats.minTaskDuration);
-    Assert.assertEquals(100, stats.maxTaskDuration);
-    Assert.assertTrue(100 == stats.avgTaskDuration);
-    Assert.assertTrue(stats.firstTasksToStart.contains(tezTaskID1));
-    Assert.assertTrue(stats.lastTasksToFinish.contains(tezTaskID1));
-    Assert.assertTrue(stats.shortestDurationTasks.contains(tezTaskID1));
-    Assert.assertTrue(stats.longestDurationTasks.contains(tezTaskID1));
-    Assert.assertEquals(1, stats.firstTasksToStart.size());
-    Assert.assertEquals(1, stats.lastTasksToFinish.size());
-    Assert.assertEquals(1, stats.shortestDurationTasks.size());
-    Assert.assertEquals(1, stats.longestDurationTasks.size());
+    assertEquals(100, stats.firstTaskStartTime);
+    assertEquals(200, stats.lastTaskFinishTime);
+    assertEquals(100, stats.minTaskDuration);
+    assertEquals(100, stats.maxTaskDuration);
+    assertEquals(100, stats.avgTaskDuration);
+    assertTrue(stats.firstTasksToStart.contains(tezTaskID1));
+    assertTrue(stats.lastTasksToFinish.contains(tezTaskID1));
+    assertTrue(stats.shortestDurationTasks.contains(tezTaskID1));
+    assertTrue(stats.longestDurationTasks.contains(tezTaskID1));
+    assertEquals(1, stats.firstTasksToStart.size());
+    assertEquals(1, stats.lastTasksToFinish.size());
+    assertEquals(1, stats.shortestDurationTasks.size());
+    assertEquals(1, stats.longestDurationTasks.size());
 
     stats.updateStats(new TaskReportImpl(tezTaskID2,
         TaskState.FAILED, 1, 150, 300));
-    Assert.assertEquals(100, stats.firstTaskStartTime);
-    Assert.assertEquals(300, stats.lastTaskFinishTime);
-    Assert.assertEquals(100, stats.minTaskDuration);
-    Assert.assertEquals(100, stats.maxTaskDuration);
-    Assert.assertTrue(100 == stats.avgTaskDuration);
-    Assert.assertTrue(stats.firstTasksToStart.contains(tezTaskID1));
-    Assert.assertTrue(stats.lastTasksToFinish.contains(tezTaskID2));
-    Assert.assertTrue(stats.shortestDurationTasks.contains(tezTaskID1));
-    Assert.assertTrue(stats.longestDurationTasks.contains(tezTaskID1));
-    Assert.assertEquals(1, stats.firstTasksToStart.size());
-    Assert.assertEquals(1, stats.lastTasksToFinish.size());
-    Assert.assertEquals(1, stats.shortestDurationTasks.size());
-    Assert.assertEquals(1, stats.longestDurationTasks.size());
+    assertEquals(100, stats.firstTaskStartTime);
+    assertEquals(300, stats.lastTaskFinishTime);
+    assertEquals(100, stats.minTaskDuration);
+    assertEquals(100, stats.maxTaskDuration);
+    assertEquals(100, stats.avgTaskDuration);
+    assertTrue(stats.firstTasksToStart.contains(tezTaskID1));
+    assertTrue(stats.lastTasksToFinish.contains(tezTaskID2));
+    assertTrue(stats.shortestDurationTasks.contains(tezTaskID1));
+    assertTrue(stats.longestDurationTasks.contains(tezTaskID1));
+    assertEquals(1, stats.firstTasksToStart.size());
+    assertEquals(1, stats.lastTasksToFinish.size());
+    assertEquals(1, stats.shortestDurationTasks.size());
+    assertEquals(1, stats.longestDurationTasks.size());
 
     stats.updateStats(new TaskReportImpl(tezTaskID3,
         TaskState.RUNNING, 1, 50, 550));
-    Assert.assertEquals(50, stats.firstTaskStartTime);
-    Assert.assertEquals(550, stats.lastTaskFinishTime);
-    Assert.assertEquals(100, stats.minTaskDuration);
-    Assert.assertEquals(100, stats.maxTaskDuration);
-    Assert.assertTrue(100 == stats.avgTaskDuration);
-    Assert.assertTrue(stats.shortestDurationTasks.contains(tezTaskID1));
-    Assert.assertTrue(stats.longestDurationTasks.contains(tezTaskID1));
-    Assert.assertTrue(stats.firstTasksToStart.contains(tezTaskID3));
-    Assert.assertTrue(stats.lastTasksToFinish.contains(tezTaskID3));
-    Assert.assertEquals(1, stats.firstTasksToStart.size());
-    Assert.assertEquals(1, stats.lastTasksToFinish.size());
-    Assert.assertEquals(1, stats.shortestDurationTasks.size());
-    Assert.assertEquals(1, stats.longestDurationTasks.size());
+    assertEquals(50, stats.firstTaskStartTime);
+    assertEquals(550, stats.lastTaskFinishTime);
+    assertEquals(100, stats.minTaskDuration);
+    assertEquals(100, stats.maxTaskDuration);
+    assertEquals(100, stats.avgTaskDuration);
+    assertTrue(stats.shortestDurationTasks.contains(tezTaskID1));
+    assertTrue(stats.longestDurationTasks.contains(tezTaskID1));
+    assertTrue(stats.firstTasksToStart.contains(tezTaskID3));
+    assertTrue(stats.lastTasksToFinish.contains(tezTaskID3));
+    assertEquals(1, stats.firstTasksToStart.size());
+    assertEquals(1, stats.lastTasksToFinish.size());
+    assertEquals(1, stats.shortestDurationTasks.size());
+    assertEquals(1, stats.longestDurationTasks.size());
 
     stats.updateStats(new TaskReportImpl(tezTaskID4,
         TaskState.SUCCEEDED, 1, 50, 450));
-    Assert.assertEquals(50, stats.firstTaskStartTime);
-    Assert.assertEquals(550, stats.lastTaskFinishTime);
-    Assert.assertEquals(100, stats.minTaskDuration);
-    Assert.assertEquals(400, stats.maxTaskDuration);
-    Assert.assertTrue(250 == stats.avgTaskDuration);
-    Assert.assertTrue(stats.firstTasksToStart.contains(tezTaskID4));
-    Assert.assertTrue(stats.firstTasksToStart.contains(tezTaskID3));
-    Assert.assertTrue(stats.lastTasksToFinish.contains(tezTaskID3));
-    Assert.assertTrue(stats.shortestDurationTasks.contains(tezTaskID1));
-    Assert.assertTrue(stats.longestDurationTasks.contains(tezTaskID4));
-    Assert.assertEquals(2, stats.firstTasksToStart.size());
-    Assert.assertEquals(1, stats.lastTasksToFinish.size());
-    Assert.assertEquals(1, stats.shortestDurationTasks.size());
-    Assert.assertEquals(1, stats.longestDurationTasks.size());
+    assertEquals(50, stats.firstTaskStartTime);
+    assertEquals(550, stats.lastTaskFinishTime);
+    assertEquals(100, stats.minTaskDuration);
+    assertEquals(400, stats.maxTaskDuration);
+    assertEquals(250, stats.avgTaskDuration);
+    assertTrue(stats.firstTasksToStart.contains(tezTaskID4));
+    assertTrue(stats.firstTasksToStart.contains(tezTaskID3));
+    assertTrue(stats.lastTasksToFinish.contains(tezTaskID3));
+    assertTrue(stats.shortestDurationTasks.contains(tezTaskID1));
+    assertTrue(stats.longestDurationTasks.contains(tezTaskID4));
+    assertEquals(2, stats.firstTasksToStart.size());
+    assertEquals(1, stats.lastTasksToFinish.size());
+    assertEquals(1, stats.shortestDurationTasks.size());
+    assertEquals(1, stats.longestDurationTasks.size());
 
     stats.updateStats(new TaskReportImpl(tezTaskID5,
         TaskState.SUCCEEDED, 1, 50, 450));
-    Assert.assertEquals(50, stats.firstTaskStartTime);
-    Assert.assertEquals(550, stats.lastTaskFinishTime);
-    Assert.assertEquals(100, stats.minTaskDuration);
-    Assert.assertEquals(400, stats.maxTaskDuration);
-    Assert.assertTrue(300 == stats.avgTaskDuration);
-    Assert.assertTrue(stats.firstTasksToStart.contains(tezTaskID5));
-    Assert.assertTrue(stats.firstTasksToStart.contains(tezTaskID4));
-    Assert.assertTrue(stats.firstTasksToStart.contains(tezTaskID3));
-    Assert.assertTrue(stats.lastTasksToFinish.contains(tezTaskID3));
-    Assert.assertTrue(stats.shortestDurationTasks.contains(tezTaskID1));
-    Assert.assertTrue(stats.longestDurationTasks.contains(tezTaskID4));
-    Assert.assertTrue(stats.longestDurationTasks.contains(tezTaskID5));
-    Assert.assertEquals(3, stats.firstTasksToStart.size());
-    Assert.assertEquals(1, stats.lastTasksToFinish.size());
-    Assert.assertEquals(1, stats.shortestDurationTasks.size());
-    Assert.assertEquals(2, stats.longestDurationTasks.size());
+    assertEquals(50, stats.firstTaskStartTime);
+    assertEquals(550, stats.lastTaskFinishTime);
+    assertEquals(100, stats.minTaskDuration);
+    assertEquals(400, stats.maxTaskDuration);
+    assertEquals(300, stats.avgTaskDuration);
+    assertTrue(stats.firstTasksToStart.contains(tezTaskID5));
+    assertTrue(stats.firstTasksToStart.contains(tezTaskID4));
+    assertTrue(stats.firstTasksToStart.contains(tezTaskID3));
+    assertTrue(stats.lastTasksToFinish.contains(tezTaskID3));
+    assertTrue(stats.shortestDurationTasks.contains(tezTaskID1));
+    assertTrue(stats.longestDurationTasks.contains(tezTaskID4));
+    assertTrue(stats.longestDurationTasks.contains(tezTaskID5));
+    assertEquals(3, stats.firstTasksToStart.size());
+    assertEquals(1, stats.lastTasksToFinish.size());
+    assertEquals(1, stats.shortestDurationTasks.size());
+    assertEquals(2, stats.longestDurationTasks.size());
 
     stats.updateStats(new TaskReportImpl(tezTaskID6,
         TaskState.SUCCEEDED, 1, 450, 550));
-    Assert.assertEquals(50, stats.firstTaskStartTime);
-    Assert.assertEquals(550, stats.lastTaskFinishTime);
-    Assert.assertEquals(100, stats.minTaskDuration);
-    Assert.assertEquals(400, stats.maxTaskDuration);
-    Assert.assertTrue(250 == stats.avgTaskDuration);
-    Assert.assertTrue(stats.firstTasksToStart.contains(tezTaskID5));
-    Assert.assertTrue(stats.firstTasksToStart.contains(tezTaskID4));
-    Assert.assertTrue(stats.firstTasksToStart.contains(tezTaskID3));
-    Assert.assertTrue(stats.lastTasksToFinish.contains(tezTaskID3));
-    Assert.assertTrue(stats.lastTasksToFinish.contains(tezTaskID6));
-    Assert.assertTrue(stats.shortestDurationTasks.contains(tezTaskID1));
-    Assert.assertTrue(stats.shortestDurationTasks.contains(tezTaskID6));
-    Assert.assertTrue(stats.longestDurationTasks.contains(tezTaskID4));
-    Assert.assertTrue(stats.longestDurationTasks.contains(tezTaskID5));
-    Assert.assertEquals(3, stats.firstTasksToStart.size());
-    Assert.assertEquals(2, stats.lastTasksToFinish.size());
-    Assert.assertEquals(2, stats.shortestDurationTasks.size());
-    Assert.assertEquals(2, stats.longestDurationTasks.size());
+    assertEquals(50, stats.firstTaskStartTime);
+    assertEquals(550, stats.lastTaskFinishTime);
+    assertEquals(100, stats.minTaskDuration);
+    assertEquals(400, stats.maxTaskDuration);
+    assertEquals(250, stats.avgTaskDuration);
+    assertTrue(stats.firstTasksToStart.contains(tezTaskID5));
+    assertTrue(stats.firstTasksToStart.contains(tezTaskID4));
+    assertTrue(stats.firstTasksToStart.contains(tezTaskID3));
+    assertTrue(stats.lastTasksToFinish.contains(tezTaskID3));
+    assertTrue(stats.lastTasksToFinish.contains(tezTaskID6));
+    assertTrue(stats.shortestDurationTasks.contains(tezTaskID1));
+    assertTrue(stats.shortestDurationTasks.contains(tezTaskID6));
+    assertTrue(stats.longestDurationTasks.contains(tezTaskID4));
+    assertTrue(stats.longestDurationTasks.contains(tezTaskID5));
+    assertEquals(3, stats.firstTasksToStart.size());
+    assertEquals(2, stats.lastTasksToFinish.size());
+    assertEquals(2, stats.shortestDurationTasks.size());
+    assertEquals(2, stats.longestDurationTasks.size());
   }
 
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/dag/speculation/legacy/TestDataStatistics.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/dag/speculation/legacy/TestDataStatistics.java
@@ -18,56 +18,64 @@
  */
 package org.apache.tez.dag.app.dag.speculation.legacy;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestDataStatistics {
 
   private static final double TOL = 0.001;
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEmptyDataStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics();
-    Assert.assertEquals(0, statistics.count(), TOL);
-    Assert.assertEquals(Long.MAX_VALUE, statistics.mean(), TOL);
-    Assert.assertEquals(0, statistics.var(), TOL);
-    Assert.assertEquals(0, statistics.std(), TOL);
-    Assert.assertEquals(Long.MAX_VALUE, statistics.outlier(1.0f), TOL);
+    assertEquals(0, statistics.count(), TOL);
+    assertEquals(Long.MAX_VALUE, statistics.mean(), TOL);
+    assertEquals(0, statistics.var(), TOL);
+    assertEquals(0, statistics.std(), TOL);
+    assertEquals(Long.MAX_VALUE, statistics.outlier(1.0f), TOL);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSingleEntryDataStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics(17.29);
-    Assert.assertEquals(1, statistics.count(), TOL);
-    Assert.assertEquals(17.29, statistics.mean(), TOL);
-    Assert.assertEquals(0, statistics.var(), TOL);
-    Assert.assertEquals(0, statistics.std(), TOL);
-    Assert.assertEquals(17.29, statistics.outlier(1.0f), TOL);
+    assertEquals(1, statistics.count(), TOL);
+    assertEquals(17.29, statistics.mean(), TOL);
+    assertEquals(0, statistics.var(), TOL);
+    assertEquals(0, statistics.std(), TOL);
+    assertEquals(17.29, statistics.outlier(1.0f), TOL);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMutiEntryDataStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics();
     statistics.add(17);
     statistics.add(29);
-    Assert.assertEquals(2, statistics.count(), TOL);
-    Assert.assertEquals(23.0, statistics.mean(), TOL);
-    Assert.assertEquals(36.0, statistics.var(), TOL);
-    Assert.assertEquals(6.0, statistics.std(), TOL);
-    Assert.assertEquals(29.0, statistics.outlier(1.0f), TOL);
+    assertEquals(2, statistics.count(), TOL);
+    assertEquals(23.0, statistics.mean(), TOL);
+    assertEquals(36.0, statistics.var(), TOL);
+    assertEquals(6.0, statistics.std(), TOL);
+    assertEquals(29.0, statistics.outlier(1.0f), TOL);
  }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testUpdateStatistics() throws Exception {
     DataStatistics statistics = new DataStatistics(17);
     statistics.add(29);
-    Assert.assertEquals(2, statistics.count(), TOL);
-    Assert.assertEquals(23.0, statistics.mean(), TOL);
-    Assert.assertEquals(36.0, statistics.var(), TOL);
+    assertEquals(2, statistics.count(), TOL);
+    assertEquals(23.0, statistics.mean(), TOL);
+    assertEquals(36.0, statistics.var(), TOL);
 
     statistics.updateStatistics(17, 29);
-    Assert.assertEquals(2, statistics.count(), TOL);
-    Assert.assertEquals(29.0, statistics.mean(), TOL);
-    Assert.assertEquals(0.0, statistics.var(), TOL);
+    assertEquals(2, statistics.count(), TOL);
+    assertEquals(29.0, statistics.mean(), TOL);
+    assertEquals(0.0, statistics.var(), TOL);
   }
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/launcher/TestContainerLauncherManager.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/launcher/TestContainerLauncherManager.java
@@ -18,11 +18,11 @@
  */
 package org.apache.tez.dag.app.launcher;
 
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -40,6 +40,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -75,9 +76,10 @@ import org.apache.tez.serviceplugins.api.ServicePluginErrorDefaults;
 import org.apache.tez.serviceplugins.api.ServicePluginException;
 import org.apache.tez.serviceplugins.api.TaskCommunicatorDescriptor;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 public class TestContainerLauncherManager {
@@ -85,13 +87,14 @@ public class TestContainerLauncherManager {
   private static final String DAG_NAME = "dagName";
   private static final int DAG_INDEX = 1;
 
-  @Before
-  @After
+  @BeforeEach
+  @AfterEach
   public void resetTest() {
     ContainerLaucherRouterForMultipleLauncherTest.reset();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNoLaunchersSpecified() throws IOException, TezException {
 
     AppContext appContext = mock(AppContext.class);
@@ -107,7 +110,8 @@ public class TestContainerLauncherManager {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCustomLauncherSpecified() throws IOException, TezException {
     Configuration conf = new Configuration(false);
 
@@ -141,7 +145,8 @@ public class TestContainerLauncherManager {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleContainerLaunchers() throws IOException, TezException {
     Configuration conf = new Configuration(false);
     conf.set("testkey", "testvalue");
@@ -185,7 +190,8 @@ public class TestContainerLauncherManager {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEventRouting() throws Exception {
     Configuration conf = new Configuration(false);
     UserPayload userPayload = TezUtils.createUserPayloadFromConf(conf);
@@ -292,7 +298,8 @@ public class TestContainerLauncherManager {
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testReportFailureFromContainerLauncher() throws ServicePluginException, TezException {
     TezDAGID dagId = TezDAGID.getInstance(ApplicationId.newInstance(0, 0), DAG_INDEX);
     DAG dag = mock(DAG.class);
@@ -325,7 +332,7 @@ public class TestContainerLauncherManager {
       verify(eventHandler, times(1)).handle(argumentCaptor.capture());
 
       Event rawEvent = argumentCaptor.getValue();
-      assertTrue(rawEvent instanceof DAGAppMasterEventUserServiceFatalError);
+      assertInstanceOf(DAGAppMasterEventUserServiceFatalError.class, rawEvent);
       DAGAppMasterEventUserServiceFatalError event =
           (DAGAppMasterEventUserServiceFatalError) rawEvent;
       assertEquals(DAGAppMasterEventType.CONTAINER_LAUNCHER_SERVICE_FATAL_ERROR, event.getType());
@@ -347,7 +354,7 @@ public class TestContainerLauncherManager {
       containerLauncherManager.handle(stopRequestEvent);
       verify(eventHandler, times(1)).handle(argumentCaptor.capture());
       rawEvent = argumentCaptor.getValue();
-      assertTrue(rawEvent instanceof DAGEventTerminateDag);
+      assertInstanceOf(DAGEventTerminateDag.class, rawEvent);
       DAGEventTerminateDag killEvent = (DAGEventTerminateDag) rawEvent;
       assertTrue(killEvent.getDiagnosticInfo().contains("ReportError"));
       assertTrue(killEvent.getDiagnosticInfo()
@@ -359,7 +366,8 @@ public class TestContainerLauncherManager {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerLauncherUserError() throws ServicePluginException {
 
     ContainerLauncher containerLauncher = mock(ContainerLauncher.class);
@@ -393,7 +401,7 @@ public class TestContainerLauncherManager {
       verify(eventHandler, times(1)).handle(argumentCaptor.capture());
 
       Event rawEvent = argumentCaptor.getValue();
-      assertTrue(rawEvent instanceof DAGAppMasterEventUserServiceFatalError);
+      assertInstanceOf(DAGAppMasterEventUserServiceFatalError.class, rawEvent);
       DAGAppMasterEventUserServiceFatalError event =
           (DAGAppMasterEventUserServiceFatalError) rawEvent;
       assertEquals(DAGAppMasterEventType.CONTAINER_LAUNCHER_SERVICE_FATAL_ERROR, event.getType());
@@ -416,7 +424,7 @@ public class TestContainerLauncherManager {
       containerLauncherManager.handle(stopRequestEvent);
       verify(eventHandler, times(1)).handle(argumentCaptor.capture());
       rawEvent = argumentCaptor.getValue();
-      assertTrue(rawEvent instanceof DAGAppMasterEventUserServiceFatalError);
+      assertInstanceOf(DAGAppMasterEventUserServiceFatalError.class, rawEvent);
       event = (DAGAppMasterEventUserServiceFatalError) rawEvent;
       assertTrue(event.getError().getMessage().contains("teststopexception"));
       assertTrue(event.getDiagnosticInfo().contains("stopping container"));
@@ -474,7 +482,7 @@ public class TestContainerLauncherManager {
                                               boolean isPureLocalMode) throws TezException {
       numContainerLaunchers.incrementAndGet();
       boolean added = containerLauncherIndices.add(containerLauncherIndex);
-      assertTrue("Cannot add multiple launchers with the same index", added);
+      assertTrue(added, "Cannot add multiple launchers with the same index");
       containerLauncherNames.add(containerLauncherDescriptor.getEntityName());
       containerLauncherContexts.add(containerLauncherContext);
       return super

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/launcher/TestContainerLauncherWrapper.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/launcher/TestContainerLauncherWrapper.java
@@ -18,16 +18,20 @@
  */
 package org.apache.tez.dag.app.launcher;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.tez.dag.app.PluginWrapperTestHelpers;
 import org.apache.tez.serviceplugins.api.ContainerLauncher;
 
 import com.google.common.collect.Sets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestContainerLauncherWrapper {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDelegation() throws Exception {
     PluginWrapperTestHelpers.testDelegation(ContainerLauncherWrapper.class, ContainerLauncher.class,
         Sets.newHashSet("getContainerLauncher", "dagComplete", "vertexComplete", "taskAttemptFailed"));

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/launcher/TestDeletionTracker.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/launcher/TestDeletionTracker.java
@@ -18,14 +18,16 @@
  */
 package org.apache.tez.dag.app.launcher;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.tez.common.security.JobTokenSecretManager;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.records.TezDAGID;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 public class TestDeletionTracker {
 
@@ -33,42 +35,43 @@ public class TestDeletionTracker {
   public void testNodeIdShufflePortMap() throws Exception {
     DeletionTrackerImpl deletionTracker = new DeletionTrackerImpl(new Configuration());
     // test NodeId
-    NodeId nodeId = new NodeId() {
-      @Override
-      public String getHost() {
-        return "testHost";
-      }
+    NodeId nodeId =
+        new NodeId() {
+          @Override
+          public String getHost() {
+            return "testHost";
+          }
 
-      @Override
-      protected void setHost(String s) {
+          @Override
+          protected void setHost(String s) {}
 
-      }
+          @Override
+          public int getPort() {
+            return 1234;
+          }
 
-      @Override
-      public int getPort() {
-        return 1234;
-      }
+          @Override
+          protected void setPort(int i) {}
 
-      @Override
-      protected void setPort(int i) {
-
-      }
-
-      @Override
-      protected void build() {
-
-      }
-    };
+          @Override
+          protected void build() {}
+        };
     // test shuffle port for the nodeId
     int shufflePort = 9999;
     deletionTracker.addNodeShufflePort(nodeId, shufflePort);
-    Assert.assertEquals("Unexpected number of entries in NodeIdShufflePortMap!",
-        1, deletionTracker.getNodeIdShufflePortMap().size());
+    assertEquals(
+        1,
+        deletionTracker.getNodeIdShufflePortMap().size(),
+        "Unexpected number of entries in NodeIdShufflePortMap!");
     deletionTracker.addNodeShufflePort(nodeId, shufflePort);
-    Assert.assertEquals("Unexpected number of entries in NodeIdShufflePortMap!",
-        1, deletionTracker.getNodeIdShufflePortMap().size());
+    assertEquals(
+        1,
+        deletionTracker.getNodeIdShufflePortMap().size(),
+        "Unexpected number of entries in NodeIdShufflePortMap!");
     deletionTracker.dagComplete(new TezDAGID(), new JobTokenSecretManager(new TezConfiguration()));
-    Assert.assertEquals("Unexpected number of entries in NodeIdShufflePortMap after dagComplete!",
-        1, deletionTracker.getNodeIdShufflePortMap().size());
+    assertEquals(
+        1,
+        deletionTracker.getNodeIdShufflePortMap().size(),
+        "Unexpected number of entries in NodeIdShufflePortMap after dagComplete!");
   }
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/launcher/TestDeletionTracker.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/launcher/TestDeletionTracker.java
@@ -35,43 +35,39 @@ public class TestDeletionTracker {
   public void testNodeIdShufflePortMap() throws Exception {
     DeletionTrackerImpl deletionTracker = new DeletionTrackerImpl(new Configuration());
     // test NodeId
-    NodeId nodeId =
-        new NodeId() {
-          @Override
-          public String getHost() {
-            return "testHost";
-          }
+    NodeId nodeId = new NodeId() {
+      @Override
+      public String getHost() {
+        return "testHost";
+      }
 
-          @Override
-          protected void setHost(String s) {}
+      @Override
+      protected void setHost(String s) {
+      }
 
-          @Override
-          public int getPort() {
-            return 1234;
-          }
+      @Override
+      public int getPort() {
+        return 1234;
+      }
 
-          @Override
-          protected void setPort(int i) {}
+      @Override
+      protected void setPort(int i) {
+      }
 
-          @Override
-          protected void build() {}
-        };
+      @Override
+      protected void build() {
+      }
+    };
     // test shuffle port for the nodeId
     int shufflePort = 9999;
     deletionTracker.addNodeShufflePort(nodeId, shufflePort);
-    assertEquals(
-        1,
-        deletionTracker.getNodeIdShufflePortMap().size(),
+    assertEquals(1, deletionTracker.getNodeIdShufflePortMap().size(),
         "Unexpected number of entries in NodeIdShufflePortMap!");
     deletionTracker.addNodeShufflePort(nodeId, shufflePort);
-    assertEquals(
-        1,
-        deletionTracker.getNodeIdShufflePortMap().size(),
+    assertEquals(1, deletionTracker.getNodeIdShufflePortMap().size(),
         "Unexpected number of entries in NodeIdShufflePortMap!");
     deletionTracker.dagComplete(new TezDAGID(), new JobTokenSecretManager(new TezConfiguration()));
-    assertEquals(
-        1,
-        deletionTracker.getNodeIdShufflePortMap().size(),
+    assertEquals(1, deletionTracker.getNodeIdShufflePortMap().size(),
         "Unexpected number of entries in NodeIdShufflePortMap after dagComplete!");
   }
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/launcher/TestTezLocalCacheManager.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/launcher/TestTezLocalCacheManager.java
@@ -18,6 +18,10 @@
  */
 package org.apache.tez.dag.app.launcher;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -38,8 +42,8 @@ import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.tez.dag.api.TezConfiguration;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * Test local cache manager.
@@ -67,17 +71,17 @@ public class TestTezLocalCacheManager {
     try {
       manager.localize();
 
-      Assert.assertEquals(
+      assertEquals(
           "content-one",
           new String(Files.readAllBytes(Paths.get("./file-one")))
       );
 
-      Assert.assertEquals(
+      assertEquals(
           "content-two",
           new String(Files.readAllBytes(Paths.get("./file-two")))
       );
 
-      Assert.assertEquals(
+      assertEquals(
           "content-two",
           new String(Files.readAllBytes(Paths.get("./file-three")))
       );
@@ -86,9 +90,9 @@ public class TestTezLocalCacheManager {
     }
 
     // verify that symlinks were removed
-    Assert.assertFalse(Files.exists(Paths.get("./file-one")));
-    Assert.assertFalse(Files.exists(Paths.get("./file-two")));
-    Assert.assertFalse(Files.exists(Paths.get("./file-three")));
+    assertFalse(Files.exists(Paths.get("./file-one")));
+    assertFalse(Files.exists(Paths.get("./file-two")));
+    assertFalse(Files.exists(Paths.get("./file-three")));
   }
 
   // create a temporary file with the given content and return a LocalResource
@@ -124,13 +128,13 @@ public class TestTezLocalCacheManager {
     TezLocalCacheManager manager = new TezLocalCacheManager(resources, new Configuration());
 
     try {
-      Assert.assertFalse(Files.exists(Paths.get("./file-one")));
+      assertFalse(Files.exists(Paths.get("./file-one")));
       manager.localize();
-      Assert.assertTrue(Files.exists(Paths.get("./file-one")));
+      assertTrue(Files.exists(Paths.get("./file-one")));
 
     } finally {
       manager.cleanup();
-      Assert.assertFalse(Files.exists(Paths.get("./file-one")));
+      assertFalse(Files.exists(Paths.get("./file-one")));
     }
 
     // configured directory
@@ -140,16 +144,16 @@ public class TestTezLocalCacheManager {
 
     try {
       // files don't exist at all
-      Assert.assertFalse(Files.exists(Paths.get("./file-one")));
-      Assert.assertFalse(Files.exists(Paths.get("./target/file-one")));
+      assertFalse(Files.exists(Paths.get("./file-one")));
+      assertFalse(Files.exists(Paths.get("./target/file-one")));
       manager.localize();
       // file appears only at configured location
-      Assert.assertFalse(Files.exists(Paths.get("./file-one")));
-      Assert.assertTrue(Files.exists(Paths.get("./target/file-one")));
+      assertFalse(Files.exists(Paths.get("./file-one")));
+      assertTrue(Files.exists(Paths.get("./target/file-one")));
 
     } finally {
       manager.cleanup();
-      Assert.assertFalse(Files.exists(Paths.get("./target/file-one")));
+      assertFalse(Files.exists(Paths.get("./target/file-one")));
     }
   }
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/launcher/TestTezLocalCacheManager.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/launcher/TestTezLocalCacheManager.java
@@ -71,20 +71,11 @@ public class TestTezLocalCacheManager {
     try {
       manager.localize();
 
-      assertEquals(
-          "content-one",
-          new String(Files.readAllBytes(Paths.get("./file-one")))
-      );
+      assertEquals("content-one", new String(Files.readAllBytes(Paths.get("./file-one"))));
 
-      assertEquals(
-          "content-two",
-          new String(Files.readAllBytes(Paths.get("./file-two")))
-      );
+      assertEquals("content-two", new String(Files.readAllBytes(Paths.get("./file-two"))));
 
-      assertEquals(
-          "content-two",
-          new String(Files.readAllBytes(Paths.get("./file-three")))
-      );
+      assertEquals("content-two", new String(Files.readAllBytes(Paths.get("./file-three"))));
     } finally {
       manager.cleanup();
     }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestContainerReuse.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestContainerReuse.java
@@ -18,9 +18,9 @@
  */
 package org.apache.tez.dag.app.rm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.conf.Configuration;
@@ -96,8 +97,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -107,12 +109,13 @@ import org.slf4j.LoggerFactory;
 public class TestContainerReuse {
   private static final Logger LOG = LoggerFactory.getLogger(TestContainerReuse.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     MockDNSToSwitchMapping.initializeMockRackResolver();
   }
 
-  @Test(timeout = 15000l)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 15000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testDelayedReuseContainerBecomesAvailable()
       throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testDelayedReuseContainerBecomesAvailable");
@@ -244,12 +247,13 @@ public class TestContainerReuse {
         exception = e;
       }
     }
-    assertTrue("containerHost2 was not released", exception == null);
+    assertNull(exception, "containerHost2 was not released");
     taskScheduler.shutdown();
     taskSchedulerManager.close();
   }
 
-  @Test(timeout = 15000l)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 15000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testDelayedReuseContainerNotAvailable()
       throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testDelayedReuseContainerNotAvailable");
@@ -354,7 +358,8 @@ public class TestContainerReuse {
     taskSchedulerManager.close();
   }
 
-  @Test(timeout = 10000l)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testSimpleReuse() throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testSimpleReuse");
     Configuration tezConf = new Configuration();
@@ -504,7 +509,8 @@ public class TestContainerReuse {
     dag.onFinish();
   }
 
-  @Test(timeout = 10000l)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testReuseWithTaskSpecificLaunchCmdOption() throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testReuseWithTaskSpecificLaunchCmdOption");
     Configuration tezConf = new Configuration();
@@ -695,7 +701,8 @@ public class TestContainerReuse {
     taskSchedulerManager.close();
   }
 
-  @Test(timeout = 30000l)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 30000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testReuseNonLocalRequest()
       throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testReuseNonLocalRequest");
@@ -818,7 +825,8 @@ public class TestContainerReuse {
     taskSchedulerManager.close();
   }
 
-  @Test(timeout = 30000l)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 30000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testReuseAcrossVertices()
       throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testReuseAcrossVertices");
@@ -941,7 +949,8 @@ public class TestContainerReuse {
     taskSchedulerManager.close();
   }
 
-  @Test(timeout = 30000l)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 30000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testReuseLocalResourcesChanged() throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testReuseLocalResourcesChanged");
     Configuration tezConf = new Configuration();
@@ -1100,7 +1109,8 @@ public class TestContainerReuse {
     taskSchedulerManager.close();
   }
 
-  @Test(timeout = 30000l)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 30000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testReuseConflictLocalResources() throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testReuseLocalResourcesChanged");
     Configuration tezConf = new Configuration();
@@ -1338,7 +1348,8 @@ public class TestContainerReuse {
     taskSchedulerManager.close();
   }
 
-  @Test(timeout = 10000l)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testAssignmentOnShutdown()
       throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testAssignmentOnShutdown");
@@ -1409,7 +1420,8 @@ public class TestContainerReuse {
     taskSchedulerManager.close();
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDifferentResourceContainerReuse() throws Exception {
     Configuration tezConf = new Configuration();
     tezConf.setBoolean(TezConfiguration.TEZ_AM_CONTAINER_REUSE_ENABLED, true);
@@ -1547,7 +1559,8 @@ public class TestContainerReuse {
     taskSchedulerManager.close();
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEnvironmentVarsContainerReuse() throws Exception {
     Configuration tezConf = new Configuration();
     tezConf.setBoolean(TezConfiguration.TEZ_AM_CONTAINER_REUSE_ENABLED, true);

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestContainerReuse.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestContainerReuse.java
@@ -115,7 +115,7 @@ public class TestContainerReuse {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 15000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 15000, unit = TimeUnit.MILLISECONDS)
   public void testDelayedReuseContainerBecomesAvailable()
       throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testDelayedReuseContainerBecomesAvailable");
@@ -253,7 +253,7 @@ public class TestContainerReuse {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 15000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 15000, unit = TimeUnit.MILLISECONDS)
   public void testDelayedReuseContainerNotAvailable()
       throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testDelayedReuseContainerNotAvailable");
@@ -359,7 +359,7 @@ public class TestContainerReuse {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleReuse() throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testSimpleReuse");
     Configuration tezConf = new Configuration();
@@ -510,7 +510,7 @@ public class TestContainerReuse {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testReuseWithTaskSpecificLaunchCmdOption() throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testReuseWithTaskSpecificLaunchCmdOption");
     Configuration tezConf = new Configuration();
@@ -702,7 +702,7 @@ public class TestContainerReuse {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 30000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testReuseNonLocalRequest()
       throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testReuseNonLocalRequest");
@@ -826,7 +826,7 @@ public class TestContainerReuse {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 30000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testReuseAcrossVertices()
       throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testReuseAcrossVertices");
@@ -950,7 +950,7 @@ public class TestContainerReuse {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 30000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testReuseLocalResourcesChanged() throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testReuseLocalResourcesChanged");
     Configuration tezConf = new Configuration();
@@ -1110,7 +1110,7 @@ public class TestContainerReuse {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 30000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testReuseConflictLocalResources() throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testReuseLocalResourcesChanged");
     Configuration tezConf = new Configuration();
@@ -1349,7 +1349,7 @@ public class TestContainerReuse {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testAssignmentOnShutdown()
       throws IOException, InterruptedException, ExecutionException {
     LOG.info("Test testAssignmentOnShutdown");

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestDagAwareYarnTaskScheduler.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestDagAwareYarnTaskScheduler.java
@@ -1264,7 +1264,7 @@ public class TestDagAwareYarnTaskScheduler {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 50000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testPreemptionWhenBlocked() throws Exception {
     AMRMClientAsyncWrapperForTest mockRMClient = spy(new AMRMClientAsyncWrapperForTest());
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestDagAwareYarnTaskScheduler.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestDagAwareYarnTaskScheduler.java
@@ -20,9 +20,9 @@ package org.apache.tez.dag.app.rm;
 
 import static org.apache.tez.dag.app.rm.TestTaskSchedulerHelpers.createCountingExecutingService;
 import static org.apache.tez.dag.app.rm.TestTaskSchedulerHelpers.setupMockTaskSchedulerContext;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.protocolrecords.RegisterApplicationMasterResponse;
@@ -85,22 +86,23 @@ import org.apache.tez.test.ControlledScheduledExecutorService;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 
 public class TestDagAwareYarnTaskScheduler {
   private ExecutorService contextCallbackExecutor;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
 
     MockDNSToSwitchMapping.initializeMockRackResolver();
   }
 
-  @Before
+  @BeforeEach
   public void preTest() {
     contextCallbackExecutor = Executors.newSingleThreadExecutor(
         new ThreadFactoryBuilder().setNameFormat("TaskSchedulerAppCallbackExecutor #%d")
@@ -108,7 +110,7 @@ public class TestDagAwareYarnTaskScheduler {
             .build());
   }
 
-  @After
+  @AfterEach
   public void postTest() {
     contextCallbackExecutor.shutdownNow();
   }
@@ -122,7 +124,8 @@ public class TestDagAwareYarnTaskScheduler {
   }
 
   @SuppressWarnings({ "unchecked" })
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testNoReuse() throws Exception {
     AMRMClientAsyncWrapperForTest mockRMClient = spy(new AMRMClientAsyncWrapperForTest());
 
@@ -398,7 +401,8 @@ public class TestDagAwareYarnTaskScheduler {
     verify(mockRMClient).stop();
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleReuseLocalMatching() throws Exception {
     AMRMClientAsyncWrapperForTest mockRMClient = spy(new AMRMClientAsyncWrapperForTest());
 
@@ -503,7 +507,8 @@ public class TestDagAwareYarnTaskScheduler {
     verify(mockRMClient).stop();
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleReuseRackMatching() throws Exception {
     AMRMClientAsyncWrapperForTest mockRMClient = spy(new AMRMClientAsyncWrapperForTest());
 
@@ -610,7 +615,8 @@ public class TestDagAwareYarnTaskScheduler {
     verify(mockRMClient).stop();
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleReuseAnyMatching() throws Exception {
     AMRMClientAsyncWrapperForTest mockRMClient = spy(new AMRMClientAsyncWrapperForTest());
 
@@ -726,7 +732,8 @@ public class TestDagAwareYarnTaskScheduler {
     verify(mockRMClient).stop();
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testReuseWithAffinity() throws Exception {
     AMRMClientAsyncWrapperForTest mockRMClient = spy(new AMRMClientAsyncWrapperForTest());
 
@@ -814,7 +821,8 @@ public class TestDagAwareYarnTaskScheduler {
     verify(mockRMClient).stop();
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testReuseVertexDescendants() throws Exception {
     AMRMClientAsyncWrapperForTest mockRMClient = spy(new AMRMClientAsyncWrapperForTest());
 
@@ -940,7 +948,8 @@ public class TestDagAwareYarnTaskScheduler {
     verify(mockRMClient).stop();
   }
 
-  @Test(timeout=30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testSessionContainers() throws Exception {
     AMRMClientAsyncWrapperForTest mockRMClient = spy(new AMRMClientAsyncWrapperForTest());
 
@@ -1110,7 +1119,8 @@ public class TestDagAwareYarnTaskScheduler {
     verify(mockRMClient).stop();
   }
 
-  @Test(timeout=50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testPreemptionNoHeadroom() throws Exception {
     AMRMClientAsyncWrapperForTest mockRMClient = spy(new AMRMClientAsyncWrapperForTest());
 
@@ -1253,7 +1263,8 @@ public class TestDagAwareYarnTaskScheduler {
     verify(mockRMClient).stop();
   }
 
-  @Test (timeout = 50000L)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 50000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testPreemptionWhenBlocked() throws Exception {
     AMRMClientAsyncWrapperForTest mockRMClient = spy(new AMRMClientAsyncWrapperForTest());
 
@@ -1362,7 +1373,8 @@ public class TestDagAwareYarnTaskScheduler {
     verify(mockRMClient).stop();
   }
 
-  @Test(timeout=50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testContainerAssignmentReleaseNewContainers() throws Exception {
     AMRMClientAsyncWrapperForTest mockRMClient = spy(new AMRMClientAsyncWrapperForTest());
 
@@ -1432,7 +1444,8 @@ public class TestDagAwareYarnTaskScheduler {
     verify(mockRMClient).releaseAssignedContainer(eq(cid1));
   }
 
-  @Test(timeout=50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testIdleContainerAssignmentReuseNewContainers() throws Exception {
     AMRMClientAsyncWrapperForTest mockRMClient = spy(new AMRMClientAsyncWrapperForTest());
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestLocalTaskScheduler.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestLocalTaskScheduler.java
@@ -54,8 +54,8 @@ public class TestLocalTaskScheduler {
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId, 1);
 
     TaskSchedulerContext mockContext =
-        TestTaskSchedulerHelpers.setupMockTaskSchedulerContext(
-            "", 0, "", true, appAttemptId, 1000L, null, new Configuration());
+        TestTaskSchedulerHelpers.setupMockTaskSchedulerContext("", 0, "", true, appAttemptId, 1000L, null,
+            new Configuration());
 
     LocalContainerFactory containerFactory = new LocalContainerFactory(appAttemptId, 1000);
 
@@ -64,8 +64,7 @@ public class TestLocalTaskScheduler {
 
     // Object under test
     AsyncDelegateRequestHandler requestHandler =
-        new AsyncDelegateRequestHandler(
-            clientRequestQueue, containerFactory, taskAllocations, mockContext, tezConf);
+        new AsyncDelegateRequestHandler(clientRequestQueue, containerFactory, taskAllocations, mockContext, tezConf);
 
     // Allocate up to max tasks
     for (int i = 0; i < MAX_TASKS; i++) {

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestLocalTaskScheduler.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestLocalTaskScheduler.java
@@ -18,9 +18,13 @@
  */
 package org.apache.tez.dag.app.rm;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -33,13 +37,13 @@ import org.apache.tez.dag.app.rm.LocalTaskSchedulerService.LocalContainerFactory
 import org.apache.tez.dag.app.rm.LocalTaskSchedulerService.SchedulerRequest;
 import org.apache.tez.serviceplugins.api.TaskSchedulerContext;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestLocalTaskScheduler {
 
-
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void maxTasksAllocationsCannotBeExceeded() {
 
     final int MAX_TASKS = 4;
@@ -49,9 +53,9 @@ public class TestLocalTaskScheduler {
     ApplicationId appId = ApplicationId.newInstance(2000, 1);
     ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(appId, 1);
 
-    TaskSchedulerContext
-        mockContext = TestTaskSchedulerHelpers.setupMockTaskSchedulerContext("", 0, "", true,
-        appAttemptId, 1000L, null, new Configuration());
+    TaskSchedulerContext mockContext =
+        TestTaskSchedulerHelpers.setupMockTaskSchedulerContext(
+            "", 0, "", true, appAttemptId, 1000L, null, new Configuration());
 
     LocalContainerFactory containerFactory = new LocalContainerFactory(appAttemptId, 1000);
 
@@ -60,11 +64,8 @@ public class TestLocalTaskScheduler {
 
     // Object under test
     AsyncDelegateRequestHandler requestHandler =
-      new AsyncDelegateRequestHandler(clientRequestQueue,
-          containerFactory,
-          taskAllocations,
-          mockContext,
-          tezConf);
+        new AsyncDelegateRequestHandler(
+            clientRequestQueue, containerFactory, taskAllocations, mockContext, tezConf);
 
     // Allocate up to max tasks
     for (int i = 0; i < MAX_TASKS; i++) {
@@ -75,8 +76,8 @@ public class TestLocalTaskScheduler {
     }
 
     // Only MAX_TASKS number of tasks should have been allocated
-    Assert.assertEquals("Wrong number of allocate tasks", MAX_TASKS, taskAllocations.size());
-    Assert.assertTrue("Another allocation should not fit", !requestHandler.shouldProcess());
+    assertEquals(MAX_TASKS, taskAllocations.size(), "Wrong number of allocate tasks");
+    assertFalse(requestHandler.shouldProcess(), "Another allocation should not fit");
 
     // Deallocate down to zero
     for (int i = 0; i < MAX_TASKS; i++) {
@@ -85,6 +86,6 @@ public class TestLocalTaskScheduler {
     }
 
     // All allocated tasks should have been removed
-    Assert.assertEquals("Wrong number of allocate tasks", 0, taskAllocations.size());
+    assertEquals(0, taskAllocations.size(), "Wrong number of allocate tasks");
   }
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestLocalTaskSchedulerService.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestLocalTaskSchedulerService.java
@@ -44,7 +44,6 @@ import org.apache.tez.serviceplugins.api.TaskSchedulerContext;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 public class TestLocalTaskSchedulerService {
@@ -169,8 +168,7 @@ public class TestLocalTaskSchedulerService {
     Long grandchildTask1 = new Long(4);
 
     TaskSchedulerContext mockContext =
-        TestTaskSchedulerHelpers.setupMockTaskSchedulerContext(
-            "", 0, "", true, appAttemptId, 1000l, null, tezConf);
+        TestTaskSchedulerHelpers.setupMockTaskSchedulerContext("", 0, "", true, appAttemptId, 1000l, null, tezConf);
     when(mockContext.getVertexIndexForTask(parentTask1)).thenReturn(0);
     when(mockContext.getVertexIndexForTask(parentTask2)).thenReturn(0);
     when(mockContext.getVertexIndexForTask(childTask1)).thenReturn(1);
@@ -195,19 +193,14 @@ public class TestLocalTaskSchedulerService {
     Priority priority4 = Priority.newInstance(4);
     Resource resource = Resource.newInstance(1024, 1);
 
-    MockLocalTaskSchedulerSerivce taskSchedulerService =
-        new MockLocalTaskSchedulerSerivce(mockContext);
+    MockLocalTaskSchedulerSerivce taskSchedulerService = new MockLocalTaskSchedulerSerivce(mockContext);
 
     // The mock context need to send a deallocate container request to the scheduler service
-    Answer<Void> answer =
-        new Answer<Void>() {
-          @Override
-          public Void answer(InvocationOnMock invocation) {
-            ContainerId containerId = invocation.getArgument(0, ContainerId.class);
-            taskSchedulerService.deallocateContainer(containerId);
-            return null;
-          }
-        };
+    Answer<Void> answer = invocation -> {
+      ContainerId containerId = invocation.getArgument(0, ContainerId.class);
+      taskSchedulerService.deallocateContainer(containerId);
+      return null;
+    };
     doAnswer(answer).when(mockContext).preemptContainer(any());
 
     taskSchedulerService.initialize();

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestLocalTaskSchedulerService.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestLocalTaskSchedulerService.java
@@ -18,12 +18,17 @@
  */
 package org.apache.tez.dag.app.rm;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -37,8 +42,8 @@ import org.apache.tez.dag.app.rm.TestLocalTaskSchedulerService.MockLocalTaskSche
 import org.apache.tez.serviceplugins.api.DagInfo;
 import org.apache.tez.serviceplugins.api.TaskSchedulerContext;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -47,28 +52,31 @@ public class TestLocalTaskSchedulerService {
   LocalTaskSchedulerService ltss ;
   int core =10;
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCreateResource() {
     Resource resource;
     //value in integer
     long value = 4*1024*1024;
     resource = ltss.createResource(value,core);
-    Assert.assertEquals((int)(value/(1024*1024)),resource.getMemory());
+    assertEquals((int)(value/(1024*1024)),resource.getMemory());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCreateResourceLargerThanIntMax() {
     //value beyond integer but within Long.MAX_VALUE
     try {
       ltss.createResource(Long.MAX_VALUE, core);
       fail("No exception thrown.");
     } catch (Exception ex) {
-      assertTrue(ex instanceof IllegalArgumentException);
+      assertInstanceOf(IllegalArgumentException.class, ex);
       assertTrue(ex.getMessage().contains("Out of range:"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCreateResourceWithNegativeValue() {
     //value is Long.MAX_VALUE*1024*1024,
     // it will be negative after it is passed to createResource
@@ -77,7 +85,7 @@ public class TestLocalTaskSchedulerService {
       ltss.createResource((Long.MAX_VALUE*1024*1024), core);
       fail("No exception thrown.");
     } catch (Exception ex) {
-      assertTrue(ex instanceof IllegalArgumentException);
+      assertInstanceOf(IllegalArgumentException.class, ex);
       assertTrue(ex.getMessage().contains("Negative Memory or Core provided!"));
     }
   }
@@ -85,7 +93,8 @@ public class TestLocalTaskSchedulerService {
   /**
    * Normal flow of TaskAttempt
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDeallocationBeforeAllocation() throws InterruptedException {
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(ApplicationId.newInstance(10000l, 1), 1);
@@ -117,7 +126,8 @@ public class TestLocalTaskSchedulerService {
   /**
    * TaskAttempt Killed from START_WAIT
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDeallocationAfterAllocation() throws InterruptedException {
     ApplicationAttemptId appAttemptId =
         ApplicationAttemptId.newInstance(ApplicationId.newInstance(10000l, 1), 1);
@@ -158,9 +168,9 @@ public class TestLocalTaskSchedulerService {
     Long childTask1 = new Long(3);
     Long grandchildTask1 = new Long(4);
 
-    TaskSchedulerContext
-        mockContext = TestTaskSchedulerHelpers.setupMockTaskSchedulerContext("", 0, "", true,
-        appAttemptId, 1000l, null, tezConf);
+    TaskSchedulerContext mockContext =
+        TestTaskSchedulerHelpers.setupMockTaskSchedulerContext(
+            "", 0, "", true, appAttemptId, 1000l, null, tezConf);
     when(mockContext.getVertexIndexForTask(parentTask1)).thenReturn(0);
     when(mockContext.getVertexIndexForTask(parentTask2)).thenReturn(0);
     when(mockContext.getVertexIndexForTask(childTask1)).thenReturn(1);
@@ -185,17 +195,19 @@ public class TestLocalTaskSchedulerService {
     Priority priority4 = Priority.newInstance(4);
     Resource resource = Resource.newInstance(1024, 1);
 
-    MockLocalTaskSchedulerSerivce taskSchedulerService = new MockLocalTaskSchedulerSerivce(mockContext);
+    MockLocalTaskSchedulerSerivce taskSchedulerService =
+        new MockLocalTaskSchedulerSerivce(mockContext);
 
     // The mock context need to send a deallocate container request to the scheduler service
-    Answer<Void> answer = new Answer<Void>() {
-      @Override
-      public Void answer(InvocationOnMock invocation) {
-        ContainerId containerId = invocation.getArgument(0, ContainerId.class);
-        taskSchedulerService.deallocateContainer(containerId);
-        return null;
-      }
-    };
+    Answer<Void> answer =
+        new Answer<Void>() {
+          @Override
+          public Void answer(InvocationOnMock invocation) {
+            ContainerId containerId = invocation.getArgument(0, ContainerId.class);
+            taskSchedulerService.deallocateContainer(containerId);
+            return null;
+          }
+        };
     doAnswer(answer).when(mockContext).preemptContainer(any());
 
     taskSchedulerService.initialize();
@@ -209,15 +221,16 @@ public class TestLocalTaskSchedulerService {
     requestHandler.drainRequest(3);
 
     // We should not preempt if we have not reached max task allocations
-    Assert.assertEquals("Wrong number of allocate tasks", MAX_TASKS, requestHandler.allocateCount);
-    Assert.assertTrue("Another allocation should not fit", !requestHandler.shouldProcess());
+    assertEquals(MAX_TASKS, requestHandler.allocateCount, "Wrong number of allocate tasks");
+    assertFalse(requestHandler.shouldProcess(), "Another allocation should not fit");
 
     // Next task allocation should preempt
-    taskSchedulerService.allocateTask(parentTask2, Resource.newInstance(1024, 1), null, null, priority2, null, null);
+    taskSchedulerService.allocateTask(
+        parentTask2, Resource.newInstance(1024, 1), null, null, priority2, null, null);
     requestHandler.drainRequest(5);
 
     // All allocated tasks should have been removed
-    Assert.assertEquals("Wrong number of preempted tasks", 1, requestHandler.preemptCount);
+    assertEquals(1, requestHandler.preemptCount, "Wrong number of preempted tasks");
   }
 
   static class MockLocalTaskSchedulerSerivce extends LocalTaskSchedulerService {

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskScheduler.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskScheduler.java
@@ -20,9 +20,11 @@ package org.apache.tez.dag.app.rm;
 
 import static org.apache.tez.dag.app.rm.TestTaskSchedulerHelpers.createCountingExecutingService;
 import static org.apache.tez.dag.app.rm.TestTaskSchedulerHelpers.setupMockTaskSchedulerContext;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
@@ -43,6 +45,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.conf.Configuration;
@@ -77,11 +80,11 @@ import org.apache.tez.serviceplugins.api.TaskSchedulerContext.AppFinalStatus;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -96,12 +99,12 @@ public class TestTaskScheduler {
   private static final String SUCCEED_APP_MESSAGE = "success";
   private static final int DEFAULT_APP_PORT = 0;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     MockDNSToSwitchMapping.initializeMockRackResolver();
   }
 
-  @Before
+  @BeforeEach
   public void preTest() {
     contextCallbackExecutor = Executors.newSingleThreadExecutor(
         new ThreadFactoryBuilder().setNameFormat("TaskSchedulerAppCallbackExecutor #%d")
@@ -109,7 +112,7 @@ public class TestTaskScheduler {
             .build());
   }
 
-  @After
+  @AfterEach
   public void postTest() {
     contextCallbackExecutor.shutdownNow();
   }
@@ -123,7 +126,8 @@ public class TestTaskScheduler {
   }
 
   @SuppressWarnings({ "unchecked" })
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerNoReuse() throws Exception {
     AMRMClientAsyncForTest mockRMClient = spy(
         new AMRMClientAsyncForTest(new AMRMClientForTest(), 100));
@@ -155,7 +159,7 @@ public class TestTaskScheduler {
                                                    regResponse.getClientToAMTokenMasterKey(),
                                                    regResponse.getQueue());
 
-    Assert.assertEquals(scheduler.getClusterNodeCount(), mockRMClient.getClusterNodeCount());
+    assertEquals(scheduler.getClusterNodeCount(), mockRMClient.getClusterNodeCount());
 
     Object mockTask1 = new MockTask("task1");
     Object mockCookie1 = new Object();
@@ -250,7 +254,7 @@ public class TestTaskScheduler {
     verify(mockApp).containerBeingReleased(mockCId1);
     verify(mockRMClient).releaseAssignedContainer(mockCId1);
     // deallocate allocated container
-    Assert.assertEquals(mockTask2, scheduler.deallocateContainer(mockCId2));
+    assertEquals(mockTask2, scheduler.deallocateContainer(mockCId2));
     drainableAppCallback.drain();
     verify(mockRMClient).releaseAssignedContainer(mockCId2);
     verify(mockRMClient, times(3)).releaseAssignedContainer((ContainerId) any());
@@ -328,7 +332,7 @@ public class TestTaskScheduler {
 
     float progress = 0.5f;
     when(mockApp.getProgress()).thenReturn(progress);
-    Assert.assertEquals(progress, scheduler.getProgress(), 0);
+    assertEquals(progress, scheduler.getProgress(), 0);
 
     // check duplicate allocation request
     scheduler.allocateTask(mockTask1, mockCapability, hosts, racks,
@@ -396,7 +400,8 @@ public class TestTaskScheduler {
     verify(mockRMClient).stop();
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerInitiateStop() throws Exception {
 
     Configuration conf = new Configuration();
@@ -484,24 +489,25 @@ public class TestTaskScheduler {
     TestTaskSchedulerHelpers.waitForDelayedDrainNotify(drainNotifier);
     drainableAppCallback.drain();
 
-    Assert.assertEquals(2, scheduler.heldContainers.size());
-    Assert.assertEquals(1, scheduler.taskRequests.size());
+    assertEquals(2, scheduler.heldContainers.size());
+    assertEquals(1, scheduler.taskRequests.size());
     // 2 containers are allocated and their corresponding taskRequests are removed.
     verify(mockRMClient).removeContainerRequest(request1);
     verify(mockRMClient).removeContainerRequest(request2);
 
     scheduler.initiateStop();
     // verify all the containers are released
-    Assert.assertEquals(0, scheduler.heldContainers.size());
+    assertEquals(0, scheduler.heldContainers.size());
     verify(mockRMClient).releaseAssignedContainer(mockCId1);
     verify(mockRMClient).releaseAssignedContainer(mockCId2);
     // verify taskRequests are removed
-    Assert.assertEquals(0, scheduler.taskRequests.size());
+    assertEquals(0, scheduler.taskRequests.size());
     verify(mockRMClient).removeContainerRequest(request3);
   }
 
   @SuppressWarnings({ "unchecked" })
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerWithReuse() throws Exception {
     TezAMRMClientAsync<CookieContainerRequest> mockRMClient = spy(
         new AMRMClientAsyncForTest(new AMRMClientForTest(), 100));
@@ -605,7 +611,7 @@ public class TestTaskScheduler {
     verify(mockApp).containerBeingReleased(mockCId1);
     verify(mockRMClient).releaseAssignedContainer(mockCId1);
     // deallocate allocated container
-    Assert.assertEquals(mockTask2, scheduler.deallocateContainer(mockCId2));
+    assertEquals(mockTask2, scheduler.deallocateContainer(mockCId2));
     drainableAppCallback.drain();
     verify(mockRMClient).releaseAssignedContainer(mockCId2);
     verify(mockRMClient, times(3)).releaseAssignedContainer((ContainerId) any());
@@ -731,7 +737,7 @@ public class TestTaskScheduler {
 
     float progress = 0.5f;
     when(mockApp.getProgress()).thenReturn(progress);
-    Assert.assertEquals(progress, scheduler.getProgress(), 0);
+    assertEquals(progress, scheduler.getProgress(), 0);
 
     List<NodeReport> mockUpdatedNodes = mock(List.class);
     scheduler.onNodesUpdated(mockUpdatedNodes);
@@ -762,7 +768,8 @@ public class TestTaskScheduler {
     verify(mockRMClient).stop();
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerDetermineMinHeldContainers() throws Exception {
     TezAMRMClientAsync<CookieContainerRequest> mockRMClient = spy(
         new AMRMClientAsyncForTest(new AMRMClientForTest(), 100));
@@ -843,17 +850,17 @@ public class TestTaskScheduler {
     // test empty case
     scheduler.sessionNumMinHeldContainers = 0;
     scheduler.determineMinHeldContainers();
-    Assert.assertEquals(0, scheduler.sessionMinHeldContainers.size());
+    assertEquals(0, scheduler.sessionMinHeldContainers.size());
 
     // test min >= held
     scheduler.sessionNumMinHeldContainers = 7;
     scheduler.determineMinHeldContainers();
-    Assert.assertEquals(7, scheduler.sessionMinHeldContainers.size());
+    assertEquals(7, scheduler.sessionMinHeldContainers.size());
 
     // test min < held
     scheduler.sessionNumMinHeldContainers = 5;
     scheduler.determineMinHeldContainers();
-    Assert.assertEquals(5, scheduler.sessionMinHeldContainers.size());
+    assertEquals(5, scheduler.sessionMinHeldContainers.size());
 
     Set<HeldContainer> heldContainers = Sets.newHashSet();
     for (ContainerId cId : scheduler.sessionMinHeldContainers) {
@@ -869,12 +876,12 @@ public class TestTaskScheduler {
     // covers not enough containers in rack (rack 3)
     // covers just enough containers in rack (rack 2)
     // covers more than enough containers in rack (rack 1)
-    Assert.assertEquals(5, nodes.size());
-    Assert.assertTrue(nodes.contains(node1Rack1) && nodes.contains(node2Rack1) &&
+    assertEquals(5, nodes.size());
+    assertTrue(nodes.contains(node1Rack1) && nodes.contains(node2Rack1) &&
         nodes.contains(node1Rack2) && nodes.contains(node2Rack2) &&
         nodes.contains(node1Rack3));
-    Assert.assertEquals(3, racks.size());
-    Assert.assertTrue(racks.contains(rack1) && racks.contains(rack2) &&
+    assertEquals(3, racks.size());
+    assertTrue(racks.contains(rack1) && racks.contains(rack2) &&
         racks.contains(rack3));
 
     long currTime = System.currentTimeMillis();
@@ -888,7 +895,7 @@ public class TestTaskScheduler {
     drainableAppCallback.drain();
     // only the 2 container not in min-held containers are released
     verify(mockRMClient, times(2)).releaseAssignedContainer((ContainerId)any());
-    Assert.assertEquals(5, scheduler.heldContainers.size());
+    assertEquals(5, scheduler.heldContainers.size());
 
     AppFinalStatus finalStatus =
         new AppFinalStatus(FinalApplicationStatus.SUCCEEDED, SUCCEED_APP_MESSAGE, DEFAULT_APP_URL);
@@ -896,7 +903,8 @@ public class TestTaskScheduler {
     scheduler.shutdown();
   }
 
-  @Test (timeout=3000)
+  @Test
+  @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerHeldContainersReleaseAfterExpired() throws Exception {
     final TezAMRMClientAsync<CookieContainerRequest> mockRMClient = spy(
       new AMRMClientAsyncForTest(new AMRMClientForTest(), 100));
@@ -926,7 +934,7 @@ public class TestTaskScheduler {
     Thread.sleep(1000);
 
     verify(mockRMClient, times(1)).releaseAssignedContainer((ContainerId)any());
-    Assert.assertEquals(0, scheduler.heldContainers.size());
+    assertEquals(0, scheduler.heldContainers.size());
 
     AppFinalStatus finalStatus =
       new AppFinalStatus(FinalApplicationStatus.SUCCEEDED, SUCCEED_APP_MESSAGE, DEFAULT_APP_URL);
@@ -934,7 +942,8 @@ public class TestTaskScheduler {
     scheduler.shutdown();
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerRandomReuseExpireTime() throws Exception {
     TezAMRMClientAsync<CookieContainerRequest> mockRMClient = spy(
         new AMRMClientAsyncForTest(new AMRMClientForTest(), 100));
@@ -968,17 +977,15 @@ public class TestTaskScheduler {
 
     // when min == max the expire time is always min
     for (int i=0; i<10; ++i) {
-      Assert.assertEquals(minTime, scheduler1.getHeldContainerExpireTime(0));
+      assertEquals(minTime, scheduler1.getHeldContainerExpireTime(0));
     }
 
     long lastExpireTime = 0;
     // when min < max the expire time is random in between min and max
     for (int i=0; i<10; ++i) {
       long currExpireTime = scheduler2.getHeldContainerExpireTime(0);
-      Assert.assertTrue(
-          "min: " + minTime + " curr: " + currExpireTime + " max: " + maxTime,
-          (minTime <= currExpireTime && currExpireTime <= maxTime));
-      Assert.assertNotEquals(lastExpireTime, currExpireTime);
+      assertTrue((minTime <= currExpireTime && currExpireTime <= maxTime), "min: " + minTime + " curr: " + currExpireTime + " max: " + maxTime);
+      assertNotEquals(lastExpireTime, currExpireTime);
       lastExpireTime = currExpireTime;
     }
 
@@ -990,7 +997,8 @@ public class TestTaskScheduler {
     scheduler2.shutdown();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerPreemptionWithLowAndHighPriorityRequests() throws Exception {
     TezAMRMClientAsync<CookieContainerRequest> mockRMClient = spy(
             new AMRMClientAsyncForTest(new AMRMClientForTest(), 100));
@@ -1092,7 +1100,8 @@ public class TestTaskScheduler {
   }
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerPreemption() throws Exception {
     TezAMRMClientAsync<CookieContainerRequest> mockRMClient =
                                                   mock(TezAMRMClientAsync.class);
@@ -1123,7 +1132,7 @@ public class TestTaskScheduler {
     // no preemption
     scheduler.getProgress();
     drainableAppCallback.drain();
-    Assert.assertEquals(totalResource, scheduler.getTotalResources());
+    assertEquals(totalResource, scheduler.getTotalResources());
     verify(mockRMClient, times(0)).releaseAssignedContainer((ContainerId)any());
 
     // allocate task
@@ -1180,7 +1189,7 @@ public class TestTaskScheduler {
     when(mockRMClient.getAvailableResources()).thenReturn(freeResource);
     scheduler.getProgress();
     drainableAppCallback.drain();
-    Assert.assertEquals(totalResource, scheduler.getTotalResources());
+    assertEquals(totalResource, scheduler.getTotalResources());
     verify(mockRMClient, times(0)).releaseAssignedContainer((ContainerId)any());
 
     final List<ArrayList<CookieContainerRequest>> anyList =
@@ -1255,17 +1264,17 @@ public class TestTaskScheduler {
 
     scheduler.onContainersAllocated(containers);
     drainableAppCallback.drain();
-    Assert.assertEquals(4, scheduler.taskAllocations.size());
-    Assert.assertEquals(4096, scheduler.allocatedResources.getMemory());
-    Assert.assertEquals(mockCId1,
+    assertEquals(4, scheduler.taskAllocations.size());
+    assertEquals(4096, scheduler.allocatedResources.getMemory());
+    assertEquals(mockCId1,
         scheduler.taskAllocations.get(mockTask1).getId());
-    Assert.assertEquals(mockCId2,
+    assertEquals(mockCId2,
         scheduler.taskAllocations.get(mockTask3).getId());
-    Assert.assertEquals(mockCId3,
+    assertEquals(mockCId3,
         scheduler.taskAllocations.get(mockTask3KillA).getId());
     // high priority container assigned to lower pri task. This task should still be preempted
     // because the task priority is relevant for preemption and not the container priority
-    Assert.assertEquals(mockCId4,
+    assertEquals(mockCId4,
         scheduler.taskAllocations.get(mockTask3KillB).getId());
 
     // no preemption
@@ -1273,7 +1282,7 @@ public class TestTaskScheduler {
     drainableAppCallback.drain();
     verify(mockRMClient, times(0)).releaseAssignedContainer((ContainerId)any());
     // no need for task preemption until now - so they should match
-    Assert.assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
+    assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
 
     // add a pending request that cannot be allocated until resources free up
     Object mockTask3WaitCookie = new Object();
@@ -1304,7 +1313,7 @@ public class TestTaskScheduler {
     drainableAppCallback.drain();
     verify(mockRMClient, times(0)).releaseAssignedContainer((ContainerId)any());
     // no need for task preemption until now - so they should match
-    Assert.assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
+    assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
 
     heldContainer.incrementAssignmentAttempts();
     // no preemption - container assignment attempts < 3
@@ -1321,15 +1330,15 @@ public class TestTaskScheduler {
     // internally re-request pri8 task request because we release pri8 new container
     verify(mockRMClient, times(7)).addContainerRequest(requestCaptor.capture());
     CookieContainerRequest reAdded = requestCaptor.getValue();
-    Assert.assertEquals(pri8, reAdded.getPriority());
-    Assert.assertEquals(taskAsk, reAdded.getCapability());
-    Assert.assertEquals(mockTaskPri8Cookie, reAdded.getCookie().getAppCookie());
+    assertEquals(pri8, reAdded.getPriority());
+    assertEquals(taskAsk, reAdded.getCapability());
+    assertEquals(mockTaskPri8Cookie, reAdded.getCookie().getAppCookie());
 
     // remove fudging.
     scheduler.delayedContainerManager.delayedContainers.clear();
 
     // no need for task preemption until now - so they should match
-    Assert.assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
+    assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
 
     scheduler.allocateTask(mockTask3Retry, taskAsk, null,
                            null, pri5, obj3, null);
@@ -1338,7 +1347,7 @@ public class TestTaskScheduler {
     // no need for task preemption until now - so they should match
     drainableAppCallback.drain();
     // no need for task preemption until now - so they should match
-    Assert.assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
+    assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
     verify(mockRMClient, times(1)).releaseAssignedContainer((ContainerId)any());
 
     for (int i=0; i<11; ++i) {
@@ -1352,7 +1361,7 @@ public class TestTaskScheduler {
     // lower priority task. Task priority is relevant for preemption and not container priority as
     // containers can run tasks of different priorities
     scheduler.getProgress(); // first heartbeat
-    Assert.assertTrue(scheduler.numHeartbeats > scheduler.heartbeatAtLastPreemption);
+    assertTrue(scheduler.numHeartbeats > scheduler.heartbeatAtLastPreemption);
     drainableAppCallback.drain();
     scheduler.getProgress(); // second heartbeat
     drainableAppCallback.drain();
@@ -1361,7 +1370,7 @@ public class TestTaskScheduler {
     drainableAppCallback.drain();
     verify(mockRMClient, times(2)).releaseAssignedContainer((ContainerId)any());
     verify(mockRMClient, times(1)).releaseAssignedContainer(mockCId4);
-    Assert.assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
+    assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
     // there are pending preemptions.
     scheduler.getProgress(); // first heartbeat
     scheduler.getProgress(); // second heartbeat
@@ -1379,7 +1388,8 @@ public class TestTaskScheduler {
     drainableAppCallback.drain();
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerPreemption2() throws Exception {
     TezAMRMClientAsync<CookieContainerRequest> mockRMClient = spy(
         new AMRMClientAsyncForTest(new AMRMClientForTest(), 100));
@@ -1405,7 +1415,7 @@ public class TestTaskScheduler {
     scheduler.getProgress();
     drainableAppCallback.drain();
     Resource totalResource = mockRMClient.getAvailableResources();
-    Assert.assertEquals(totalResource, scheduler.getTotalResources());
+    assertEquals(totalResource, scheduler.getTotalResources());
     verify(mockRMClient, times(0)).releaseAssignedContainer((ContainerId)any());
 
     // allocate task
@@ -1433,7 +1443,7 @@ public class TestTaskScheduler {
 
     scheduler.getProgress();
     drainableAppCallback.drain();
-    Assert.assertEquals(totalResource, scheduler.getTotalResources());
+    assertEquals(totalResource, scheduler.getTotalResources());
     verify(mockRMClient, times(0)).releaseAssignedContainer((ContainerId)any());
 
     NodeId host1 = NodeId.newInstance("host1", 1);
@@ -1454,8 +1464,8 @@ public class TestTaskScheduler {
 
     scheduler.onContainersAllocated(containers);
     drainableAppCallback.drain();
-    Assert.assertEquals(1, scheduler.taskAllocations.size());
-    Assert.assertEquals(mockCId1,
+    assertEquals(1, scheduler.taskAllocations.size());
+    assertEquals(mockCId1,
         scheduler.taskAllocations.get(mockTask1).getId());
 
     // no preemption
@@ -1463,7 +1473,7 @@ public class TestTaskScheduler {
     drainableAppCallback.drain();
     verify(mockRMClient, times(0)).releaseAssignedContainer((ContainerId)any());
     // no need for task preemption until now - so they should match
-    Assert.assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
+    assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
 
     // add a pending request that cannot be allocated until resources free up
     Object mockTask2Cookie = new Object();
@@ -1473,17 +1483,17 @@ public class TestTaskScheduler {
     scheduler.allocateTask(mockTask3, taskAsk, null,
                            null, pri6, obj3, mockTask3Cookie);
     // nothing waiting till now
-    Assert.assertNull(scheduler.highestWaitingRequestPriority);
-    Assert.assertEquals(0, scheduler.highestWaitingRequestWaitStartTime);
+    assertNull(scheduler.highestWaitingRequestPriority);
+    assertEquals(0, scheduler.highestWaitingRequestWaitStartTime);
 
     long currTime = System.currentTimeMillis();
     scheduler.getProgress();
     drainableAppCallback.drain();
     verify(mockRMClient, times(0)).releaseAssignedContainer((ContainerId)any());
     // enough free resources. preemption not triggered
-    Assert.assertEquals(pri2, scheduler.highestWaitingRequestPriority);
-    Assert.assertTrue(scheduler.highestWaitingRequestWaitStartTime >= currTime);
-    Assert.assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
+    assertEquals(pri2, scheduler.highestWaitingRequestPriority);
+    assertTrue(scheduler.highestWaitingRequestWaitStartTime >= currTime);
+    assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
 
     Thread.sleep(waitTime + 10);
     long oldStartWaitTime = scheduler.highestWaitingRequestWaitStartTime;
@@ -1492,39 +1502,39 @@ public class TestTaskScheduler {
     drainableAppCallback.drain();
     verify(mockRMClient, times(0)).releaseAssignedContainer((ContainerId)any());
     // enough free resources. deadline crossed. preemption triggered
-    Assert.assertEquals(pri2, scheduler.highestWaitingRequestPriority);
-    Assert.assertEquals(oldStartWaitTime, scheduler.highestWaitingRequestWaitStartTime);
-    Assert.assertTrue(scheduler.numHeartbeats > scheduler.heartbeatAtLastPreemption);
+    assertEquals(pri2, scheduler.highestWaitingRequestPriority);
+    assertEquals(oldStartWaitTime, scheduler.highestWaitingRequestWaitStartTime);
+    assertTrue(scheduler.numHeartbeats > scheduler.heartbeatAtLastPreemption);
 
     scheduler.getProgress();
     drainableAppCallback.drain();
     verify(mockRMClient, times(1)).releaseAssignedContainer((ContainerId)any());
     verify(mockRMClient, times(1)).releaseAssignedContainer(mockCId1);
-    Assert.assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
+    assertEquals(scheduler.numHeartbeats, scheduler.heartbeatAtLastPreemption);
     // maintains existing waiting values
-    Assert.assertEquals(pri2, scheduler.highestWaitingRequestPriority);
-    Assert.assertEquals(oldStartWaitTime, scheduler.highestWaitingRequestWaitStartTime);
+    assertEquals(pri2, scheduler.highestWaitingRequestPriority);
+    assertEquals(oldStartWaitTime, scheduler.highestWaitingRequestWaitStartTime);
 
     // remove high pri request to test waiting pri change
     scheduler.deallocateTask(mockTask2, false, null, null);
 
     scheduler.getProgress();
     // waiting value changes
-    Assert.assertEquals(pri6, scheduler.highestWaitingRequestPriority);
-    Assert.assertTrue(oldStartWaitTime < scheduler.highestWaitingRequestWaitStartTime);
+    assertEquals(pri6, scheduler.highestWaitingRequestPriority);
+    assertTrue(oldStartWaitTime < scheduler.highestWaitingRequestWaitStartTime);
 
     Thread.sleep(waitTime + 10);
     scheduler.getProgress();
     drainableAppCallback.drain();
     // deadlines crossed but nothing lower pri running. so reset
-    Assert.assertNull(scheduler.highestWaitingRequestPriority);
-    Assert.assertEquals(0, scheduler.highestWaitingRequestWaitStartTime);
+    assertNull(scheduler.highestWaitingRequestPriority);
+    assertEquals(0, scheduler.highestWaitingRequestWaitStartTime);
 
     scheduler.getProgress();
     drainableAppCallback.drain();
     // waiting value changes
-    Assert.assertEquals(pri6, scheduler.highestWaitingRequestPriority);
-    Assert.assertTrue(oldStartWaitTime < scheduler.highestWaitingRequestWaitStartTime);
+    assertEquals(pri6, scheduler.highestWaitingRequestPriority);
+    assertTrue(oldStartWaitTime < scheduler.highestWaitingRequestWaitStartTime);
 
     AppFinalStatus finalStatus =
         new AppFinalStatus(FinalApplicationStatus.SUCCEEDED, "", DEFAULT_APP_URL);
@@ -1533,15 +1543,17 @@ public class TestTaskScheduler {
     drainableAppCallback.drain();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLocalityMatching() throws Exception {
-    TezAMRMClientAsync<CookieContainerRequest> amrmClient = spy(
-        new AMRMClientAsyncForTest(new AMRMClientForTest(), 100));
+    TezAMRMClientAsync<CookieContainerRequest> amrmClient =
+        spy(new AMRMClientAsyncForTest(new AMRMClientForTest(), 100));
 
     Configuration conf = new Configuration();
     conf.setBoolean(TezConfiguration.TEZ_AM_CONTAINER_REUSE_ENABLED, false);
 
-    TaskSchedulerContext appClient = setupMockTaskSchedulerContext(DEFAULT_APP_HOST, DEFAULT_APP_PORT, "", conf);
+    TaskSchedulerContext appClient =
+        setupMockTaskSchedulerContext(DEFAULT_APP_HOST, DEFAULT_APP_PORT, "", conf);
     final TaskSchedulerContextDrainable drainableAppCallback = createDrainableContext(appClient);
 
     TaskSchedulerWithDrainableContext taskScheduler =
@@ -1553,20 +1565,18 @@ public class TestTaskScheduler {
     Resource resource = Resource.newInstance(1024, 1);
     Priority priority = Priority.newInstance(1);
 
-    String hostsTask1[] = { "host1" };
-    String hostsTask2[] = { "non-allocated-host" };
+    String hostsTask1[] = {"host1"};
+    String hostsTask2[] = {"non-allocated-host"};
 
-    String defaultRack[] = { "/default-rack" };
-    String otherRack[] = { "/other-rack" };
+    String defaultRack[] = {"/default-rack"};
+    String otherRack[] = {"/other-rack"};
 
     Object mockTask1 = new MockTask("task1");
-    CookieContainerRequest mockCookie1 = mock(CookieContainerRequest.class,
-        RETURNS_DEEP_STUBS);
+    CookieContainerRequest mockCookie1 = mock(CookieContainerRequest.class, RETURNS_DEEP_STUBS);
     when(mockCookie1.getCookie().getTask()).thenReturn(mockTask1);
 
     Object mockTask2 = new MockTask("task2");
-    CookieContainerRequest mockCookie2 = mock(CookieContainerRequest.class,
-        RETURNS_DEEP_STUBS);
+    CookieContainerRequest mockCookie2 = mock(CookieContainerRequest.class, RETURNS_DEEP_STUBS);
     when(mockCookie2.getCookie().getTask()).thenReturn(mockTask2);
 
     Container containerHost1 = createContainer(1, "host1", resource, priority);
@@ -1576,8 +1586,8 @@ public class TestTaskScheduler {
     allocatedContainers.add(containerHost3);
     allocatedContainers.add(containerHost1);
 
-    taskScheduler.allocateTask(mockTask1, resource, hostsTask1, defaultRack,
-        priority, null, mockCookie1);
+    taskScheduler.allocateTask(
+        mockTask1, resource, hostsTask1, defaultRack, priority, null, mockCookie1);
     drainableAppCallback.drain();
 
     List<CookieContainerRequest> host1List = new ArrayList<CookieContainerRequest>();
@@ -1585,15 +1595,15 @@ public class TestTaskScheduler {
     List<CookieContainerRequest> defaultRackList = new ArrayList<CookieContainerRequest>();
     defaultRackList.add(mockCookie1);
 
-    List<CookieContainerRequest> nonAllocatedHostList = new ArrayList<YarnTaskSchedulerService.CookieContainerRequest>();
+    List<CookieContainerRequest> nonAllocatedHostList = new ArrayList<CookieContainerRequest>();
     nonAllocatedHostList.add(mockCookie2);
-    List<CookieContainerRequest> otherRackList = new ArrayList<YarnTaskSchedulerService.CookieContainerRequest>();
+    List<CookieContainerRequest> otherRackList = new ArrayList<CookieContainerRequest>();
     otherRackList.add(mockCookie2);
-    taskScheduler.allocateTask(mockTask2, resource, hostsTask2, otherRack,
-        priority, null, mockCookie2);
+    taskScheduler.allocateTask(
+        mockTask2, resource, hostsTask2, otherRack, priority, null, mockCookie2);
     drainableAppCallback.drain();
 
-    List<CookieContainerRequest> anyList = new LinkedList<YarnTaskSchedulerService.CookieContainerRequest>();
+    List<CookieContainerRequest> anyList = new LinkedList<CookieContainerRequest>();
     anyList.add(mockCookie1);
     anyList.add(mockCookie2);
 
@@ -1601,45 +1611,46 @@ public class TestTaskScheduler {
     drainableAppCallback.drain();
 
     ArgumentCaptor<Object> taskCaptor = ArgumentCaptor.forClass(Object.class);
-    ArgumentCaptor<Container> containerCaptor = ArgumentCaptor
-        .forClass(Container.class);
-    verify(appClient, times(2)).taskAllocated(taskCaptor.capture(), any(),
-        containerCaptor.capture());
+    ArgumentCaptor<Container> containerCaptor = ArgumentCaptor.forClass(Container.class);
+    verify(appClient, times(2))
+        .taskAllocated(taskCaptor.capture(), any(), containerCaptor.capture());
 
     // Expected containerHost1 allocated to task1 due to locality,
     // containerHost3 allocated to task2.
 
     List<Container> assignedContainers = containerCaptor.getAllValues();
     int container1Pos = assignedContainers.indexOf(containerHost1);
-    assertTrue("Container: " + containerHost1 + " was not assigned",
-        container1Pos != -1);
-    assertEquals("Task 1 was not allocated to containerHost1", mockTask1,
-        taskCaptor.getAllValues().get(container1Pos));
+    assertTrue(container1Pos != -1, "Container: " + containerHost1 + " was not assigned");
+    assertEquals(
+        mockTask1,
+        taskCaptor.getAllValues().get(container1Pos),
+        "Task 1 was not allocated to containerHost1");
 
     int container2Pos = assignedContainers.indexOf(containerHost3);
-    assertTrue("Container: " + containerHost3 + " was not assigned",
-        container2Pos != -1);
-    assertEquals("Task 2 was not allocated to containerHost3", mockTask2,
-        taskCaptor.getAllValues().get(container2Pos));
+    assertTrue(container2Pos != -1, "Container: " + containerHost3 + " was not assigned");
+    assertEquals(
+        mockTask2,
+        taskCaptor.getAllValues().get(container2Pos),
+        "Task 2 was not allocated to containerHost3");
 
-    AppFinalStatus finalStatus = new AppFinalStatus(
-        FinalApplicationStatus.SUCCEEDED, "", "");
+    AppFinalStatus finalStatus = new AppFinalStatus(FinalApplicationStatus.SUCCEEDED, "", "");
     when(appClient.getFinalAppStatus()).thenReturn(finalStatus);
     taskScheduler.shutdown();
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testScaleDownPercentage() {
-    Assert.assertEquals(100, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(100, 100));
-    Assert.assertEquals(70, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(100, 70));
-    Assert.assertEquals(50, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(100, 50));
-    Assert.assertEquals(10, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(100, 10));
-    Assert.assertEquals(5, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(100, 5));
-    Assert.assertEquals(1, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(100, 1));
-    Assert.assertEquals(1, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(5, 5));
-    Assert.assertEquals(1, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(1, 10));
-    Assert.assertEquals(1, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(1, 70));
-    Assert.assertEquals(1, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(1, 1));
+    assertEquals(100, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(100, 100));
+    assertEquals(70, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(100, 70));
+    assertEquals(50, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(100, 50));
+    assertEquals(10, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(100, 10));
+    assertEquals(5, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(100, 5));
+    assertEquals(1, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(100, 1));
+    assertEquals(1, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(5, 5));
+    assertEquals(1, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(1, 10));
+    assertEquals(1, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(1, 70));
+    assertEquals(1, YarnTaskSchedulerService.scaleDownByPreemptionPercentage(1, 1));
   }
 
   @Test

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskScheduler.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskScheduler.java
@@ -984,7 +984,8 @@ public class TestTaskScheduler {
     // when min < max the expire time is random in between min and max
     for (int i=0; i<10; ++i) {
       long currExpireTime = scheduler2.getHeldContainerExpireTime(0);
-      assertTrue((minTime <= currExpireTime && currExpireTime <= maxTime), "min: " + minTime + " curr: " + currExpireTime + " max: " + maxTime);
+      assertTrue((minTime <= currExpireTime && currExpireTime <= maxTime),
+          "min: " + minTime + " curr: " + currExpireTime + " max: " + maxTime);
       assertNotEquals(lastExpireTime, currExpireTime);
       lastExpireTime = currExpireTime;
     }
@@ -1586,8 +1587,7 @@ public class TestTaskScheduler {
     allocatedContainers.add(containerHost3);
     allocatedContainers.add(containerHost1);
 
-    taskScheduler.allocateTask(
-        mockTask1, resource, hostsTask1, defaultRack, priority, null, mockCookie1);
+    taskScheduler.allocateTask(mockTask1, resource, hostsTask1, defaultRack, priority, null, mockCookie1);
     drainableAppCallback.drain();
 
     List<CookieContainerRequest> host1List = new ArrayList<CookieContainerRequest>();
@@ -1599,8 +1599,7 @@ public class TestTaskScheduler {
     nonAllocatedHostList.add(mockCookie2);
     List<CookieContainerRequest> otherRackList = new ArrayList<CookieContainerRequest>();
     otherRackList.add(mockCookie2);
-    taskScheduler.allocateTask(
-        mockTask2, resource, hostsTask2, otherRack, priority, null, mockCookie2);
+    taskScheduler.allocateTask(mockTask2, resource, hostsTask2, otherRack, priority, null, mockCookie2);
     drainableAppCallback.drain();
 
     List<CookieContainerRequest> anyList = new LinkedList<CookieContainerRequest>();
@@ -1612,8 +1611,7 @@ public class TestTaskScheduler {
 
     ArgumentCaptor<Object> taskCaptor = ArgumentCaptor.forClass(Object.class);
     ArgumentCaptor<Container> containerCaptor = ArgumentCaptor.forClass(Container.class);
-    verify(appClient, times(2))
-        .taskAllocated(taskCaptor.capture(), any(), containerCaptor.capture());
+    verify(appClient, times(2)).taskAllocated(taskCaptor.capture(), any(), containerCaptor.capture());
 
     // Expected containerHost1 allocated to task1 due to locality,
     // containerHost3 allocated to task2.
@@ -1621,17 +1619,11 @@ public class TestTaskScheduler {
     List<Container> assignedContainers = containerCaptor.getAllValues();
     int container1Pos = assignedContainers.indexOf(containerHost1);
     assertTrue(container1Pos != -1, "Container: " + containerHost1 + " was not assigned");
-    assertEquals(
-        mockTask1,
-        taskCaptor.getAllValues().get(container1Pos),
-        "Task 1 was not allocated to containerHost1");
+    assertEquals(mockTask1, taskCaptor.getAllValues().get(container1Pos), "Task 1 was not allocated to containerHost1");
 
     int container2Pos = assignedContainers.indexOf(containerHost3);
     assertTrue(container2Pos != -1, "Container: " + containerHost3 + " was not assigned");
-    assertEquals(
-        mockTask2,
-        taskCaptor.getAllValues().get(container2Pos),
-        "Task 2 was not allocated to containerHost3");
+    assertEquals(mockTask2, taskCaptor.getAllValues().get(container2Pos), "Task 2 was not allocated to containerHost3");
 
     AppFinalStatus finalStatus = new AppFinalStatus(FinalApplicationStatus.SUCCEEDED, "", "");
     when(appClient.getFinalAppStatus()).thenReturn(finalStatus);

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskSchedulerHelpers.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskSchedulerHelpers.java
@@ -18,7 +18,8 @@
  */
 package org.apache.tez.dag.app.rm;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -76,6 +77,7 @@ import org.apache.tez.serviceplugins.api.TaskSchedulerContext;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
 
 final class TestTaskSchedulerHelpers {
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskSchedulerHelpers.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskSchedulerHelpers.java
@@ -78,7 +78,6 @@ import org.apache.tez.serviceplugins.api.TaskSchedulerContext;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
-
 final class TestTaskSchedulerHelpers {
 
   private TestTaskSchedulerHelpers() {}

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskSchedulerManager.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskSchedulerManager.java
@@ -18,11 +18,12 @@
  */
 package org.apache.tez.dag.app.rm;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
@@ -44,6 +45,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -124,9 +126,9 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -182,7 +184,7 @@ public class TestTaskSchedulerManager {
   AMContainerMap mockAMContainerMap;
   WebUIService mockWebUIService;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mockAppContext = mock(AppContext.class, RETURNS_DEEP_STUBS);
     doReturn(new Configuration(false)).when(mockAppContext).getAMConf();
@@ -198,7 +200,8 @@ public class TestTaskSchedulerManager {
         mockAppContext, mockClientService, mockEventHandler, mockSigMatcher, mockWebUIService);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleAllocate() throws Exception {
     Configuration conf = new Configuration(false);
     taskSchedulerManager.init(conf);
@@ -230,7 +233,7 @@ public class TestTaskSchedulerManager {
             priority, containerContext, 0, 0, 0);
     taskSchedulerManager.taskAllocated(0, mockTaskAttempt, lr, container);
     assertEquals(1, mockEventHandler.events.size());
-    assertTrue(mockEventHandler.events.get(0) instanceof AMContainerEventAssignTA);
+    assertInstanceOf(AMContainerEventAssignTA.class, mockEventHandler.events.get(0));
     AMContainerEventAssignTA assignEvent =
         (AMContainerEventAssignTA) mockEventHandler.events.get(0);
     assertEquals(priority, assignEvent.getPriority());
@@ -239,7 +242,8 @@ public class TestTaskSchedulerManager {
     verify(mockAppContext.getCurrentDAG()).addUsedContainer(any(Container.class)); // called on taskAllocated
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTASucceededAfterContainerCleanup() throws Exception {
     Configuration conf = new Configuration(false);
     taskSchedulerManager.init(conf);
@@ -272,14 +276,15 @@ public class TestTaskSchedulerManager {
             priority, containerContext, 0, 0, 0);
     taskSchedulerManager.taskAllocated(0, mockTaskAttempt, lr, container);
     assertEquals(1, mockEventHandler.events.size());
-    assertTrue(mockEventHandler.events.get(0) instanceof AMContainerEventAssignTA);
+    assertInstanceOf(AMContainerEventAssignTA.class, mockEventHandler.events.get(0));
     AMContainerEventAssignTA assignEvent =
         (AMContainerEventAssignTA) mockEventHandler.events.get(0);
     assertEquals(priority, assignEvent.getPriority());
     assertEquals(mockAttemptId, assignEvent.getTaskAttemptId());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTAUnsuccessfulAfterContainerCleanup() throws Exception {
     Configuration conf = new Configuration(false);
     taskSchedulerManager.init(conf);
@@ -306,13 +311,14 @@ public class TestTaskSchedulerManager {
         new AMSchedulerEventTAEnded(
             mockTaskAttempt, mockCId, TaskAttemptState.KILLED, null, null, 0));
     assertEquals(1, mockEventHandler.events.size());
-    assertTrue(mockEventHandler.events.get(0) instanceof AMContainerEventStopRequest);
+    assertInstanceOf(AMContainerEventStopRequest.class, mockEventHandler.events.get(0));
     AMContainerEventStopRequest stopEvent =
         (AMContainerEventStopRequest) mockEventHandler.events.get(0);
     assertEquals(mockCId, stopEvent.getContainerId());
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskBasedAffinity() throws Exception {
     Configuration conf = new Configuration(false);
     taskSchedulerManager.init(conf);
@@ -351,7 +357,8 @@ public class TestTaskSchedulerManager {
     taskSchedulerManager.close();
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerPreempted() throws IOException {
     Configuration conf = new Configuration(false);
     taskSchedulerManager.init(conf);
@@ -378,13 +385,14 @@ public class TestTaskSchedulerManager {
     assertTrue(completedEvent.isPreempted());
     assertEquals(TaskAttemptTerminationCause.EXTERNAL_PREEMPTION,
         completedEvent.getTerminationCause());
-    Assert.assertFalse(completedEvent.isDiskFailed());
+    assertFalse(completedEvent.isDiskFailed());
 
     taskSchedulerManager.stop();
     taskSchedulerManager.close();
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerInternalPreempted() throws IOException, ServicePluginException {
     Configuration conf = new Configuration(false);
     taskSchedulerManager.init(conf);
@@ -406,7 +414,7 @@ public class TestTaskSchedulerManager {
     assertEquals(mockCId, completedEvent.getContainerId());
     assertEquals("Container preempted internally", completedEvent.getDiagnostics());
     assertTrue(completedEvent.isPreempted());
-    Assert.assertFalse(completedEvent.isDiskFailed());
+    assertFalse(completedEvent.isDiskFailed());
     assertEquals(TaskAttemptTerminationCause.INTERNAL_PREEMPTION,
         completedEvent.getTerminationCause());
 
@@ -414,7 +422,8 @@ public class TestTaskSchedulerManager {
     taskSchedulerManager.close();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerInternalPreemptedAfterContainerCleanup() throws IOException, ServicePluginException {
     Configuration conf = new Configuration(false);
     taskSchedulerManager.init(conf);
@@ -437,7 +446,7 @@ public class TestTaskSchedulerManager {
     assertEquals(mockCId, completedEvent.getContainerId());
     assertEquals("Container preempted internally", completedEvent.getDiagnostics());
     assertTrue(completedEvent.isPreempted());
-    Assert.assertFalse(completedEvent.isDiskFailed());
+    assertFalse(completedEvent.isDiskFailed());
     assertEquals(TaskAttemptTerminationCause.INTERNAL_PREEMPTION,
         completedEvent.getTerminationCause());
 
@@ -445,7 +454,8 @@ public class TestTaskSchedulerManager {
     taskSchedulerManager.close();
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerDiskFailed() throws IOException {
     Configuration conf = new Configuration(false);
     taskSchedulerManager.init(conf);
@@ -469,7 +479,7 @@ public class TestTaskSchedulerManager {
     assertEquals(mockCId, completedEvent.getContainerId());
     assertEquals("Container disk failed. NM disk failed.",
         completedEvent.getDiagnostics());
-    Assert.assertFalse(completedEvent.isPreempted());
+    assertFalse(completedEvent.isPreempted());
     assertTrue(completedEvent.isDiskFailed());
     assertEquals(TaskAttemptTerminationCause.NODE_DISK_ERROR,
         completedEvent.getTerminationCause());
@@ -478,7 +488,8 @@ public class TestTaskSchedulerManager {
     taskSchedulerManager.close();
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerExceededPMem() throws IOException {
     Configuration conf = new Configuration(false);
     taskSchedulerManager.init(conf);
@@ -504,8 +515,8 @@ public class TestTaskSchedulerManager {
     assertEquals(mockCId, completedEvent.getContainerId());
     assertEquals("Container failed, exitCode=-104. Exceeded Physical Memory",
         completedEvent.getDiagnostics());
-    Assert.assertFalse(completedEvent.isPreempted());
-    Assert.assertFalse(completedEvent.isDiskFailed());
+    assertFalse(completedEvent.isPreempted());
+    assertFalse(completedEvent.isDiskFailed());
     assertEquals(TaskAttemptTerminationCause.CONTAINER_EXITED,
         completedEvent.getTerminationCause());
 
@@ -513,7 +524,8 @@ public class TestTaskSchedulerManager {
     taskSchedulerManager.close();
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testHistoryUrlConf() throws Exception {
     Configuration conf = taskSchedulerManager.appContext.getAMConf();
     final ApplicationId mockApplicationId = mock(ApplicationId.class);
@@ -549,7 +561,8 @@ public class TestTaskSchedulerManager {
 
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testHistoryUrlWithoutScheme() throws Exception {
     Configuration conf = taskSchedulerManager.appContext.getAMConf();
     final ApplicationId mockApplicationId = mock(ApplicationId.class);
@@ -571,7 +584,8 @@ public class TestTaskSchedulerManager {
         taskSchedulerManager.getHistoryUrl());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNoSchedulerSpecified() throws IOException {
     try {
       new TSEHForMultipleSchedulersTest(mockAppContext, mockClientService, mockEventHandler,
@@ -582,7 +596,8 @@ public class TestTaskSchedulerManager {
   }
 
   // Verified via statics
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCustomTaskSchedulerSetup() throws IOException {
     Configuration conf = new Configuration(false);
     conf.set("testkey", "testval");
@@ -625,7 +640,8 @@ public class TestTaskSchedulerManager {
     assertEquals("testval", parsed.get("testkey"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerRouting() throws Exception {
     Configuration conf = new Configuration(false);
     UserPayload defaultPayload = TezUtils.createUserPayloadFromConf(conf);
@@ -695,7 +711,8 @@ public class TestTaskSchedulerManager {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testShutdownBeforeStartTaskScheduler() {
     Configuration conf = new TezConfiguration();
     AppContext appContext = mock(AppContext.class, RETURNS_DEEP_STUBS);
@@ -707,12 +724,12 @@ public class TestTaskSchedulerManager {
     TaskSchedulerManager taskSchedulerManager =
         new TaskSchedulerManager(appContext, null, null,
             null, null, list, false,null);
-    assertFalse("Should not return true unless actually unregistered successfully",
-        taskSchedulerManager.hasUnregistered());
+    assertFalse(taskSchedulerManager.hasUnregistered(), "Should not return true unless actually unregistered successfully");
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testReportFailureFromTaskScheduler() {
     String dagName = DAG_NAME;
     Configuration conf = new TezConfiguration();
@@ -758,7 +775,7 @@ public class TestTaskSchedulerManager {
       verify(eventHandler, times(1)).handle(argumentCaptor.capture());
 
       Event rawEvent = argumentCaptor.getValue();
-      assertTrue(rawEvent instanceof DAGEventTerminateDag);
+      assertInstanceOf(DAGEventTerminateDag.class, rawEvent);
       DAGEventTerminateDag killEvent = (DAGEventTerminateDag) rawEvent;
       assertTrue(killEvent.getDiagnosticInfo().contains("ReportError"));
       assertTrue(killEvent.getDiagnosticInfo()
@@ -773,7 +790,7 @@ public class TestTaskSchedulerManager {
       verify(eventHandler, times(1)).handle(argumentCaptor.capture());
       rawEvent = argumentCaptor.getValue();
 
-      assertTrue(rawEvent instanceof DAGAppMasterEventUserServiceFatalError);
+      assertInstanceOf(DAGAppMasterEventUserServiceFatalError.class, rawEvent);
       DAGAppMasterEventUserServiceFatalError event =
           (DAGAppMasterEventUserServiceFatalError) rawEvent;
       assertEquals(DAGAppMasterEventType.TASK_SCHEDULER_SERVICE_FATAL_ERROR, event.getType());
@@ -788,7 +805,8 @@ public class TestTaskSchedulerManager {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerUserError() {
     TaskScheduler taskScheduler = mock(TaskScheduler.class, new ExceptionAnswer());
 
@@ -831,7 +849,7 @@ public class TestTaskSchedulerManager {
       verify(eventHandler, times(1)).handle(argumentCaptor.capture());
 
       Event rawEvent = argumentCaptor.getValue();
-      assertTrue(rawEvent instanceof DAGAppMasterEventUserServiceFatalError);
+      assertInstanceOf(DAGAppMasterEventUserServiceFatalError.class, rawEvent);
       DAGAppMasterEventUserServiceFatalError event =
           (DAGAppMasterEventUserServiceFatalError) rawEvent;
 
@@ -846,7 +864,7 @@ public class TestTaskSchedulerManager {
       verify(eventHandler, times(2)).handle(argumentCaptor.capture());
 
       rawEvent = argumentCaptor.getAllValues().get(1);
-      assertTrue(rawEvent instanceof DAGAppMasterEventUserServiceFatalError);
+      assertInstanceOf(DAGAppMasterEventUserServiceFatalError.class, rawEvent);
       event = (DAGAppMasterEventUserServiceFatalError) rawEvent;
 
       assertEquals(DAGAppMasterEventType.TASK_SCHEDULER_SERVICE_FATAL_ERROR, event.getType());
@@ -859,7 +877,8 @@ public class TestTaskSchedulerManager {
     }
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testHandleException() throws Exception {
     Configuration tezConf = new Configuration(new YarnConfiguration());
     UserPayload defaultPayload = TezUtils.createUserPayloadFromConf(tezConf);
@@ -871,10 +890,10 @@ public class TestTaskSchedulerManager {
     BiMap<String, Integer> tsMap = HashBiMap.create();
 
     // Only TezYarn found.
-    Assert.assertEquals(1, tsDescriptors.size());
-    Assert.assertEquals(TezConstants.getTezYarnServicePluginName(), tsDescriptors.get(0).getEntityName());
-    Assert.assertEquals(1, pluginManager.getTaskSchedulers().size());
-    Assert.assertTrue(pluginManager.getTaskSchedulers().containsKey(TezConstants.getTezYarnServicePluginName()));
+    assertEquals(1, tsDescriptors.size());
+    assertEquals(TezConstants.getTezYarnServicePluginName(), tsDescriptors.get(0).getEntityName());
+    assertEquals(1, pluginManager.getTaskSchedulers().size());
+    assertTrue(pluginManager.getTaskSchedulers().containsKey(TezConstants.getTezYarnServicePluginName()));
 
     // Construct eventHandler
     TestTaskSchedulerHelpers.CapturingEventHandler eventHandler = new TestTaskSchedulerHelpers.CapturingEventHandler();
@@ -934,7 +953,7 @@ public class TestTaskSchedulerManager {
     tseh.init(conf);
     tseh.start();
 
-    Assert.assertEquals(TSEHForMultipleSchedulersTest.YARN_TASK_SCHEDULER_HELD_CONTAINERS
+    assertEquals(TSEHForMultipleSchedulersTest.YARN_TASK_SCHEDULER_HELD_CONTAINERS
         + TSEHForMultipleSchedulersTest.CUSTOM_TASK_SCHEDULER_HELD_CONTAINERS, tseh.getHeldContainersCount());
     tseh.close();
   }
@@ -990,7 +1009,7 @@ public class TestTaskSchedulerManager {
 
       numCreateInvocations.incrementAndGet();
       boolean added = seenSchedulers.add(schedulerId);
-      assertTrue("Cannot add multiple schedulers with the same schedulerId", added);
+      assertTrue(added, "Cannot add multiple schedulers with the same schedulerId");
       taskSchedulerNames.add(taskSchedulerDescriptor.getEntityName());
       return super.createTaskScheduler(host, port, trackingUrl, appContext, taskSchedulerDescriptor,
           customAppIdIdentifier, schedulerId);
@@ -1241,7 +1260,8 @@ public class TestTaskSchedulerManager {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetNumClusterNodes() throws Exception {
     Configuration conf = new Configuration(false);
     taskSchedulerManager.init(conf);

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskSchedulerWrapper.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTaskSchedulerWrapper.java
@@ -18,16 +18,20 @@
  */
 package org.apache.tez.dag.app.rm;
 
+import java.util.concurrent.TimeUnit;
+
 import org.apache.tez.dag.app.PluginWrapperTestHelpers;
 import org.apache.tez.serviceplugins.api.TaskScheduler;
 
 import com.google.common.collect.Sets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTaskSchedulerWrapper {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDelegation() throws Exception {
     PluginWrapperTestHelpers.testDelegation(TaskSchedulerWrapper.class, TaskScheduler.class,
         Sets.newHashSet("getTaskScheduler"));

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTezAMRMClient.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/TestTezAMRMClient.java
@@ -18,10 +18,14 @@
  */
 package org.apache.tez.dag.app.rm;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.Priority;
@@ -32,36 +36,37 @@ import org.apache.hadoop.yarn.client.api.impl.AMRMClientImpl;
 import org.apache.hadoop.yarn.util.RackResolver;
 import org.apache.tez.common.MockDNSToSwitchMapping;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTezAMRMClient {
 
   private TezAMRMClientAsync amrmClient;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     MockDNSToSwitchMapping.initializeMockRackResolver();
   }
 
   @SuppressWarnings("unchecked")
-  @Before
+  @BeforeEach
   public void setup() {
     amrmClient = new TezAMRMClientAsync(new AMRMClientImpl(),
       1000, mock(AMRMClientAsync.CallbackHandler.class));
     RackResolver.init(new Configuration());
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     amrmClient = null;
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testMatchingRequestsForTopPriority() {
     String[] hosts = { "host1" };
     String[] racks = { "rack1" };
@@ -78,21 +83,21 @@ public class TestTezAMRMClient {
     amrmClient.addContainerRequest(req2);
     amrmClient.addContainerRequest(req3);
 
-    Assert.assertTrue(amrmClient.getMatchingRequestsForTopPriority("host1",
+    assertTrue(amrmClient.getMatchingRequestsForTopPriority("host1",
       Resource.newInstance(1024, 1)).isEmpty());
 
     List<? extends Collection<AMRMClient.ContainerRequest>> ret =
       amrmClient.getMatchingRequestsForTopPriority("host1",
         Resource.newInstance(2048, 1));
-    Assert.assertFalse(ret.isEmpty());
-    Assert.assertEquals(req1, ret.get(0).iterator().next());
+    assertFalse(ret.isEmpty());
+    assertEquals(req1, ret.get(0).iterator().next());
 
     amrmClient.removeContainerRequest(req1);
 
     ret = amrmClient.getMatchingRequestsForTopPriority("host1",
         Resource.newInstance(1024, 1));
-    Assert.assertFalse(ret.isEmpty());
-    Assert.assertEquals(req2, ret.get(0).iterator().next());
+    assertFalse(ret.isEmpty());
+    assertEquals(req2, ret.get(0).iterator().next());
   }
 
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/container/TestAMContainer.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/container/TestAMContainer.java
@@ -1449,9 +1449,7 @@ public class TestAMContainer {
     }
 
     public void verifyState(AMContainerState state) {
-      assertEquals(
-          state,
-          amContainer.getState(),
+      assertEquals(state, amContainer.getState(),
           "Expected state: " + state + ", but found: " + amContainer.getState());
     }
   }
@@ -1497,11 +1495,8 @@ public class TestAMContainer {
         }
       }
     }
-    assertTrue(
-        expectedTypeList.isEmpty(),
-        "Did not find types : " + expectedTypeList + " in outgoing event list");
-    assertTrue(
-        eventsCopy.isEmpty(), "Found unexpected events: " + eventsCopy + " in outgoing event list");
+    assertTrue(expectedTypeList.isEmpty(), "Did not find types : " + expectedTypeList + " in outgoing event list");
+    assertTrue(eventsCopy.isEmpty(), "Found unexpected events: " + eventsCopy + " in outgoing event list");
   }
 
   private Event findEventByType(List<Event> events, Enum<?> type) {

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/container/TestAMContainer.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/container/TestAMContainer.java
@@ -18,11 +18,12 @@
  */
 package org.apache.tez.dag.app.rm.container;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -39,6 +40,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -92,15 +94,16 @@ import org.apache.tez.serviceplugins.api.TaskCommunicator;
 
 import com.google.common.collect.Maps;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 
 public class TestAMContainer {
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Assign before launch.
   public void tetSingleSuccessfulTaskFlow() {
     WrappedContainer wc = new WrappedContainer();
@@ -159,7 +162,8 @@ public class TestAMContainer {
     assertFalse(wc.amContainer.isInErrorState());
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Assign after launch.
   public void testSingleSuccessfulTaskFlow2() {
     WrappedContainer wc = new WrappedContainer();
@@ -211,7 +215,8 @@ public class TestAMContainer {
     assertFalse(wc.amContainer.isInErrorState());
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Assign before launch.
   public void tetMultipleSuccessfulTaskFlow() {
     WrappedContainer wc = new WrappedContainer();
@@ -283,7 +288,8 @@ public class TestAMContainer {
     assertFalse(wc.amContainer.isInErrorState());
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSingleSuccessfulTaskFlowStopRequest() {
     WrappedContainer wc = new WrappedContainer();
 
@@ -320,7 +326,8 @@ public class TestAMContainer {
     assertFalse(wc.amContainer.isInErrorState());
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSingleSuccessfulTaskFlowFailedNMStopRequest() {
     WrappedContainer wc = new WrappedContainer();
 
@@ -343,7 +350,7 @@ public class TestAMContainer {
     wc.verifyState(AMContainerState.STOPPING);
     // Event to ask a RM container release.
     wc.verifyCountAndGetOutgoingEvents(1);
-    assertTrue(wc.verifyCountAndGetOutgoingEvents(1).get(0).getType() ==
+    assertSame(wc.verifyCountAndGetOutgoingEvents(1).get(0).getType(),
         AMSchedulerEventType.S_CONTAINER_DEALLOCATE);
 
     wc.containerCompleted();
@@ -360,7 +367,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleAllocationsWhileActive() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -400,7 +408,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleAllocationsAtLaunching() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -440,7 +449,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerTimedOutAtRunning() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -476,7 +486,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testStopRequestedAtRunning() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -512,7 +523,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLaunchFailure() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -534,7 +546,7 @@ public class TestAMContainer {
         AMNodeEventType.N_CONTAINER_COMPLETED);
     for (Event e : outgoingEvents) {
       if (e.getType() == TaskAttemptEventType.TA_CONTAINER_TERMINATING) {
-        Assert.assertEquals(TaskAttemptTerminationCause.CONTAINER_LAUNCH_FAILED,
+        assertEquals(TaskAttemptTerminationCause.CONTAINER_LAUNCH_FAILED,
             ((TaskAttemptEventContainerTerminating)e).getTerminationCause());
       }
     }
@@ -548,7 +560,8 @@ public class TestAMContainer {
     assertFalse(wc.amContainer.isInErrorState());
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerCompletedAtAllocated() {
     WrappedContainer wc = new WrappedContainer();
     wc.verifyState(AMContainerState.ALLOCATED);
@@ -563,7 +576,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Verify that incoming NM launched events to COMPLETED containers are
   // handled.
   public void testContainerCompletedAtLaunching() {
@@ -584,7 +598,7 @@ public class TestAMContainer {
     verifyUnOrderedOutgoingEventTypes(outgoingEvents,
         TaskAttemptEventType.TA_CONTAINER_TERMINATED,
         AMNodeEventType.N_CONTAINER_COMPLETED);
-    Assert.assertEquals(TaskAttemptTerminationCause.CONTAINER_LAUNCH_FAILED,
+    assertEquals(TaskAttemptTerminationCause.CONTAINER_LAUNCH_FAILED,
         ((TaskAttemptEventContainerTerminated)outgoingEvents.get(0)).getTerminationCause());
 
     assertFalse(wc.amContainer.isInErrorState());
@@ -597,7 +611,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerCompletedAtLaunchingSpecificClusterError() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -615,7 +630,7 @@ public class TestAMContainer {
     verifyUnOrderedOutgoingEventTypes(outgoingEvents,
         TaskAttemptEventType.TA_CONTAINER_TERMINATED_BY_SYSTEM,
         AMNodeEventType.N_CONTAINER_COMPLETED);
-    Assert.assertEquals(TaskAttemptTerminationCause.NODE_DISK_ERROR,
+    assertEquals(TaskAttemptTerminationCause.NODE_DISK_ERROR,
         ((TaskAttemptEventContainerTerminatedBySystem)outgoingEvents.get(0)).getTerminationCause());
 
     assertFalse(wc.amContainer.isInErrorState());
@@ -628,7 +643,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerCompletedAtLaunchingSpecificError() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -648,7 +664,7 @@ public class TestAMContainer {
     verifyUnOrderedOutgoingEventTypes(outgoingEvents,
         TaskAttemptEventType.TA_CONTAINER_TERMINATED,
         AMNodeEventType.N_CONTAINER_COMPLETED);
-    Assert.assertEquals(TaskAttemptTerminationCause.NODE_FAILED,
+    assertEquals(TaskAttemptTerminationCause.NODE_FAILED,
         ((TaskAttemptEventContainerTerminated)outgoingEvents.get(0)).getTerminationCause());
 
     assertFalse(wc.amContainer.isInErrorState());
@@ -661,7 +677,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerCompletedAtIdle() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -690,7 +707,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerCompletedAtRunning() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -726,7 +744,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerPreemptedAtRunning() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -749,7 +768,7 @@ public class TestAMContainer {
     outgoingEvents = wc.verifyCountAndGetOutgoingEvents(2);
 
     Event event = findEventByType(outgoingEvents, TaskAttemptEventType.TA_CONTAINER_TERMINATED_BY_SYSTEM);
-    Assert.assertEquals(TaskAttemptTerminationCause.EXTERNAL_PREEMPTION,
+    assertEquals(TaskAttemptTerminationCause.EXTERNAL_PREEMPTION,
         ((TaskAttemptEventContainerTerminatedBySystem)event).getTerminationCause());
     verifyUnOrderedOutgoingEventTypes(outgoingEvents,
         TaskAttemptEventType.TA_CONTAINER_TERMINATED_BY_SYSTEM,
@@ -768,7 +787,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerInternallyPreemptedAtRunning() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -792,7 +812,7 @@ public class TestAMContainer {
     verifyUnOrderedOutgoingEventTypes(outgoingEvents,
         TaskAttemptEventType.TA_CONTAINER_TERMINATED_BY_SYSTEM,
         AMNodeEventType.N_CONTAINER_COMPLETED);
-    Assert.assertEquals(TaskAttemptTerminationCause.INTERNAL_PREEMPTION,
+    assertEquals(TaskAttemptTerminationCause.INTERNAL_PREEMPTION,
         ((TaskAttemptEventContainerTerminatedBySystem)outgoingEvents.get(0)).getTerminationCause());
 
     assertFalse(wc.amContainer.isInErrorState());
@@ -808,7 +828,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerDiskFailedAtRunning() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -829,7 +850,7 @@ public class TestAMContainer {
 
     outgoingEvents = wc.verifyCountAndGetOutgoingEvents(2);
     Event event = findEventByType(outgoingEvents, TaskAttemptEventType.TA_CONTAINER_TERMINATED_BY_SYSTEM);
-    Assert.assertEquals(TaskAttemptTerminationCause.NODE_DISK_ERROR,
+    assertEquals(TaskAttemptTerminationCause.NODE_DISK_ERROR,
         ((TaskAttemptEventContainerTerminatedBySystem)event).getTerminationCause());
     verifyUnOrderedOutgoingEventTypes(outgoingEvents,
         TaskAttemptEventType.TA_CONTAINER_TERMINATED_BY_SYSTEM,
@@ -848,7 +869,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskAssignedToCompletedContainer() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -879,7 +901,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNodeFailedAtRunning() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -916,7 +939,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNodeFailedAtIdleMultipleAttempts() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -960,7 +984,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNodeFailedAtRunningMultipleAttempts() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -1004,7 +1029,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNodeFailedAtCompletedMultipleSuccessfulTAs() {
     WrappedContainer wc = new WrappedContainer();
     List<Event> outgoingEvents;
@@ -1032,7 +1058,8 @@ public class TestAMContainer {
     assertEquals(2, wc.amContainer.getAllTaskAttempts().size());
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDuplicateCompletedEvents() {
     WrappedContainer wc = new WrappedContainer();
 
@@ -1056,7 +1083,8 @@ public class TestAMContainer {
     wc.verifyHistoryStopEvent();
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLocalResourceAddition() {
     WrappedContainer wc = new WrappedContainer();
 
@@ -1119,7 +1147,8 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("unchecked")
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCredentialsTransfer() {
     WrappedContainerMultipleDAGs wc = new WrappedContainerMultipleDAGs();
 
@@ -1421,8 +1450,9 @@ public class TestAMContainer {
 
     public void verifyState(AMContainerState state) {
       assertEquals(
-          "Expected state: " + state + ", but found: " + amContainer.getState(),
-          state, amContainer.getState());
+          state,
+          amContainer.getState(),
+          "Expected state: " + state + ", but found: " + amContainer.getState());
     }
   }
 
@@ -1446,8 +1476,7 @@ public class TestAMContainer {
   }
 
   @SuppressWarnings("rawtypes")
-  private void verifyUnOrderedOutgoingEventTypes(List<Event> events,
-      Enum<?>... expectedTypes) {
+  private void verifyUnOrderedOutgoingEventTypes(List<Event> events, Enum<?>... expectedTypes) {
 
     List<Enum<?>> expectedTypeList = new LinkedList<Enum<?>>();
     for (Enum<?> expectedType : expectedTypes) {
@@ -1468,10 +1497,11 @@ public class TestAMContainer {
         }
       }
     }
-    assertTrue("Did not find types : " + expectedTypeList
-        + " in outgoing event list", expectedTypeList.isEmpty());
-    assertTrue("Found unexpected events: " + eventsCopy
-        + " in outgoing event list", eventsCopy.isEmpty());
+    assertTrue(
+        expectedTypeList.isEmpty(),
+        "Did not find types : " + expectedTypeList + " in outgoing event list");
+    assertTrue(
+        eventsCopy.isEmpty(), "Found unexpected events: " + eventsCopy + " in outgoing event list");
   }
 
   private Event findEventByType(List<Event> events, Enum<?> type) {

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/container/TestAMContainerMap.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/container/TestAMContainerMap.java
@@ -18,10 +18,12 @@
  */
 package org.apache.tez.dag.app.rm.container;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.Container;
@@ -32,12 +34,14 @@ import org.apache.tez.dag.app.TaskCommunicatorManagerInterface;
 import org.apache.tez.dag.app.dag.DAG;
 import org.apache.tez.dag.app.rm.container.TestAMContainer.WrappedContainer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestAMContainerMap {
 
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testCleanupOnDagComplete() {
 
     ContainerHeartbeatHandler chh = mock(ContainerHeartbeatHandler.class);

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/node/TestAMNodeTracker.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/node/TestAMNodeTracker.java
@@ -18,16 +18,17 @@
  */
 package org.apache.tez.dag.app.rm.node;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ContainerId;
@@ -51,9 +52,10 @@ import org.apache.tez.dag.records.TezTaskAttemptID;
 
 import com.google.common.collect.Lists;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +67,7 @@ public class TestAMNodeTracker {
   DrainDispatcher dispatcher;
   EventHandler eventHandler;
 
-  @Before
+  @BeforeEach
   public void setup() {
     dispatcher = new DrainDispatcher();
     dispatcher.init(new Configuration());
@@ -83,12 +85,13 @@ public class TestAMNodeTracker {
     }
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     dispatcher.stop();
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testHealthUpdateKnownNode() {
     AppContext appContext = mock(AppContext.class);
 
@@ -107,7 +110,8 @@ public class TestAMNodeTracker {
     amNodeTracker.stop();
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testHealthUpdateUnknownNode() {
     AppContext appContext = mock(AppContext.class);
 
@@ -127,7 +131,8 @@ public class TestAMNodeTracker {
     // the log message for verification.
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleSourcesNodeRegistration() {
     AppContext appContext = mock(AppContext.class);
     AMNodeTracker amNodeTracker = new AMNodeTracker(eventHandler, appContext);
@@ -150,7 +155,8 @@ public class TestAMNodeTracker {
     assertNotNull(amNodeTracker.get(nodeId2, 1));
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleSourcesNodeCountUpdated() {
     AppContext appContext = mock(AppContext.class);
     AMNodeTracker amNodeTracker = new AMNodeTracker(eventHandler, appContext);
@@ -176,7 +182,8 @@ public class TestAMNodeTracker {
     assertNotNull(amNodeTracker.get(nodeId2, 1));
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSingleNodeNotBlacklisted() {
     AppContext appContext = mock(AppContext.class);
     Configuration conf = new Configuration(false);
@@ -199,7 +206,8 @@ public class TestAMNodeTracker {
     _testSingleNodeNotBlacklisted(amNodeTracker, handler, 0);
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSingleNodeNotBlacklistedAlternateScheduler() {
     AppContext appContext = mock(AppContext.class);
     Configuration conf = new Configuration(false);
@@ -222,7 +230,8 @@ public class TestAMNodeTracker {
     _testSingleNodeNotBlacklisted(amNodeTracker, handler, 1);
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSingleNodeNotBlacklistedAlternateScheduler2() {
     AppContext appContext = mock(AppContext.class);
     Configuration conf = new Configuration(false);
@@ -253,7 +262,8 @@ public class TestAMNodeTracker {
     assertFalse(amNodeTracker.isBlacklistingIgnored(0));
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testNodeSelfBlacklist() {
     AppContext appContext = mock(AppContext.class);
     Configuration conf = new Configuration(false);
@@ -276,7 +286,8 @@ public class TestAMNodeTracker {
     }
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testNodeSelfBlacklistAlternateScheduler1() {
     AppContext appContext = mock(AppContext.class);
     Configuration conf = new Configuration(false);
@@ -299,7 +310,8 @@ public class TestAMNodeTracker {
     }
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testNodeSelfBlacklistAlternateScheduler2() {
     AppContext appContext = mock(AppContext.class);
     Configuration conf = new Configuration(false);
@@ -328,7 +340,8 @@ public class TestAMNodeTracker {
     }
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleAMNodeIDs() {
     AppContext appContext = mock(AppContext.class);
     Configuration conf = new Configuration(false);
@@ -355,7 +368,8 @@ public class TestAMNodeTracker {
     }
   }
 
-  @Test(timeout = 10000L)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testNodeCompletedAndCleanup() {
     AppContext appContext = mock(AppContext.class);
     Configuration conf = new Configuration(false);
@@ -427,23 +441,27 @@ public class TestAMNodeTracker {
 
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testNodeUnhealthyRescheduleTasksEnabled() throws Exception {
     _testNodeUnhealthyRescheduleTasks(true, false);
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testNodeUnhealthyRescheduleTasksDisabled() throws Exception {
     _testNodeUnhealthyRescheduleTasks(false, false);
   }
 
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testNodeUnhealthyRescheduleTasksEnabledAMNode() throws Exception {
     _testNodeUnhealthyRescheduleTasks(true, true);
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testNodeUnhealthyRescheduleTasksDisabledAMNode() throws Exception {
     _testNodeUnhealthyRescheduleTasks(false, true);
   }

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/rm/node/TestAMNodeTracker.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/rm/node/TestAMNodeTracker.java
@@ -369,7 +369,7 @@ public class TestAMNodeTracker {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 10000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testNodeCompletedAndCleanup() {
     AppContext appContext = mock(AppContext.class);
     Configuration conf = new Configuration(false);

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/web/TestAMWebController.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/web/TestAMWebController.java
@@ -107,16 +107,12 @@ public class TestAMWebController {
 
     String httpResponseSplitOrigin = validOrigin + " \nSecondHeader: value";
     String encodedResponseSplitOrigin = AMWebController.encodeHeader(httpResponseSplitOrigin);
-    assertEquals(
-        validOrigin,
-        encodedResponseSplitOrigin,
-        "Http response split origin should be protected against");
+    assertEquals(validOrigin, encodedResponseSplitOrigin, "Http response split origin should be protected against");
 
     // Test Origin List
     String validOriginList = "http://foo.example.com:12345 http://bar.example.com:12345";
     String encodedValidOriginList = AMWebController.encodeHeader(validOriginList);
-    assertEquals(
-        validOriginList, encodedValidOriginList, "Valid origin list encoding should match exactly");
+    assertEquals(validOriginList, encodedValidOriginList, "Valid origin list encoding should match exactly");
   }
 
   @Test

--- a/tez-dag/src/test/java/org/apache/tez/dag/app/web/TestAMWebController.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/app/web/TestAMWebController.java
@@ -18,6 +18,10 @@
  */
 package org.apache.tez.dag.app.web;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -38,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -67,9 +72,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
@@ -81,7 +86,7 @@ public class TestAMWebController {
   HttpServletRequest mockRequest;
   String[] userGroups = {};
 
-  @Before
+  @BeforeEach
   public void setup() {
     MockitoAnnotations.initMocks(this);
 
@@ -98,24 +103,24 @@ public class TestAMWebController {
   public void testEncodeHeaders() {
     String validOrigin = "http://localhost:12345";
     String encodedValidOrigin = AMWebController.encodeHeader(validOrigin);
-    Assert.assertEquals("Valid origin encoding should match exactly",
-        validOrigin, encodedValidOrigin);
+    assertEquals(validOrigin, encodedValidOrigin, "Valid origin encoding should match exactly");
 
     String httpResponseSplitOrigin = validOrigin + " \nSecondHeader: value";
-    String encodedResponseSplitOrigin =
-        AMWebController.encodeHeader(httpResponseSplitOrigin);
-    Assert.assertEquals("Http response split origin should be protected against",
-        validOrigin, encodedResponseSplitOrigin);
+    String encodedResponseSplitOrigin = AMWebController.encodeHeader(httpResponseSplitOrigin);
+    assertEquals(
+        validOrigin,
+        encodedResponseSplitOrigin,
+        "Http response split origin should be protected against");
 
     // Test Origin List
     String validOriginList = "http://foo.example.com:12345 http://bar.example.com:12345";
-    String encodedValidOriginList = AMWebController
-        .encodeHeader(validOriginList);
-    Assert.assertEquals("Valid origin list encoding should match exactly",
-        validOriginList, encodedValidOriginList);
+    String encodedValidOriginList = AMWebController.encodeHeader(validOriginList);
+    assertEquals(
+        validOriginList, encodedValidOriginList, "Valid origin list encoding should match exactly");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCorsHeadersWithOrigin() {
     AMWebController amWebController = new AMWebController(mockRequestContext, mockAppContext,
         "TEST_HISTORY_URL");
@@ -131,7 +136,8 @@ public class TestAMWebController {
     verify(mockResponse).setHeader("Access-Control-Allow-Origin", originURL);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCorsHeadersAreSet() {
     AMWebController amWebController = new AMWebController(mockRequestContext, mockAppContext,
         "TEST_HISTORY_URL");
@@ -147,7 +153,8 @@ public class TestAMWebController {
         "X-Requested-With,Content-Type,Accept,Origin");
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void sendErrorResponseIfNoAccess() throws Exception {
     AMWebController amWebController = new AMWebController(mockRequestContext, mockAppContext,
         "TEST_HISTORY_URL");
@@ -174,7 +181,8 @@ public class TestAMWebController {
   @Captor
   ArgumentCaptor<Map<String, AMWebController.ProgressInfo>> singleResultCaptor;
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDagProgressResponse() {
     AMWebController amWebController = new AMWebController(mockRequestContext, mockAppContext,
         "TEST_HISTORY_URL");
@@ -193,14 +201,15 @@ public class TestAMWebController {
     verify(spy).renderJSON(singleResultCaptor.capture());
 
     final Map<String, AMWebController.ProgressInfo> result = singleResultCaptor.getValue();
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsKey("dagProgress"));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("dagProgress"));
     AMWebController.ProgressInfo progressInfo = result.get("dagProgress");
-    Assert.assertTrue("dag_1422960590892_0007_42".equals(progressInfo.getId()));
-    Assert.assertEquals(66.0, progressInfo.getProgress(), 0.1);
+    assertEquals("dag_1422960590892_0007_42", progressInfo.getId());
+    assertEquals(66.0, progressInfo.getProgress(), 0.1);
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testVertexProgressResponse() {
     AMWebController amWebController = new AMWebController(mockRequestContext, mockAppContext,
         "TEST_HISTORY_URL");
@@ -224,14 +233,15 @@ public class TestAMWebController {
     verify(spy).renderJSON(singleResultCaptor.capture());
 
     final Map<String, AMWebController.ProgressInfo> result = singleResultCaptor.getValue();
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsKey("vertexProgress"));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("vertexProgress"));
     AMWebController.ProgressInfo progressInfo = result.get("vertexProgress");
-    Assert.assertTrue("vertex_1422960590892_0007_42_43".equals(progressInfo.getId()));
-    Assert.assertEquals(66.0f, progressInfo.getProgress(), 0.1);
+    assertEquals("vertex_1422960590892_0007_42_43", progressInfo.getId());
+    assertEquals(66.0f, progressInfo.getProgress(), 0.1);
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testHasAccessWithAclsDisabled() {
     Configuration conf = new Configuration(false);
     conf.setBoolean(TezConfiguration.TEZ_AM_ACLS_ENABLED, false);
@@ -239,14 +249,15 @@ public class TestAMWebController {
 
     when(mockAppContext.getAMACLManager()).thenReturn(aclManager);
 
-    Assert.assertEquals(true, AMWebController._hasAccess(null, mockAppContext));
+    assertTrue(AMWebController._hasAccess(null, mockAppContext));
 
     UserGroupInformation mockUser = UserGroupInformation.createUserForTesting(
         "mockUser", userGroups);
-    Assert.assertEquals(true, AMWebController._hasAccess(mockUser, mockAppContext));
+    assertTrue(AMWebController._hasAccess(mockUser, mockAppContext));
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testHasAccess() {
     Configuration conf = new Configuration(false);
     conf.setBoolean(TezConfiguration.TEZ_AM_ACLS_ENABLED, true);
@@ -254,15 +265,15 @@ public class TestAMWebController {
 
     when(mockAppContext.getAMACLManager()).thenReturn(aclManager);
 
-    Assert.assertEquals(false, AMWebController._hasAccess(null, mockAppContext));
+    assertFalse(AMWebController._hasAccess(null, mockAppContext));
 
     UserGroupInformation mockUser = UserGroupInformation.createUserForTesting(
         "mockUser", userGroups);
-    Assert.assertEquals(false, AMWebController._hasAccess(mockUser, mockAppContext));
+    assertFalse(AMWebController._hasAccess(mockUser, mockAppContext));
 
     UserGroupInformation testUser = UserGroupInformation.createUserForTesting(
         "amUser", userGroups);
-    Assert.assertEquals(true, AMWebController._hasAccess(testUser, mockAppContext));
+    assertTrue(AMWebController._hasAccess(testUser, mockAppContext));
   }
 
 
@@ -272,7 +283,8 @@ public class TestAMWebController {
   ArgumentCaptor<Map<String,Object>> returnResultCaptor;
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetDagInfo() {
     AMWebController amWebController = new AMWebController(mockRequestContext, mockAppContext,
         "TEST_HISTORY_URL");
@@ -310,20 +322,21 @@ public class TestAMWebController {
     verify(spy).renderJSON(returnResultCaptor.capture());
 
     final Map<String, Object> result = returnResultCaptor.getValue();
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsKey("dag"));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("dag"));
     Map<String, String> dagInfo = (Map<String, String>) result.get("dag");
 
-    Assert.assertEquals(4, dagInfo.size());
-    Assert.assertTrue("dag_1422960590892_0007_42".equals(dagInfo.get("id")));
-    Assert.assertEquals("66.0", dagInfo.get("progress"));
-    Assert.assertEquals("RUNNING", dagInfo.get("status"));
-    Assert.assertNotNull(dagInfo.get("counters"));
+    assertEquals(4, dagInfo.size());
+    assertEquals("dag_1422960590892_0007_42", dagInfo.get("id"));
+    assertEquals("66.0", dagInfo.get("progress"));
+    assertEquals("RUNNING", dagInfo.get("status"));
+    assertNotNull(dagInfo.get("counters"));
 
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetVerticesInfoGetAll() {
     Vertex mockVertex1 = createMockVertex("vertex_1422960590892_0007_42_00", VertexState.RUNNING,
         0.33f, 3);
@@ -332,11 +345,11 @@ public class TestAMWebController {
 
     final Map<String, Object> result = getVerticesTestHelper(0, mockVertex1, mockVertex2);
 
-    Assert.assertEquals(1, result.size());
+    assertEquals(1, result.size());
 
-    Assert.assertTrue(result.containsKey("vertices"));
+    assertTrue(result.containsKey("vertices"));
     ArrayList<Map<String, String>> verticesInfo = (ArrayList<Map<String, String>>) result.get("vertices");
-    Assert.assertEquals(2, verticesInfo.size());
+    assertEquals(2, verticesInfo.size());
 
     Map<String, String> vertex1Result = verticesInfo.get(0);
     Map<String, String> vertex2Result = verticesInfo.get(1);
@@ -346,7 +359,8 @@ public class TestAMWebController {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetVerticesInfoGetPartial() {
     Vertex mockVertex1 = createMockVertex("vertex_1422960590892_0007_42_00", VertexState.RUNNING,
         0.33f, 3);
@@ -355,11 +369,11 @@ public class TestAMWebController {
 
     final Map<String, Object> result = getVerticesTestHelper(1, mockVertex1, mockVertex2);
 
-    Assert.assertEquals(1, result.size());
+    assertEquals(1, result.size());
 
-    Assert.assertTrue(result.containsKey("vertices"));
+    assertTrue(result.containsKey("vertices"));
     List<Map<String, String>> verticesInfo = (List<Map<String, String>>) result.get("vertices");
-    Assert.assertEquals(1, verticesInfo.size());
+    assertEquals(1, verticesInfo.size());
 
     Map<String, String> vertex1Result = verticesInfo.get(0);
 
@@ -448,38 +462,39 @@ public class TestAMWebController {
 
   private void verifySingleVertexResult(Vertex mockVertex2, Map<String, String> vertex2Result) {
     ProgressBuilder progress;
-    Assert.assertEquals(mockVertex2.getVertexId().toString(), vertex2Result.get("id"));
-    Assert.assertEquals(mockVertex2.getState().toString(), vertex2Result.get("status"));
-    Assert.assertEquals(Float.toString(mockVertex2.getCompletedTaskProgress()), vertex2Result.get("progress"));
+    assertEquals(mockVertex2.getVertexId().toString(), vertex2Result.get("id"));
+    assertEquals(mockVertex2.getState().toString(), vertex2Result.get("status"));
+    assertEquals(Float.toString(mockVertex2.getCompletedTaskProgress()), vertex2Result.get("progress"));
     progress = mockVertex2.getVertexProgress();
-    Assert.assertEquals(Integer.toString(progress.getTotalTaskCount()),
+    assertEquals(Integer.toString(progress.getTotalTaskCount()),
         vertex2Result.get("totalTasks"));
-    Assert.assertEquals(Integer.toString(progress.getRunningTaskCount()),
+    assertEquals(Integer.toString(progress.getRunningTaskCount()),
         vertex2Result.get("runningTasks"));
-    Assert.assertEquals(Integer.toString(progress.getSucceededTaskCount()),
+    assertEquals(Integer.toString(progress.getSucceededTaskCount()),
         vertex2Result.get("succeededTasks"));
-    Assert.assertEquals(Integer.toString(progress.getKilledTaskAttemptCount()),
+    assertEquals(Integer.toString(progress.getKilledTaskAttemptCount()),
         vertex2Result.get("killedTaskAttempts"));
-    Assert.assertEquals(Integer.toString(progress.getFailedTaskAttemptCount()),
+    assertEquals(Integer.toString(progress.getFailedTaskAttemptCount()),
         vertex2Result.get("failedTaskAttempts"));
     String str0 = Long.toString(mockVertex2.getInitTime());
     String str1 = vertex2Result.get("initTime");
-    Assert.assertEquals(Long.toString(mockVertex2.getInitTime()),
+    assertEquals(Long.toString(mockVertex2.getInitTime()),
         vertex2Result.get("initTime"));
-    Assert.assertEquals(Long.toString(mockVertex2.getStartTime()),
+    assertEquals(Long.toString(mockVertex2.getStartTime()),
         vertex2Result.get("startTime"));
-    Assert.assertEquals(Long.toString(mockVertex2.getFinishTime()),
+    assertEquals(Long.toString(mockVertex2.getFinishTime()),
         vertex2Result.get("finishTime"));
-    Assert.assertEquals(Long.toString(mockVertex2.getFirstTaskStartTime()),
+    assertEquals(Long.toString(mockVertex2.getFirstTaskStartTime()),
         vertex2Result.get("firstTaskStartTime"));
-    Assert.assertEquals(Long.toString(mockVertex2.getLastTaskFinishTime()),
+    assertEquals(Long.toString(mockVertex2.getLastTaskFinishTime()),
         vertex2Result.get("lastTaskFinishTime"));
   }
 
   //-- Get Tasks Info Tests -----------------------------------------------------------------------
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetTasksInfoWithTaskIds() {
     List <Task> tasks = createMockTasks();
     List <Integer> vertexMinIds = Arrays.asList();
@@ -491,12 +506,12 @@ public class TestAMWebController {
     Map<String, Object> result = getTasksTestHelper(tasks, taskMinIds, vertexMinIds,
         AMWebController.MAX_QUERIED);
 
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsKey("tasks"));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("tasks"));
 
     ArrayList<Map<String, String>> tasksInfo = (ArrayList<Map<String, String>>) result.
         get("tasks");
-    Assert.assertEquals(3, tasksInfo.size());
+    assertEquals(3, tasksInfo.size());
 
     verifySingleTaskResult(tasks.get(0), tasksInfo.get(0));
     verifySingleTaskResult(tasks.get(3), tasksInfo.get(1));
@@ -505,18 +520,19 @@ public class TestAMWebController {
     // With limit
     result = getTasksTestHelper(tasks, taskMinIds, vertexMinIds, 2);
 
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsKey("tasks"));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("tasks"));
 
     tasksInfo = (ArrayList<Map<String, String>>) result.get("tasks");
-    Assert.assertEquals(2, tasksInfo.size());
+    assertEquals(2, tasksInfo.size());
 
     verifySingleTaskResult(tasks.get(0), tasksInfo.get(0));
     verifySingleTaskResult(tasks.get(3), tasksInfo.get(1));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetTasksInfoGracefulTaskFetch() {
     List <Task> tasks = createMockTasks();
     List <Integer> vertexMinIds = Arrays.asList();
@@ -528,19 +544,20 @@ public class TestAMWebController {
     Map<String, Object> result = getTasksTestHelper(tasks, taskMinIds, vertexMinIds,
         AMWebController.MAX_QUERIED);
 
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsKey("tasks"));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("tasks"));
 
     ArrayList<Map<String, String>> tasksInfo = (ArrayList<Map<String, String>>) result.
         get("tasks");
-    Assert.assertEquals(2, tasksInfo.size());
+    assertEquals(2, tasksInfo.size());
 
     verifySingleTaskResult(tasks.get(0), tasksInfo.get(0));
     verifySingleTaskResult(tasks.get(1), tasksInfo.get(1));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetTasksInfoWithVertexId() {
     List <Task> tasks = createMockTasks();
     List <Integer> vertexMinIds = Arrays.asList(0);
@@ -549,12 +566,12 @@ public class TestAMWebController {
     Map<String, Object> result = getTasksTestHelper(tasks, taskMinIds, vertexMinIds,
         AMWebController.MAX_QUERIED);
 
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsKey("tasks"));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("tasks"));
 
     ArrayList<Map<String, String>> tasksInfo = (ArrayList<Map<String, String>>) result.
         get("tasks");
-    Assert.assertEquals(4, tasksInfo.size());
+    assertEquals(4, tasksInfo.size());
 
     sortMapList(tasksInfo, "id");
     verifySingleTaskResult(tasks.get(0), tasksInfo.get(0));
@@ -565,15 +582,16 @@ public class TestAMWebController {
     // With limit
     result = getTasksTestHelper(tasks, taskMinIds, vertexMinIds, 2);
 
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsKey("tasks"));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("tasks"));
 
     tasksInfo = (ArrayList<Map<String, String>>) result.get("tasks");
-    Assert.assertEquals(2, tasksInfo.size());
+    assertEquals(2, tasksInfo.size());
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetTasksInfoWithJustDAGId() {
     List <Task> tasks = createMockTasks();
     List <Integer> vertexMinIds = Arrays.asList();
@@ -582,12 +600,12 @@ public class TestAMWebController {
     Map<String, Object> result = getTasksTestHelper(tasks, taskMinIds, vertexMinIds,
         AMWebController.MAX_QUERIED);
 
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsKey("tasks"));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("tasks"));
 
     ArrayList<Map<String, String>> tasksInfo = (ArrayList<Map<String, String>>) result.
         get("tasks");
-    Assert.assertEquals(4, tasksInfo.size());
+    assertEquals(4, tasksInfo.size());
 
     sortMapList(tasksInfo, "id");
     verifySingleTaskResult(tasks.get(0), tasksInfo.get(0));
@@ -598,11 +616,11 @@ public class TestAMWebController {
     // With limit
     result = getTasksTestHelper(tasks, taskMinIds, vertexMinIds, 2);
 
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsKey("tasks"));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("tasks"));
 
     tasksInfo = (ArrayList<Map<String, String>>) result.get("tasks");
-    Assert.assertEquals(2, tasksInfo.size());
+    assertEquals(2, tasksInfo.size());
   }
 
   private void sortMapList(ArrayList<Map<String, String>> list, String propertyName) {
@@ -712,16 +730,17 @@ public class TestAMWebController {
   }
 
   private void verifySingleTaskResult(Task mockTask, Map<String, String> taskResult) {
-    Assert.assertEquals(3, taskResult.size());
-    Assert.assertEquals(mockTask.getTaskID().toString(), taskResult.get("id"));
-    Assert.assertEquals(mockTask.getState().toString(), taskResult.get("status"));
-    Assert.assertEquals(Float.toString(mockTask.getProgress()), taskResult.get("progress"));
+    assertEquals(3, taskResult.size());
+    assertEquals(mockTask.getTaskID().toString(), taskResult.get("id"));
+    assertEquals(mockTask.getState().toString(), taskResult.get("status"));
+    assertEquals(Float.toString(mockTask.getProgress()), taskResult.get("progress"));
   }
 
   //-- Get Attempts Info Tests -----------------------------------------------------------------------
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetAttemptsInfoWithIds() {
     List <TaskAttempt> attempts = createMockAttempts();
     List <Integer> vertexMinIds = Arrays.asList();
@@ -735,12 +754,12 @@ public class TestAMWebController {
     Map<String, Object> result = getAttemptsTestHelper(attempts, attemptMinIds, vertexMinIds,
         taskMinIds, AMWebController.MAX_QUERIED);
 
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsKey("attempts"));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("attempts"));
 
     ArrayList<Map<String, String>> attemptsInfo = (ArrayList<Map<String, String>>) result.
         get("attempts");
-    Assert.assertEquals(4, attemptsInfo.size());
+    assertEquals(4, attemptsInfo.size());
 
     verifySingleAttemptResult(attempts.get(0), attemptsInfo.get(0));
     verifySingleAttemptResult(attempts.get(1), attemptsInfo.get(1));
@@ -750,11 +769,11 @@ public class TestAMWebController {
     // With limit
     result = getAttemptsTestHelper(attempts, attemptMinIds, vertexMinIds, taskMinIds, 2);
 
-    Assert.assertEquals(1, result.size());
-    Assert.assertTrue(result.containsKey("attempts"));
+    assertEquals(1, result.size());
+    assertTrue(result.containsKey("attempts"));
 
     attemptsInfo = (ArrayList<Map<String, String>>) result.get("attempts");
-    Assert.assertEquals(2, attemptsInfo.size());
+    assertEquals(2, attemptsInfo.size());
 
     verifySingleAttemptResult(attempts.get(0), attemptsInfo.get(0));
     verifySingleAttemptResult(attempts.get(1), attemptsInfo.get(1));
@@ -859,10 +878,10 @@ public class TestAMWebController {
   }
 
   private void verifySingleAttemptResult(TaskAttempt mockTask, Map<String, String> taskResult) {
-    Assert.assertEquals(3, taskResult.size());
-    Assert.assertEquals(mockTask.getTaskAttemptID().toString(), taskResult.get("id"));
-    Assert.assertEquals(mockTask.getState().toString(), taskResult.get("status"));
-    Assert.assertEquals(Float.toString(mockTask.getProgress()), taskResult.get("progress"));
+    assertEquals(3, taskResult.size());
+    assertEquals(mockTask.getTaskAttemptID().toString(), taskResult.get("id"));
+    assertEquals(mockTask.getState().toString(), taskResult.get("status"));
+    assertEquals(Float.toString(mockTask.getProgress()), taskResult.get("progress"));
   }
 
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/history/TestHistoryEventHandler.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/history/TestHistoryEventHandler.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tez.dag.history;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -55,8 +55,8 @@ import org.apache.tez.dag.records.TezTaskID;
 import org.apache.tez.dag.records.TezVertexID;
 import org.apache.tez.hadoop.shim.HadoopShim;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestHistoryEventHandler {
 
@@ -65,7 +65,7 @@ public class TestHistoryEventHandler {
   private static String user = "TEST_USER";
   private Configuration baseConfig;
 
-  @Before
+  @BeforeEach
   public void setupConfig() {
     baseConfig = new Configuration(false);
   }
@@ -139,8 +139,7 @@ public class TestHistoryEventHandler {
     for (DAGHistoryEvent event : events) {
       handler.handle(event);
     }
-    assertEquals("Failed for level: " + level,
-        expectedCount, InMemoryHistoryLoggingService.events.size());
+    assertEquals(expectedCount, InMemoryHistoryLoggingService.events.size(), "Failed for level: " + level);
     handler.stop();
   }
 
@@ -151,8 +150,7 @@ public class TestHistoryEventHandler {
     for (DAGHistoryEvent event : makeHistoryEvents(dagId, handler.getConfig())) {
       handler.handle(event);
     }
-    assertEquals("Failed for level: " + level,
-        expectedCount, InMemoryHistoryLoggingService.events.size());
+    assertEquals(expectedCount, InMemoryHistoryLoggingService.events.size(), "Failed for level: " + level);
     handler.stop();
   }
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/history/TestHistoryEventType.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/history/TestHistoryEventType.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
-
 public class TestHistoryEventType {
 
   @Test

--- a/tez-dag/src/test/java/org/apache/tez/dag/history/TestHistoryEventType.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/history/TestHistoryEventType.java
@@ -18,8 +18,11 @@
  */
 package org.apache.tez.dag.history;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
 
 public class TestHistoryEventType {
 
@@ -29,9 +32,9 @@ public class TestHistoryEventType {
       if (eventType.name().startsWith("AM_")
           || eventType.name().startsWith("APP_")
           || eventType.name().startsWith("CONTAINER_")) {
-        Assert.assertFalse(HistoryEventType.isDAGSpecificEvent(eventType));
+        assertFalse(HistoryEventType.isDAGSpecificEvent(eventType));
       } else {
-        Assert.assertTrue(HistoryEventType.isDAGSpecificEvent(eventType));
+        assertTrue(HistoryEventType.isDAGSpecificEvent(eventType));
       }
     }
   }

--- a/tez-dag/src/test/java/org/apache/tez/dag/history/events/TestHistoryEventsProtoConversion.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/history/events/TestHistoryEventsProtoConversion.java
@@ -156,12 +156,9 @@ public class TestHistoryEventsProtoConversion {
         100, 100, null);
     AMLaunchedEvent deserializedEvent = (AMLaunchedEvent)
         testProtoConversion(event);
-    assertEquals(event.getApplicationAttemptId(),
-        deserializedEvent.getApplicationAttemptId());
-    assertEquals(event.getAppSubmitTime(),
-        deserializedEvent.getAppSubmitTime());
-    assertEquals(event.getLaunchTime(),
-        deserializedEvent.getLaunchTime());
+    assertEquals(event.getApplicationAttemptId(), deserializedEvent.getApplicationAttemptId());
+    assertEquals(event.getAppSubmitTime(), deserializedEvent.getAppSubmitTime());
+    assertEquals(event.getLaunchTime(), deserializedEvent.getLaunchTime());
     logEvents(event, deserializedEvent);
   }
 
@@ -171,10 +168,8 @@ public class TestHistoryEventsProtoConversion {
             ApplicationId.newInstance(0, 1), 1), 100, "");
     AMStartedEvent deserializedEvent = (AMStartedEvent)
         testProtoConversion(event);
-    assertEquals(event.getApplicationAttemptId(),
-        deserializedEvent.getApplicationAttemptId());
-    assertEquals(event.getStartTime(),
-        deserializedEvent.getStartTime());
+    assertEquals(event.getApplicationAttemptId(), deserializedEvent.getApplicationAttemptId());
+    assertEquals(event.getStartTime(), deserializedEvent.getStartTime());
     logEvents(event, deserializedEvent);
   }
 
@@ -187,16 +182,11 @@ public class TestHistoryEventsProtoConversion {
             ApplicationId.newInstance(0, 1), 1), null, "", null, null, QUEUE_NAME);
     DAGSubmittedEvent deserializedEvent = (DAGSubmittedEvent)
         testProtoConversion(event);
-    assertEquals(event.getApplicationAttemptId(),
-        deserializedEvent.getApplicationAttemptId());
-    assertEquals(event.getDAGID(),
-        deserializedEvent.getDAGID());
-    assertEquals(event.getDAGName(),
-        deserializedEvent.getDAGName());
-    assertEquals(event.getSubmitTime(),
-        deserializedEvent.getSubmitTime());
-    assertEquals(event.getDAGPlan(),
-        deserializedEvent.getDAGPlan());
+    assertEquals(event.getApplicationAttemptId(), deserializedEvent.getApplicationAttemptId());
+    assertEquals(event.getDAGID(), deserializedEvent.getDAGID());
+    assertEquals(event.getDAGName(), deserializedEvent.getDAGName());
+    assertEquals(event.getSubmitTime(), deserializedEvent.getSubmitTime());
+    assertEquals(event.getDAGPlan(), deserializedEvent.getDAGPlan());
     assertEquals(event.getQueueName(), deserializedEvent.getQueueName());
     logEvents(event, deserializedEvent);
   }
@@ -207,8 +197,7 @@ public class TestHistoryEventsProtoConversion {
         "user", "dagName", null);
     DAGInitializedEvent deserializedEvent = (DAGInitializedEvent)
         testProtoConversion(event);
-    assertEquals(event.getDAGID(),
-        deserializedEvent.getDAGID());
+    assertEquals(event.getDAGID(), deserializedEvent.getDAGID());
     assertEquals(event.getInitTime(), deserializedEvent.getInitTime());
     logEvents(event, deserializedEvent);
   }
@@ -219,8 +208,7 @@ public class TestHistoryEventsProtoConversion {
         "user", "dagName");
     DAGStartedEvent deserializedEvent = (DAGStartedEvent)
         testProtoConversion(event);
-    assertEquals(event.getDAGID(),
-        deserializedEvent.getDAGID());
+    assertEquals(event.getDAGID(), deserializedEvent.getDAGID());
     assertEquals(event.getStartTime(), deserializedEvent.getStartTime());
     logEvents(event, deserializedEvent);
   }
@@ -230,8 +218,7 @@ public class TestHistoryEventsProtoConversion {
         new DAGKillRequestEvent(TezDAGID.getInstance(ApplicationId.newInstance(0, 1), 1), 100334l,false);
     DAGKillRequestEvent deserializedEvent = (DAGKillRequestEvent)
         testProtoConversion(event);
-    assertEquals(event.getDagID(),
-        deserializedEvent.getDagID());
+    assertEquals(event.getDagID(), deserializedEvent.getDagID());
     assertEquals(event.getKillRequestTime(), deserializedEvent.getKillRequestTime());
     assertEquals(event.isSessionStopped(), deserializedEvent.isSessionStopped());
     logEvents(event, deserializedEvent);
@@ -245,9 +232,7 @@ public class TestHistoryEventsProtoConversion {
           DAGPlan.newBuilder().setName("dagName").build());
       DAGFinishedEvent deserializedEvent = (DAGFinishedEvent)
           testProtoConversion(event);
-      assertEquals(
-          event.getDAGID(),
-          deserializedEvent.getDAGID());
+      assertEquals(event.getDAGID(), deserializedEvent.getDAGID());
       assertEquals(event.getState(), deserializedEvent.getState());
       assertNotEquals(event.getStartTime(), deserializedEvent.getStartTime());
       assertEquals(event.getFinishTime(), deserializedEvent.getFinishTime());
@@ -266,16 +251,13 @@ public class TestHistoryEventsProtoConversion {
           "user", "dagName", null, null, DAGPlan.newBuilder().setName("dagName").build());
       DAGFinishedEvent deserializedEvent = (DAGFinishedEvent)
           testProtoConversion(event);
-      assertEquals(
-          event.getDAGID(),
-          deserializedEvent.getDAGID());
+      assertEquals(event.getDAGID(), deserializedEvent.getDAGID());
       assertEquals(event.getState(), deserializedEvent.getState());
       assertNotEquals(event.getStartTime(), deserializedEvent.getStartTime());
       assertEquals(event.getFinishTime(), deserializedEvent.getFinishTime());
       assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
       assertEquals(event.getTezCounters(), deserializedEvent.getTezCounters());
-      assertEquals(101,
-          deserializedEvent.getTezCounters().getGroup("foo").findCounter("c1").getValue());
+      assertEquals(101, deserializedEvent.getTezCounters().getGroup("foo").findCounter("c1").getValue());
       logEvents(event, deserializedEvent);
     }
   }
@@ -290,20 +272,14 @@ public class TestHistoryEventsProtoConversion {
     VertexInitializedEvent deserializedEvent = (VertexInitializedEvent)
         testProtoConversion(event);
     assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
-    assertEquals(event.getInitRequestedTime(),
-        deserializedEvent.getInitRequestedTime());
-    assertEquals(event.getInitedTime(),
-        deserializedEvent.getInitedTime());
-    assertEquals(event.getNumTasks(),
-        deserializedEvent.getNumTasks());
-    assertEquals(event.getAdditionalInputs(),
-        deserializedEvent.getAdditionalInputs());
+    assertEquals(event.getInitRequestedTime(), deserializedEvent.getInitRequestedTime());
+    assertEquals(event.getInitedTime(), deserializedEvent.getInitedTime());
+    assertEquals(event.getNumTasks(), deserializedEvent.getNumTasks());
+    assertEquals(event.getAdditionalInputs(), deserializedEvent.getAdditionalInputs());
     assertNull(deserializedEvent.getProcessorName());
     assertEquals(1, event.getInitGeneratedEvents().size());
-    assertEquals(EventType.ROOT_INPUT_DATA_INFORMATION_EVENT,
-        event.getInitGeneratedEvents().get(0).getEventType());
-    assertEquals(event.getInitGeneratedEvents().size(),
-        deserializedEvent.getInitGeneratedEvents().size());
+    assertEquals(EventType.ROOT_INPUT_DATA_INFORMATION_EVENT, event.getInitGeneratedEvents().get(0).getEventType());
+    assertEquals(event.getInitGeneratedEvents().size(), deserializedEvent.getInitGeneratedEvents().size());
     logEvents(event, deserializedEvent);
   }
 
@@ -315,10 +291,8 @@ public class TestHistoryEventsProtoConversion {
     VertexStartedEvent deserializedEvent = (VertexStartedEvent)
         testProtoConversion(event);
     assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
-    assertEquals(event.getStartRequestedTime(),
-        deserializedEvent.getStartRequestedTime());
-    assertEquals(event.getStartTime(),
-        deserializedEvent.getStartTime());
+    assertEquals(event.getStartRequestedTime(), deserializedEvent.getStartRequestedTime());
+    assertEquals(event.getStartTime(), deserializedEvent.getStartTime());
     logEvents(event, deserializedEvent);
   }
 
@@ -360,37 +334,29 @@ public class TestHistoryEventsProtoConversion {
     assertEquals(event.getNumTasks(), deserializedEvent.getNumTasks());
     assertEquals(event.isSetParallelismCalled(), deserializedEvent.isSetParallelismCalled());
     // vertexLocationHint
-    assertEquals(event.getVertexLocationHint(),
-        deserializedEvent.getVertexLocationHint());
+    assertEquals(event.getVertexLocationHint(), deserializedEvent.getVertexLocationHint());
     // rootInputSpec
-    assertEquals(event.getRootInputSpecUpdates().size(), deserializedEvent
-        .getRootInputSpecUpdates().size());
+    assertEquals(event.getRootInputSpecUpdates().size(), deserializedEvent.getRootInputSpecUpdates().size());
     InputSpecUpdate deserializedBulk = deserializedEvent.getRootInputSpecUpdates().get("input1");
     InputSpecUpdate deserializedPerTask = deserializedEvent.getRootInputSpecUpdates().get("input2");
-    assertEquals(rootInputSpecUpdateBulk.isForAllWorkUnits(),
-        deserializedBulk.isForAllWorkUnits());
-    assertEquals(rootInputSpecUpdateBulk.getAllNumPhysicalInputs(),
-        deserializedBulk.getAllNumPhysicalInputs());
-    assertEquals(rootInputSpecUpdatePerTask.isForAllWorkUnits(),
-        deserializedPerTask.isForAllWorkUnits());
-    assertEquals(rootInputSpecUpdatePerTask.getAllNumPhysicalInputs(),
-        deserializedPerTask.getAllNumPhysicalInputs());
+    assertEquals(rootInputSpecUpdateBulk.isForAllWorkUnits(), deserializedBulk.isForAllWorkUnits());
+    assertEquals(rootInputSpecUpdateBulk.getAllNumPhysicalInputs(), deserializedBulk.getAllNumPhysicalInputs());
+    assertEquals(rootInputSpecUpdatePerTask.isForAllWorkUnits(), deserializedPerTask.isForAllWorkUnits());
+    assertEquals(rootInputSpecUpdatePerTask.getAllNumPhysicalInputs(), deserializedPerTask.getAllNumPhysicalInputs());
     // sourceEdgeManager
-    assertEquals(event.getSourceEdgeProperties().size(), deserializedEvent
-        .getSourceEdgeProperties().size());
+    assertEquals(event.getSourceEdgeProperties().size(), deserializedEvent.getSourceEdgeProperties().size());
     assertEquals(event.getSourceEdgeProperties().get("foo").getDataMovementType(),
         deserializedEvent.getSourceEdgeProperties().get("foo").getDataMovementType());
-    assertNull(deserializedEvent.getSourceEdgeProperties().get("foo")
-        .getEdgeManagerDescriptor());
+    assertNull(deserializedEvent.getSourceEdgeProperties().get("foo").getEdgeManagerDescriptor());
     assertEquals(event.getSourceEdgeProperties().get("foo1").getDataMovementType(),
         deserializedEvent.getSourceEdgeProperties().get("foo1").getDataMovementType());
-    assertEquals(event.getSourceEdgeProperties().get("foo1").getEdgeManagerDescriptor()
-        .getUserPayload().getVersion(), deserializedEvent.getSourceEdgeProperties().get("foo1")
-        .getEdgeManagerDescriptor().getUserPayload().getVersion());
-    assertArrayEquals(event.getSourceEdgeProperties().get("foo1")
-        .getEdgeManagerDescriptor().getUserPayload().deepCopyAsArray(), deserializedEvent
-        .getSourceEdgeProperties().get("foo1").getEdgeManagerDescriptor().getUserPayload()
-        .deepCopyAsArray());
+    assertEquals(event.getSourceEdgeProperties().get("foo1").getEdgeManagerDescriptor().getUserPayload().getVersion(),
+        deserializedEvent.getSourceEdgeProperties().get("foo1").getEdgeManagerDescriptor().getUserPayload()
+            .getVersion());
+    assertArrayEquals(
+        event.getSourceEdgeProperties().get("foo1").getEdgeManagerDescriptor().getUserPayload().deepCopyAsArray(),
+        deserializedEvent.getSourceEdgeProperties().get("foo1").getEdgeManagerDescriptor().getUserPayload()
+            .deepCopyAsArray());
 
     logEvents(event, deserializedEvent);
   }
@@ -420,8 +386,7 @@ public class TestHistoryEventsProtoConversion {
       VertexFinishedEvent deserializedEvent = (VertexFinishedEvent)
           testProtoConversion(event);
       assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
-      assertEquals(event.getFinishTime(),
-          deserializedEvent.getFinishTime());
+      assertEquals(event.getFinishTime(), deserializedEvent.getFinishTime());
       assertEquals(event.getState(), deserializedEvent.getState());
       assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
       logEvents(event, deserializedEvent);
@@ -436,10 +401,8 @@ public class TestHistoryEventsProtoConversion {
     TaskStartedEvent deserializedEvent = (TaskStartedEvent)
         testProtoConversion(event);
     assertEquals(event.getTaskID(), deserializedEvent.getTaskID());
-    assertEquals(event.getScheduledTime(),
-        deserializedEvent.getScheduledTime());
-    assertEquals(event.getStartTime(),
-        deserializedEvent.getStartTime());
+    assertEquals(event.getScheduledTime(), deserializedEvent.getScheduledTime());
+    assertEquals(event.getStartTime(), deserializedEvent.getStartTime());
     logEvents(event, deserializedEvent);
   }
 
@@ -452,12 +415,9 @@ public class TestHistoryEventsProtoConversion {
       TaskFinishedEvent deserializedEvent = (TaskFinishedEvent)
           testProtoConversion(event);
       assertEquals(event.getTaskID(), deserializedEvent.getTaskID());
-      assertEquals(event.getFinishTime(),
-          deserializedEvent.getFinishTime());
-      assertEquals(event.getState(),
-          deserializedEvent.getState());
-      assertEquals(event.getSuccessfulAttemptID(),
-          deserializedEvent.getSuccessfulAttemptID());
+      assertEquals(event.getFinishTime(), deserializedEvent.getFinishTime());
+      assertEquals(event.getState(), deserializedEvent.getState());
+      assertEquals(event.getSuccessfulAttemptID(), deserializedEvent.getSuccessfulAttemptID());
       assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
       logEvents(event, deserializedEvent);
     }
@@ -472,12 +432,9 @@ public class TestHistoryEventsProtoConversion {
       TaskFinishedEvent deserializedEvent = (TaskFinishedEvent)
           testProtoConversion(event);
       assertEquals(event.getTaskID(), deserializedEvent.getTaskID());
-      assertEquals(event.getFinishTime(),
-          deserializedEvent.getFinishTime());
-      assertEquals(event.getState(),
-          deserializedEvent.getState());
-      assertEquals(event.getSuccessfulAttemptID(),
-          deserializedEvent.getSuccessfulAttemptID());
+      assertEquals(event.getFinishTime(), deserializedEvent.getFinishTime());
+      assertEquals(event.getState(), deserializedEvent.getState());
+      assertEquals(event.getSuccessfulAttemptID(), deserializedEvent.getSuccessfulAttemptID());
       assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
       logEvents(event, deserializedEvent);
     }
@@ -495,12 +452,9 @@ public class TestHistoryEventsProtoConversion {
         );
     TaskAttemptStartedEvent deserializedEvent = (TaskAttemptStartedEvent)
         testProtoConversion(event);
-    assertEquals(event.getTaskAttemptID(),
-        deserializedEvent.getTaskAttemptID());
-    assertEquals(event.getContainerId(),
-        deserializedEvent.getContainerId());
-    assertEquals(event.getNodeId(),
-        deserializedEvent.getNodeId());
+    assertEquals(event.getTaskAttemptID(), deserializedEvent.getTaskAttemptID());
+    assertEquals(event.getContainerId(), deserializedEvent.getContainerId());
+    assertEquals(event.getNodeId(), deserializedEvent.getNodeId());
     logEvents(event, deserializedEvent);
   }
 
@@ -520,32 +474,19 @@ public class TestHistoryEventsProtoConversion {
                   "host1", 19999), "inProgress", "Completed", "nodeHttpAddress");
       TaskAttemptFinishedEvent deserializedEvent = (TaskAttemptFinishedEvent)
           testProtoConversion(event);
-      assertEquals(event.getTaskAttemptID(),
-          deserializedEvent.getTaskAttemptID());
-      assertEquals(event.getCreationTime(),
-          deserializedEvent.getCreationTime());
-      assertEquals(event.getAllocationTime(),
-          deserializedEvent.getAllocationTime());
-      assertEquals(event.getStartTime(),
-          deserializedEvent.getStartTime());
-      assertEquals(event.getFinishTime(),
-          deserializedEvent.getFinishTime());
-      assertEquals(event.getCreationCausalTA(),
-          deserializedEvent.getCreationCausalTA());
-      assertEquals(event.getDiagnostics(),
-          deserializedEvent.getDiagnostics());
-      assertEquals(event.getState(),
-          deserializedEvent.getState());
-      assertEquals(event.getCounters(),
-          deserializedEvent.getCounters());
-      assertEquals(event.getContainerId(),
-          deserializedEvent.getContainerId());
-      assertEquals(event.getNodeId(),
-          deserializedEvent.getNodeId());
-      assertEquals(event.getNodeHttpAddress(),
-          deserializedEvent.getNodeHttpAddress());
-      assertEquals(event.getTaskFailureType(),
-          deserializedEvent.getTaskFailureType());
+      assertEquals(event.getTaskAttemptID(), deserializedEvent.getTaskAttemptID());
+      assertEquals(event.getCreationTime(), deserializedEvent.getCreationTime());
+      assertEquals(event.getAllocationTime(), deserializedEvent.getAllocationTime());
+      assertEquals(event.getStartTime(), deserializedEvent.getStartTime());
+      assertEquals(event.getFinishTime(), deserializedEvent.getFinishTime());
+      assertEquals(event.getCreationCausalTA(), deserializedEvent.getCreationCausalTA());
+      assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
+      assertEquals(event.getState(), deserializedEvent.getState());
+      assertEquals(event.getCounters(), deserializedEvent.getCounters());
+      assertEquals(event.getContainerId(), deserializedEvent.getContainerId());
+      assertEquals(event.getNodeId(), deserializedEvent.getNodeId());
+      assertEquals(event.getNodeHttpAddress(), deserializedEvent.getNodeHttpAddress());
+      assertEquals(event.getTaskFailureType(), deserializedEvent.getTaskFailureType());
       logEvents(event, deserializedEvent);
     }
     {
@@ -567,24 +508,15 @@ public class TestHistoryEventsProtoConversion {
               "host1", 19999), "inProgress", "Completed", "nodeHttpAddress");
       TaskAttemptFinishedEvent deserializedEvent = (TaskAttemptFinishedEvent)
           testProtoConversion(event);
-      assertEquals(event.getTaskAttemptID(),
-          deserializedEvent.getTaskAttemptID());
-      assertEquals(event.getFinishTime(),
-          deserializedEvent.getFinishTime());
-      assertEquals(event.getDiagnostics(),
-          deserializedEvent.getDiagnostics());
-      assertEquals(event.getState(),
-          deserializedEvent.getState());
-      assertEquals(event.getCounters(),
-          deserializedEvent.getCounters());
-      assertEquals(event.getContainerId(),
-          deserializedEvent.getContainerId());
-      assertEquals(event.getNodeId(),
-          deserializedEvent.getNodeId());
-      assertEquals(event.getNodeHttpAddress(),
-          deserializedEvent.getNodeHttpAddress());
-      assertEquals(event.getTaskAttemptError(),
-          deserializedEvent.getTaskAttemptError());
+      assertEquals(event.getTaskAttemptID(), deserializedEvent.getTaskAttemptID());
+      assertEquals(event.getFinishTime(), deserializedEvent.getFinishTime());
+      assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
+      assertEquals(event.getState(), deserializedEvent.getState());
+      assertEquals(event.getCounters(), deserializedEvent.getCounters());
+      assertEquals(event.getContainerId(), deserializedEvent.getContainerId());
+      assertEquals(event.getNodeId(), deserializedEvent.getNodeId());
+      assertEquals(event.getNodeHttpAddress(), deserializedEvent.getNodeHttpAddress());
+      assertEquals(event.getTaskAttemptError(), deserializedEvent.getTaskAttemptError());
       assertEquals(events.size(), event.getDataEvents().size());
       assertEquals(events.get(0).getTimestamp(), event.getDataEvents().get(0).getTimestamp());
       assertEquals(events.get(0).getTaskAttemptId(), event.getDataEvents().get(0).getTaskAttemptId());
@@ -611,28 +543,18 @@ public class TestHistoryEventsProtoConversion {
           "host1", 19999), "inProgress", "Completed", "nodeHttpAddress");
       TaskAttemptFinishedEvent deserializedEvent = (TaskAttemptFinishedEvent)
           testProtoConversion(event);
-      assertEquals(event.getTaskAttemptID(),
-          deserializedEvent.getTaskAttemptID());
-      assertEquals(event.getFinishTime(),
-          deserializedEvent.getFinishTime());
-      assertEquals(event.getDiagnostics(),
-          deserializedEvent.getDiagnostics());
-      assertEquals(event.getState(),
-          deserializedEvent.getState());
-      assertEquals(event.getCounters(),
-          deserializedEvent.getCounters());
-      assertEquals(event.getContainerId(),
-          deserializedEvent.getContainerId());
-      assertEquals(event.getNodeId(),
-          deserializedEvent.getNodeId());
-      assertEquals(event.getNodeHttpAddress(),
-          deserializedEvent.getNodeHttpAddress());
-      assertEquals(event.getTaskAttemptError(),
-          deserializedEvent.getTaskAttemptError());
+      assertEquals(event.getTaskAttemptID(), deserializedEvent.getTaskAttemptID());
+      assertEquals(event.getFinishTime(), deserializedEvent.getFinishTime());
+      assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
+      assertEquals(event.getState(), deserializedEvent.getState());
+      assertEquals(event.getCounters(), deserializedEvent.getCounters());
+      assertEquals(event.getContainerId(), deserializedEvent.getContainerId());
+      assertEquals(event.getNodeId(), deserializedEvent.getNodeId());
+      assertEquals(event.getNodeHttpAddress(), deserializedEvent.getNodeHttpAddress());
+      assertEquals(event.getTaskAttemptError(), deserializedEvent.getTaskAttemptError());
       assertEquals(events.size(), event.getDataEvents().size());
       assertEquals(events.get(0).getTimestamp(), event.getDataEvents().get(0).getTimestamp());
-      assertEquals(events.get(0).getTaskAttemptId(),
-          event.getDataEvents().get(0).getTaskAttemptId());
+      assertEquals(events.get(0).getTaskAttemptId(), event.getDataEvents().get(0).getTaskAttemptId());
       assertEquals(event.getTaskFailureType(), deserializedEvent.getTaskFailureType());
       logEvents(event, deserializedEvent);
     }
@@ -668,12 +590,9 @@ public class TestHistoryEventsProtoConversion {
             ApplicationId.newInstance(0, 1), 1));
     ContainerLaunchedEvent deserializedEvent = (ContainerLaunchedEvent)
         testProtoConversion(event);
-    assertEquals(event.getContainerId(),
-        deserializedEvent.getContainerId());
-    assertEquals(event.getLaunchTime(),
-        deserializedEvent.getLaunchTime());
-    assertEquals(event.getApplicationAttemptId(),
-        deserializedEvent.getApplicationAttemptId());
+    assertEquals(event.getContainerId(), deserializedEvent.getContainerId());
+    assertEquals(event.getLaunchTime(), deserializedEvent.getLaunchTime());
+    assertEquals(event.getApplicationAttemptId(), deserializedEvent.getApplicationAttemptId());
     logEvents(event, deserializedEvent);
   }
 
@@ -686,12 +605,9 @@ public class TestHistoryEventsProtoConversion {
             ApplicationId.newInstance(0, 1), 1));
     ContainerStoppedEvent deserializedEvent = (ContainerStoppedEvent)
         testProtoConversion(event);
-    assertEquals(event.getContainerId(),
-        deserializedEvent.getContainerId());
-    assertEquals(event.getStoppedTime(),
-        deserializedEvent.getStoppedTime());
-    assertEquals(event.getApplicationAttemptId(),
-        deserializedEvent.getApplicationAttemptId());
+    assertEquals(event.getContainerId(), deserializedEvent.getContainerId());
+    assertEquals(event.getStoppedTime(), deserializedEvent.getStoppedTime());
+    assertEquals(event.getApplicationAttemptId(), deserializedEvent.getApplicationAttemptId());
     logEvents(event, deserializedEvent);
   }
 
@@ -727,16 +643,14 @@ public class TestHistoryEventsProtoConversion {
       VertexGroupCommitStartedEvent deserializedEvent =
           (VertexGroupCommitStartedEvent) testProtoConversion(event);
       assertEquals(event.getDagID(), deserializedEvent.getDagID());
-      assertEquals(event.getVertexGroupName(),
-          deserializedEvent.getVertexGroupName());
+      assertEquals(event.getVertexGroupName(), deserializedEvent.getVertexGroupName());
       assertEquals(event.getVertexIds(), vertexIds);
       logEvents(event, deserializedEvent);
     }
     {
       VertexGroupCommitStartedEvent deserializedEvent =
           (VertexGroupCommitStartedEvent) testSummaryProtoConversion(event);
-      assertEquals(event.getVertexGroupName(),
-          deserializedEvent.getVertexGroupName());
+      assertEquals(event.getVertexGroupName(), deserializedEvent.getVertexGroupName());
       logEvents(event, deserializedEvent);
     }
   }
@@ -754,16 +668,14 @@ public class TestHistoryEventsProtoConversion {
       VertexGroupCommitFinishedEvent deserializedEvent =
           (VertexGroupCommitFinishedEvent) testProtoConversion(event);
       assertEquals(event.getDagID(), deserializedEvent.getDagID());
-      assertEquals(event.getVertexGroupName(),
-          deserializedEvent.getVertexGroupName());
+      assertEquals(event.getVertexGroupName(), deserializedEvent.getVertexGroupName());
       assertEquals(event.getVertexIds(), vertexIds);
       logEvents(event, deserializedEvent);
     }
     {
       VertexGroupCommitFinishedEvent deserializedEvent =
           (VertexGroupCommitFinishedEvent) testSummaryProtoConversion(event);
-      assertEquals(event.getVertexGroupName(),
-          deserializedEvent.getVertexGroupName());
+      assertEquals(event.getVertexGroupName(), deserializedEvent.getVertexGroupName());
       logEvents(event, deserializedEvent);
     }
   }

--- a/tez-dag/src/test/java/org/apache/tez/dag/history/events/TestHistoryEventsProtoConversion.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/history/events/TestHistoryEventsProtoConversion.java
@@ -18,8 +18,12 @@
  */
 package org.apache.tez.dag.history.events;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -76,8 +80,7 @@ import com.google.common.collect.Lists;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,11 +156,11 @@ public class TestHistoryEventsProtoConversion {
         100, 100, null);
     AMLaunchedEvent deserializedEvent = (AMLaunchedEvent)
         testProtoConversion(event);
-    Assert.assertEquals(event.getApplicationAttemptId(),
+    assertEquals(event.getApplicationAttemptId(),
         deserializedEvent.getApplicationAttemptId());
-    Assert.assertEquals(event.getAppSubmitTime(),
+    assertEquals(event.getAppSubmitTime(),
         deserializedEvent.getAppSubmitTime());
-    Assert.assertEquals(event.getLaunchTime(),
+    assertEquals(event.getLaunchTime(),
         deserializedEvent.getLaunchTime());
     logEvents(event, deserializedEvent);
   }
@@ -168,9 +171,9 @@ public class TestHistoryEventsProtoConversion {
             ApplicationId.newInstance(0, 1), 1), 100, "");
     AMStartedEvent deserializedEvent = (AMStartedEvent)
         testProtoConversion(event);
-    Assert.assertEquals(event.getApplicationAttemptId(),
+    assertEquals(event.getApplicationAttemptId(),
         deserializedEvent.getApplicationAttemptId());
-    Assert.assertEquals(event.getStartTime(),
+    assertEquals(event.getStartTime(),
         deserializedEvent.getStartTime());
     logEvents(event, deserializedEvent);
   }
@@ -184,17 +187,17 @@ public class TestHistoryEventsProtoConversion {
             ApplicationId.newInstance(0, 1), 1), null, "", null, null, QUEUE_NAME);
     DAGSubmittedEvent deserializedEvent = (DAGSubmittedEvent)
         testProtoConversion(event);
-    Assert.assertEquals(event.getApplicationAttemptId(),
+    assertEquals(event.getApplicationAttemptId(),
         deserializedEvent.getApplicationAttemptId());
-    Assert.assertEquals(event.getDAGID(),
+    assertEquals(event.getDAGID(),
         deserializedEvent.getDAGID());
-    Assert.assertEquals(event.getDAGName(),
+    assertEquals(event.getDAGName(),
         deserializedEvent.getDAGName());
-    Assert.assertEquals(event.getSubmitTime(),
+    assertEquals(event.getSubmitTime(),
         deserializedEvent.getSubmitTime());
-    Assert.assertEquals(event.getDAGPlan(),
+    assertEquals(event.getDAGPlan(),
         deserializedEvent.getDAGPlan());
-    Assert.assertEquals(event.getQueueName(), deserializedEvent.getQueueName());
+    assertEquals(event.getQueueName(), deserializedEvent.getQueueName());
     logEvents(event, deserializedEvent);
   }
 
@@ -204,9 +207,9 @@ public class TestHistoryEventsProtoConversion {
         "user", "dagName", null);
     DAGInitializedEvent deserializedEvent = (DAGInitializedEvent)
         testProtoConversion(event);
-    Assert.assertEquals(event.getDAGID(),
+    assertEquals(event.getDAGID(),
         deserializedEvent.getDAGID());
-    Assert.assertEquals(event.getInitTime(), deserializedEvent.getInitTime());
+    assertEquals(event.getInitTime(), deserializedEvent.getInitTime());
     logEvents(event, deserializedEvent);
   }
 
@@ -216,9 +219,9 @@ public class TestHistoryEventsProtoConversion {
         "user", "dagName");
     DAGStartedEvent deserializedEvent = (DAGStartedEvent)
         testProtoConversion(event);
-    Assert.assertEquals(event.getDAGID(),
+    assertEquals(event.getDAGID(),
         deserializedEvent.getDAGID());
-    Assert.assertEquals(event.getStartTime(), deserializedEvent.getStartTime());
+    assertEquals(event.getStartTime(), deserializedEvent.getStartTime());
     logEvents(event, deserializedEvent);
   }
 
@@ -227,10 +230,10 @@ public class TestHistoryEventsProtoConversion {
         new DAGKillRequestEvent(TezDAGID.getInstance(ApplicationId.newInstance(0, 1), 1), 100334l,false);
     DAGKillRequestEvent deserializedEvent = (DAGKillRequestEvent)
         testProtoConversion(event);
-    Assert.assertEquals(event.getDagID(),
+    assertEquals(event.getDagID(),
         deserializedEvent.getDagID());
-    Assert.assertEquals(event.getKillRequestTime(), deserializedEvent.getKillRequestTime());
-    Assert.assertEquals(event.isSessionStopped(), deserializedEvent.isSessionStopped());
+    assertEquals(event.getKillRequestTime(), deserializedEvent.getKillRequestTime());
+    assertEquals(event.isSessionStopped(), deserializedEvent.isSessionStopped());
     logEvents(event, deserializedEvent);
   }
 
@@ -242,14 +245,14 @@ public class TestHistoryEventsProtoConversion {
           DAGPlan.newBuilder().setName("dagName").build());
       DAGFinishedEvent deserializedEvent = (DAGFinishedEvent)
           testProtoConversion(event);
-      Assert.assertEquals(
+      assertEquals(
           event.getDAGID(),
           deserializedEvent.getDAGID());
-      Assert.assertEquals(event.getState(), deserializedEvent.getState());
-      Assert.assertNotEquals(event.getStartTime(), deserializedEvent.getStartTime());
-      Assert.assertEquals(event.getFinishTime(), deserializedEvent.getFinishTime());
-      Assert.assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
-      Assert.assertEquals(event.getTezCounters(), deserializedEvent.getTezCounters());
+      assertEquals(event.getState(), deserializedEvent.getState());
+      assertNotEquals(event.getStartTime(), deserializedEvent.getStartTime());
+      assertEquals(event.getFinishTime(), deserializedEvent.getFinishTime());
+      assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
+      assertEquals(event.getTezCounters(), deserializedEvent.getTezCounters());
       logEvents(event, deserializedEvent);
     }
     {
@@ -263,15 +266,15 @@ public class TestHistoryEventsProtoConversion {
           "user", "dagName", null, null, DAGPlan.newBuilder().setName("dagName").build());
       DAGFinishedEvent deserializedEvent = (DAGFinishedEvent)
           testProtoConversion(event);
-      Assert.assertEquals(
+      assertEquals(
           event.getDAGID(),
           deserializedEvent.getDAGID());
-      Assert.assertEquals(event.getState(), deserializedEvent.getState());
-      Assert.assertNotEquals(event.getStartTime(), deserializedEvent.getStartTime());
-      Assert.assertEquals(event.getFinishTime(), deserializedEvent.getFinishTime());
-      Assert.assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
-      Assert.assertEquals(event.getTezCounters(), deserializedEvent.getTezCounters());
-      Assert.assertEquals(101,
+      assertEquals(event.getState(), deserializedEvent.getState());
+      assertNotEquals(event.getStartTime(), deserializedEvent.getStartTime());
+      assertEquals(event.getFinishTime(), deserializedEvent.getFinishTime());
+      assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
+      assertEquals(event.getTezCounters(), deserializedEvent.getTezCounters());
+      assertEquals(101,
           deserializedEvent.getTezCounters().getGroup("foo").findCounter("c1").getValue());
       logEvents(event, deserializedEvent);
     }
@@ -286,20 +289,20 @@ public class TestHistoryEventsProtoConversion {
         "vertex1", 1000l, 15000l, 100, "procName", null, initGeneratedEvents, null);
     VertexInitializedEvent deserializedEvent = (VertexInitializedEvent)
         testProtoConversion(event);
-    Assert.assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
-    Assert.assertEquals(event.getInitRequestedTime(),
+    assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
+    assertEquals(event.getInitRequestedTime(),
         deserializedEvent.getInitRequestedTime());
-    Assert.assertEquals(event.getInitedTime(),
+    assertEquals(event.getInitedTime(),
         deserializedEvent.getInitedTime());
-    Assert.assertEquals(event.getNumTasks(),
+    assertEquals(event.getNumTasks(),
         deserializedEvent.getNumTasks());
-    Assert.assertEquals(event.getAdditionalInputs(),
+    assertEquals(event.getAdditionalInputs(),
         deserializedEvent.getAdditionalInputs());
-    Assert.assertNull(deserializedEvent.getProcessorName());
-    Assert.assertEquals(1, event.getInitGeneratedEvents().size());
-    Assert.assertEquals(EventType.ROOT_INPUT_DATA_INFORMATION_EVENT,
+    assertNull(deserializedEvent.getProcessorName());
+    assertEquals(1, event.getInitGeneratedEvents().size());
+    assertEquals(EventType.ROOT_INPUT_DATA_INFORMATION_EVENT,
         event.getInitGeneratedEvents().get(0).getEventType());
-    Assert.assertEquals(event.getInitGeneratedEvents().size(),
+    assertEquals(event.getInitGeneratedEvents().size(),
         deserializedEvent.getInitGeneratedEvents().size());
     logEvents(event, deserializedEvent);
   }
@@ -311,10 +314,10 @@ public class TestHistoryEventsProtoConversion {
         145553l, 12334455l);
     VertexStartedEvent deserializedEvent = (VertexStartedEvent)
         testProtoConversion(event);
-    Assert.assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
-    Assert.assertEquals(event.getStartRequestedTime(),
+    assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
+    assertEquals(event.getStartRequestedTime(),
         deserializedEvent.getStartRequestedTime());
-    Assert.assertEquals(event.getStartTime(),
+    assertEquals(event.getStartTime(),
         deserializedEvent.getStartTime());
     logEvents(event, deserializedEvent);
   }
@@ -349,42 +352,42 @@ public class TestHistoryEventsProtoConversion {
                 TezDAGID.getInstance(ApplicationId.newInstance(0, 1), 1), 111),
             reconfigureDoneTime, numTasks, vertexLocationHint, sourceEdgeManagers,
             rootInputSpecUpdates, true);
-    Assert.assertEquals(numTasks, event.getNumTasks());
-    Assert.assertEquals(reconfigureDoneTime, event.getReconfigureDoneTime());
+    assertEquals(numTasks, event.getNumTasks());
+    assertEquals(reconfigureDoneTime, event.getReconfigureDoneTime());
     VertexConfigurationDoneEvent deserializedEvent = (VertexConfigurationDoneEvent)
           testProtoConversion(event);
-    Assert.assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
-    Assert.assertEquals(event.getNumTasks(), deserializedEvent.getNumTasks());
-    Assert.assertEquals(event.isSetParallelismCalled(), deserializedEvent.isSetParallelismCalled());
+    assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
+    assertEquals(event.getNumTasks(), deserializedEvent.getNumTasks());
+    assertEquals(event.isSetParallelismCalled(), deserializedEvent.isSetParallelismCalled());
     // vertexLocationHint
-    Assert.assertEquals(event.getVertexLocationHint(),
+    assertEquals(event.getVertexLocationHint(),
         deserializedEvent.getVertexLocationHint());
     // rootInputSpec
-    Assert.assertEquals(event.getRootInputSpecUpdates().size(), deserializedEvent
+    assertEquals(event.getRootInputSpecUpdates().size(), deserializedEvent
         .getRootInputSpecUpdates().size());
     InputSpecUpdate deserializedBulk = deserializedEvent.getRootInputSpecUpdates().get("input1");
     InputSpecUpdate deserializedPerTask = deserializedEvent.getRootInputSpecUpdates().get("input2");
-    Assert.assertEquals(rootInputSpecUpdateBulk.isForAllWorkUnits(),
+    assertEquals(rootInputSpecUpdateBulk.isForAllWorkUnits(),
         deserializedBulk.isForAllWorkUnits());
-    Assert.assertEquals(rootInputSpecUpdateBulk.getAllNumPhysicalInputs(),
+    assertEquals(rootInputSpecUpdateBulk.getAllNumPhysicalInputs(),
         deserializedBulk.getAllNumPhysicalInputs());
-    Assert.assertEquals(rootInputSpecUpdatePerTask.isForAllWorkUnits(),
+    assertEquals(rootInputSpecUpdatePerTask.isForAllWorkUnits(),
         deserializedPerTask.isForAllWorkUnits());
-    Assert.assertEquals(rootInputSpecUpdatePerTask.getAllNumPhysicalInputs(),
+    assertEquals(rootInputSpecUpdatePerTask.getAllNumPhysicalInputs(),
         deserializedPerTask.getAllNumPhysicalInputs());
     // sourceEdgeManager
-    Assert.assertEquals(event.getSourceEdgeProperties().size(), deserializedEvent
+    assertEquals(event.getSourceEdgeProperties().size(), deserializedEvent
         .getSourceEdgeProperties().size());
-    Assert.assertEquals(event.getSourceEdgeProperties().get("foo").getDataMovementType(),
+    assertEquals(event.getSourceEdgeProperties().get("foo").getDataMovementType(),
         deserializedEvent.getSourceEdgeProperties().get("foo").getDataMovementType());
-    Assert.assertNull(deserializedEvent.getSourceEdgeProperties().get("foo")
+    assertNull(deserializedEvent.getSourceEdgeProperties().get("foo")
         .getEdgeManagerDescriptor());
-    Assert.assertEquals(event.getSourceEdgeProperties().get("foo1").getDataMovementType(),
+    assertEquals(event.getSourceEdgeProperties().get("foo1").getDataMovementType(),
         deserializedEvent.getSourceEdgeProperties().get("foo1").getDataMovementType());
-    Assert.assertEquals(event.getSourceEdgeProperties().get("foo1").getEdgeManagerDescriptor()
+    assertEquals(event.getSourceEdgeProperties().get("foo1").getEdgeManagerDescriptor()
         .getUserPayload().getVersion(), deserializedEvent.getSourceEdgeProperties().get("foo1")
         .getEdgeManagerDescriptor().getUserPayload().getVersion());
-    Assert.assertArrayEquals(event.getSourceEdgeProperties().get("foo1")
+    assertArrayEquals(event.getSourceEdgeProperties().get("foo1")
         .getEdgeManagerDescriptor().getUserPayload().deepCopyAsArray(), deserializedEvent
         .getSourceEdgeProperties().get("foo1").getEdgeManagerDescriptor().getUserPayload()
         .deepCopyAsArray());
@@ -401,11 +404,11 @@ public class TestHistoryEventsProtoConversion {
               null, null, null, null, null);
       VertexFinishedEvent deserializedEvent = (VertexFinishedEvent)
           testProtoConversion(event);
-      Assert.assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
-      Assert.assertEquals(event.getFinishTime(),
+      assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
+      assertEquals(event.getFinishTime(),
           deserializedEvent.getFinishTime());
-      Assert.assertEquals(event.getState(), deserializedEvent.getState());
-      Assert.assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
+      assertEquals(event.getState(), deserializedEvent.getState());
+      assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
       logEvents(event, deserializedEvent);
     }
     {
@@ -416,11 +419,11 @@ public class TestHistoryEventsProtoConversion {
               "diagnose", new TezCounters(), new VertexStats(), null, null);
       VertexFinishedEvent deserializedEvent = (VertexFinishedEvent)
           testProtoConversion(event);
-      Assert.assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
-      Assert.assertEquals(event.getFinishTime(),
+      assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
+      assertEquals(event.getFinishTime(),
           deserializedEvent.getFinishTime());
-      Assert.assertEquals(event.getState(), deserializedEvent.getState());
-      Assert.assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
+      assertEquals(event.getState(), deserializedEvent.getState());
+      assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
       logEvents(event, deserializedEvent);
     }
   }
@@ -432,10 +435,10 @@ public class TestHistoryEventsProtoConversion {
         "vertex1", 1000l, 100000l);
     TaskStartedEvent deserializedEvent = (TaskStartedEvent)
         testProtoConversion(event);
-    Assert.assertEquals(event.getTaskID(), deserializedEvent.getTaskID());
-    Assert.assertEquals(event.getScheduledTime(),
+    assertEquals(event.getTaskID(), deserializedEvent.getTaskID());
+    assertEquals(event.getScheduledTime(),
         deserializedEvent.getScheduledTime());
-    Assert.assertEquals(event.getStartTime(),
+    assertEquals(event.getStartTime(),
         deserializedEvent.getStartTime());
     logEvents(event, deserializedEvent);
   }
@@ -448,14 +451,14 @@ public class TestHistoryEventsProtoConversion {
           "vertex1", 11000l, 1000000l, null, TaskState.FAILED, null, null, 0);
       TaskFinishedEvent deserializedEvent = (TaskFinishedEvent)
           testProtoConversion(event);
-      Assert.assertEquals(event.getTaskID(), deserializedEvent.getTaskID());
-      Assert.assertEquals(event.getFinishTime(),
+      assertEquals(event.getTaskID(), deserializedEvent.getTaskID());
+      assertEquals(event.getFinishTime(),
           deserializedEvent.getFinishTime());
-      Assert.assertEquals(event.getState(),
+      assertEquals(event.getState(),
           deserializedEvent.getState());
-      Assert.assertEquals(event.getSuccessfulAttemptID(),
+      assertEquals(event.getSuccessfulAttemptID(),
           deserializedEvent.getSuccessfulAttemptID());
-      Assert.assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
+      assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
       logEvents(event, deserializedEvent);
     }
     {
@@ -468,14 +471,14 @@ public class TestHistoryEventsProtoConversion {
           TaskState.FAILED, "task_diagnostics", new TezCounters(), 0);
       TaskFinishedEvent deserializedEvent = (TaskFinishedEvent)
           testProtoConversion(event);
-      Assert.assertEquals(event.getTaskID(), deserializedEvent.getTaskID());
-      Assert.assertEquals(event.getFinishTime(),
+      assertEquals(event.getTaskID(), deserializedEvent.getTaskID());
+      assertEquals(event.getFinishTime(),
           deserializedEvent.getFinishTime());
-      Assert.assertEquals(event.getState(),
+      assertEquals(event.getState(),
           deserializedEvent.getState());
-      Assert.assertEquals(event.getSuccessfulAttemptID(),
+      assertEquals(event.getSuccessfulAttemptID(),
           deserializedEvent.getSuccessfulAttemptID());
-      Assert.assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
+      assertEquals(event.getDiagnostics(), deserializedEvent.getDiagnostics());
       logEvents(event, deserializedEvent);
     }
   }
@@ -492,11 +495,11 @@ public class TestHistoryEventsProtoConversion {
         );
     TaskAttemptStartedEvent deserializedEvent = (TaskAttemptStartedEvent)
         testProtoConversion(event);
-    Assert.assertEquals(event.getTaskAttemptID(),
+    assertEquals(event.getTaskAttemptID(),
         deserializedEvent.getTaskAttemptID());
-    Assert.assertEquals(event.getContainerId(),
+    assertEquals(event.getContainerId(),
         deserializedEvent.getContainerId());
-    Assert.assertEquals(event.getNodeId(),
+    assertEquals(event.getNodeId(),
         deserializedEvent.getNodeId());
     logEvents(event, deserializedEvent);
   }
@@ -517,31 +520,31 @@ public class TestHistoryEventsProtoConversion {
                   "host1", 19999), "inProgress", "Completed", "nodeHttpAddress");
       TaskAttemptFinishedEvent deserializedEvent = (TaskAttemptFinishedEvent)
           testProtoConversion(event);
-      Assert.assertEquals(event.getTaskAttemptID(),
+      assertEquals(event.getTaskAttemptID(),
           deserializedEvent.getTaskAttemptID());
-      Assert.assertEquals(event.getCreationTime(),
+      assertEquals(event.getCreationTime(),
           deserializedEvent.getCreationTime());
-      Assert.assertEquals(event.getAllocationTime(),
+      assertEquals(event.getAllocationTime(),
           deserializedEvent.getAllocationTime());
-      Assert.assertEquals(event.getStartTime(),
+      assertEquals(event.getStartTime(),
           deserializedEvent.getStartTime());
-      Assert.assertEquals(event.getFinishTime(),
+      assertEquals(event.getFinishTime(),
           deserializedEvent.getFinishTime());
-      Assert.assertEquals(event.getCreationCausalTA(),
+      assertEquals(event.getCreationCausalTA(),
           deserializedEvent.getCreationCausalTA());
-      Assert.assertEquals(event.getDiagnostics(),
+      assertEquals(event.getDiagnostics(),
           deserializedEvent.getDiagnostics());
-      Assert.assertEquals(event.getState(),
+      assertEquals(event.getState(),
           deserializedEvent.getState());
-      Assert.assertEquals(event.getCounters(),
+      assertEquals(event.getCounters(),
           deserializedEvent.getCounters());
-      Assert.assertEquals(event.getContainerId(),
+      assertEquals(event.getContainerId(),
           deserializedEvent.getContainerId());
-      Assert.assertEquals(event.getNodeId(),
+      assertEquals(event.getNodeId(),
           deserializedEvent.getNodeId());
-      Assert.assertEquals(event.getNodeHttpAddress(),
+      assertEquals(event.getNodeHttpAddress(),
           deserializedEvent.getNodeHttpAddress());
-      Assert.assertEquals(event.getTaskFailureType(),
+      assertEquals(event.getTaskFailureType(),
           deserializedEvent.getTaskFailureType());
       logEvents(event, deserializedEvent);
     }
@@ -564,28 +567,28 @@ public class TestHistoryEventsProtoConversion {
               "host1", 19999), "inProgress", "Completed", "nodeHttpAddress");
       TaskAttemptFinishedEvent deserializedEvent = (TaskAttemptFinishedEvent)
           testProtoConversion(event);
-      Assert.assertEquals(event.getTaskAttemptID(),
+      assertEquals(event.getTaskAttemptID(),
           deserializedEvent.getTaskAttemptID());
-      Assert.assertEquals(event.getFinishTime(),
+      assertEquals(event.getFinishTime(),
           deserializedEvent.getFinishTime());
-      Assert.assertEquals(event.getDiagnostics(),
+      assertEquals(event.getDiagnostics(),
           deserializedEvent.getDiagnostics());
-      Assert.assertEquals(event.getState(),
+      assertEquals(event.getState(),
           deserializedEvent.getState());
-      Assert.assertEquals(event.getCounters(),
+      assertEquals(event.getCounters(),
           deserializedEvent.getCounters());
-      Assert.assertEquals(event.getContainerId(),
+      assertEquals(event.getContainerId(),
           deserializedEvent.getContainerId());
-      Assert.assertEquals(event.getNodeId(),
+      assertEquals(event.getNodeId(),
           deserializedEvent.getNodeId());
-      Assert.assertEquals(event.getNodeHttpAddress(),
+      assertEquals(event.getNodeHttpAddress(),
           deserializedEvent.getNodeHttpAddress());
-      Assert.assertEquals(event.getTaskAttemptError(),
+      assertEquals(event.getTaskAttemptError(),
           deserializedEvent.getTaskAttemptError());
-      Assert.assertEquals(events.size(), event.getDataEvents().size());
-      Assert.assertEquals(events.get(0).getTimestamp(), event.getDataEvents().get(0).getTimestamp());
-      Assert.assertEquals(events.get(0).getTaskAttemptId(), event.getDataEvents().get(0).getTaskAttemptId());
-      Assert.assertEquals(event.getTaskFailureType(), deserializedEvent.getTaskFailureType());
+      assertEquals(events.size(), event.getDataEvents().size());
+      assertEquals(events.get(0).getTimestamp(), event.getDataEvents().get(0).getTimestamp());
+      assertEquals(events.get(0).getTaskAttemptId(), event.getDataEvents().get(0).getTaskAttemptId());
+      assertEquals(event.getTaskFailureType(), deserializedEvent.getTaskFailureType());
       logEvents(event, deserializedEvent);
     }
     {
@@ -608,30 +611,29 @@ public class TestHistoryEventsProtoConversion {
           "host1", 19999), "inProgress", "Completed", "nodeHttpAddress");
       TaskAttemptFinishedEvent deserializedEvent = (TaskAttemptFinishedEvent)
           testProtoConversion(event);
-      Assert.assertEquals(event.getTaskAttemptID(),
+      assertEquals(event.getTaskAttemptID(),
           deserializedEvent.getTaskAttemptID());
-      Assert.assertEquals(event.getFinishTime(),
+      assertEquals(event.getFinishTime(),
           deserializedEvent.getFinishTime());
-      Assert.assertEquals(event.getDiagnostics(),
+      assertEquals(event.getDiagnostics(),
           deserializedEvent.getDiagnostics());
-      Assert.assertEquals(event.getState(),
+      assertEquals(event.getState(),
           deserializedEvent.getState());
-      Assert.assertEquals(event.getCounters(),
+      assertEquals(event.getCounters(),
           deserializedEvent.getCounters());
-      Assert.assertEquals(event.getContainerId(),
+      assertEquals(event.getContainerId(),
           deserializedEvent.getContainerId());
-      Assert.assertEquals(event.getNodeId(),
+      assertEquals(event.getNodeId(),
           deserializedEvent.getNodeId());
-      Assert.assertEquals(event.getNodeHttpAddress(),
+      assertEquals(event.getNodeHttpAddress(),
           deserializedEvent.getNodeHttpAddress());
-      Assert.assertEquals(event.getTaskAttemptError(),
+      assertEquals(event.getTaskAttemptError(),
           deserializedEvent.getTaskAttemptError());
-      Assert.assertEquals(events.size(), event.getDataEvents().size());
-      Assert
-          .assertEquals(events.get(0).getTimestamp(), event.getDataEvents().get(0).getTimestamp());
-      Assert.assertEquals(events.get(0).getTaskAttemptId(),
+      assertEquals(events.size(), event.getDataEvents().size());
+      assertEquals(events.get(0).getTimestamp(), event.getDataEvents().get(0).getTimestamp());
+      assertEquals(events.get(0).getTaskAttemptId(),
           event.getDataEvents().get(0).getTaskAttemptId());
-      Assert.assertEquals(event.getTaskFailureType(), deserializedEvent.getTaskFailureType());
+      assertEquals(event.getTaskFailureType(), deserializedEvent.getTaskFailureType());
       logEvents(event, deserializedEvent);
     }
     {
@@ -666,11 +668,11 @@ public class TestHistoryEventsProtoConversion {
             ApplicationId.newInstance(0, 1), 1));
     ContainerLaunchedEvent deserializedEvent = (ContainerLaunchedEvent)
         testProtoConversion(event);
-    Assert.assertEquals(event.getContainerId(),
+    assertEquals(event.getContainerId(),
         deserializedEvent.getContainerId());
-    Assert.assertEquals(event.getLaunchTime(),
+    assertEquals(event.getLaunchTime(),
         deserializedEvent.getLaunchTime());
-    Assert.assertEquals(event.getApplicationAttemptId(),
+    assertEquals(event.getApplicationAttemptId(),
         deserializedEvent.getApplicationAttemptId());
     logEvents(event, deserializedEvent);
   }
@@ -684,11 +686,11 @@ public class TestHistoryEventsProtoConversion {
             ApplicationId.newInstance(0, 1), 1));
     ContainerStoppedEvent deserializedEvent = (ContainerStoppedEvent)
         testProtoConversion(event);
-    Assert.assertEquals(event.getContainerId(),
+    assertEquals(event.getContainerId(),
         deserializedEvent.getContainerId());
-    Assert.assertEquals(event.getStoppedTime(),
+    assertEquals(event.getStoppedTime(),
         deserializedEvent.getStoppedTime());
-    Assert.assertEquals(event.getApplicationAttemptId(),
+    assertEquals(event.getApplicationAttemptId(),
         deserializedEvent.getApplicationAttemptId());
     logEvents(event, deserializedEvent);
   }
@@ -698,7 +700,7 @@ public class TestHistoryEventsProtoConversion {
         TezDAGID.getInstance(ApplicationId.newInstance(0, 1), 1), 100l);
     DAGCommitStartedEvent deserializedEvent =
         (DAGCommitStartedEvent) testProtoConversion(event);
-    Assert.assertEquals(event.getDagID(), deserializedEvent.getDagID());
+    assertEquals(event.getDagID(), deserializedEvent.getDagID());
     logEvents(event, deserializedEvent);
   }
 
@@ -708,7 +710,7 @@ public class TestHistoryEventsProtoConversion {
             TezDAGID.getInstance(ApplicationId.newInstance(0, 1), 1), 1), 100l);
     VertexCommitStartedEvent deserializedEvent =
         (VertexCommitStartedEvent) testProtoConversion(event);
-    Assert.assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
+    assertEquals(event.getVertexID(), deserializedEvent.getVertexID());
     logEvents(event, deserializedEvent);
   }
 
@@ -724,16 +726,16 @@ public class TestHistoryEventsProtoConversion {
     {
       VertexGroupCommitStartedEvent deserializedEvent =
           (VertexGroupCommitStartedEvent) testProtoConversion(event);
-      Assert.assertEquals(event.getDagID(), deserializedEvent.getDagID());
-      Assert.assertEquals(event.getVertexGroupName(),
+      assertEquals(event.getDagID(), deserializedEvent.getDagID());
+      assertEquals(event.getVertexGroupName(),
           deserializedEvent.getVertexGroupName());
-      Assert.assertEquals(event.getVertexIds(), vertexIds);
+      assertEquals(event.getVertexIds(), vertexIds);
       logEvents(event, deserializedEvent);
     }
     {
       VertexGroupCommitStartedEvent deserializedEvent =
           (VertexGroupCommitStartedEvent) testSummaryProtoConversion(event);
-      Assert.assertEquals(event.getVertexGroupName(),
+      assertEquals(event.getVertexGroupName(),
           deserializedEvent.getVertexGroupName());
       logEvents(event, deserializedEvent);
     }
@@ -751,16 +753,16 @@ public class TestHistoryEventsProtoConversion {
     {
       VertexGroupCommitFinishedEvent deserializedEvent =
           (VertexGroupCommitFinishedEvent) testProtoConversion(event);
-      Assert.assertEquals(event.getDagID(), deserializedEvent.getDagID());
-      Assert.assertEquals(event.getVertexGroupName(),
+      assertEquals(event.getDagID(), deserializedEvent.getDagID());
+      assertEquals(event.getVertexGroupName(),
           deserializedEvent.getVertexGroupName());
-      Assert.assertEquals(event.getVertexIds(), vertexIds);
+      assertEquals(event.getVertexIds(), vertexIds);
       logEvents(event, deserializedEvent);
     }
     {
       VertexGroupCommitFinishedEvent deserializedEvent =
           (VertexGroupCommitFinishedEvent) testSummaryProtoConversion(event);
-      Assert.assertEquals(event.getVertexGroupName(),
+      assertEquals(event.getVertexGroupName(),
           deserializedEvent.getVertexGroupName());
       logEvents(event, deserializedEvent);
     }
@@ -853,11 +855,11 @@ public class TestHistoryEventsProtoConversion {
         "mockDagname", "mockuser", 100334l, null);
     try {
       testProtoConversion(dagRecoveredEvent);
-      Assert.fail("Proto conversion should have failed");
+      fail("Proto conversion should have failed");
     } catch (UnsupportedOperationException e) {
       // Expected
     } catch (IOException e) {
-      Assert.fail("Proto conversion should have failed with Unsupported Exception");
+      fail("Proto conversion should have failed with Unsupported Exception");
     }
 
   }

--- a/tez-dag/src/test/java/org/apache/tez/dag/history/logging/impl/TestHistoryEventJsonConversion.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/history/logging/impl/TestHistoryEventJsonConversion.java
@@ -17,10 +17,14 @@
  * under the License.
  */
 package org.apache.tez.dag.history.logging.impl;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -75,9 +79,9 @@ import org.apache.tez.dag.records.TezVertexID;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestHistoryEventJsonConversion {
 
@@ -94,7 +98,7 @@ public class TestHistoryEventJsonConversion {
   private NodeId nodeId;
 
   @SuppressWarnings("deprecation")
-  @Before
+  @BeforeEach
   public void setup() {
     applicationId = ApplicationId.newInstance(9999l, 1);
     applicationAttemptId = ApplicationAttemptId.newInstance(applicationId, 1);
@@ -107,7 +111,8 @@ public class TestHistoryEventJsonConversion {
     nodeId = NodeId.newInstance("node", 13435);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testHandlerExists() throws JSONException {
     for (HistoryEventType eventType : HistoryEventType.values()) {
       HistoryEvent event = null;
@@ -196,7 +201,7 @@ public class TestHistoryEventJsonConversion {
           event = new DAGKillRequestEvent();
           break;
         default:
-          Assert.fail("Unhandled event type " + eventType);
+          fail("Unhandled event type " + eventType);
       }
       if (event == null || !event.isHistoryEvent()) {
         continue;
@@ -204,18 +209,19 @@ public class TestHistoryEventJsonConversion {
       JSONObject json = HistoryEventJsonConversion.convertToJson(event);
       if (eventType == HistoryEventType.DAG_SUBMITTED) {
         try {
-          Assert.assertEquals("Q_" + eventType.name(), json.getJSONObject(ATSConstants.OTHER_INFO)
+          assertEquals("Q_" + eventType.name(), json.getJSONObject(ATSConstants.OTHER_INFO)
               .getString(ATSConstants.DAG_QUEUE_NAME));
-          Assert.assertEquals("Q_" + eventType.name(), json
+          assertEquals("Q_" + eventType.name(), json
               .getJSONObject(ATSConstants.PRIMARY_FILTERS).getString(ATSConstants.DAG_QUEUE_NAME));
         } catch (JSONException ex) {
-          Assert.fail("Exception: " + ex.getMessage() + " for type: " + eventType);
+          fail("Exception: " + ex.getMessage() + " for type: " + eventType);
         }
       }
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertVertexReconfigureDoneEvent() throws JSONException {
     TezVertexID vId = TezVertexID.getInstance(
         TezDAGID.getInstance(
@@ -230,30 +236,30 @@ public class TestHistoryEventJsonConversion {
         edgeMgrs, null, true);
 
     JSONObject jsonObject = HistoryEventJsonConversion.convertToJson(event);
-    Assert.assertNotNull(jsonObject);
-    Assert.assertEquals(vId.toString(), jsonObject.getString(ATSConstants.ENTITY_ID));
-    Assert.assertEquals(ATSConstants.TEZ_VERTEX_ID, jsonObject.get(ATSConstants.ENTITY_TYPE));
+    assertNotNull(jsonObject);
+    assertEquals(vId.toString(), jsonObject.getString(ATSConstants.ENTITY_ID));
+    assertEquals(ATSConstants.TEZ_VERTEX_ID, jsonObject.get(ATSConstants.ENTITY_TYPE));
 
     JSONArray events = jsonObject.getJSONArray(ATSConstants.EVENTS);
-    Assert.assertEquals(1, events.length());
+    assertEquals(1, events.length());
 
     JSONObject evt = events.getJSONObject(0);
-    Assert.assertEquals(HistoryEventType.VERTEX_CONFIGURE_DONE.name(),
+    assertEquals(HistoryEventType.VERTEX_CONFIGURE_DONE.name(),
         evt.getString(ATSConstants.EVENT_TYPE));
 
     JSONObject evtInfo = evt.getJSONObject(ATSConstants.EVENT_INFO);
-    Assert.assertEquals(1, evtInfo.getInt(ATSConstants.NUM_TASKS));
-    Assert.assertNotNull(evtInfo.getJSONObject(ATSConstants.UPDATED_EDGE_MANAGERS));
+    assertEquals(1, evtInfo.getInt(ATSConstants.NUM_TASKS));
+    assertNotNull(evtInfo.getJSONObject(ATSConstants.UPDATED_EDGE_MANAGERS));
 
     JSONObject updatedEdgeMgrs = evtInfo.getJSONObject(ATSConstants.UPDATED_EDGE_MANAGERS);
-    Assert.assertEquals(1, updatedEdgeMgrs.length());
-    Assert.assertNotNull(updatedEdgeMgrs.getJSONObject("a"));
+    assertEquals(1, updatedEdgeMgrs.length());
+    assertNotNull(updatedEdgeMgrs.getJSONObject("a"));
     JSONObject updatedEdgeMgr = updatedEdgeMgrs.getJSONObject("a");
 
-    Assert.assertEquals(DataMovementType.CUSTOM.name(),
+    assertEquals(DataMovementType.CUSTOM.name(),
         updatedEdgeMgr.getString(DAGUtils.DATA_MOVEMENT_TYPE_KEY));
-    Assert.assertEquals("In", updatedEdgeMgr.getString(DAGUtils.EDGE_DESTINATION_CLASS_KEY));
-    Assert.assertEquals("a.class", updatedEdgeMgr.getString(DAGUtils.EDGE_MANAGER_CLASS_KEY));
+    assertEquals("In", updatedEdgeMgr.getString(DAGUtils.EDGE_DESTINATION_CLASS_KEY));
+    assertEquals("a.class", updatedEdgeMgr.getString(DAGUtils.EDGE_MANAGER_CLASS_KEY));
 
   }
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/history/logging/impl/TestHistoryEventJsonConversion.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/history/logging/impl/TestHistoryEventJsonConversion.java
@@ -209,10 +209,10 @@ public class TestHistoryEventJsonConversion {
       JSONObject json = HistoryEventJsonConversion.convertToJson(event);
       if (eventType == HistoryEventType.DAG_SUBMITTED) {
         try {
-          assertEquals("Q_" + eventType.name(), json.getJSONObject(ATSConstants.OTHER_INFO)
-              .getString(ATSConstants.DAG_QUEUE_NAME));
-          assertEquals("Q_" + eventType.name(), json
-              .getJSONObject(ATSConstants.PRIMARY_FILTERS).getString(ATSConstants.DAG_QUEUE_NAME));
+          assertEquals("Q_" + eventType.name(),
+              json.getJSONObject(ATSConstants.OTHER_INFO).getString(ATSConstants.DAG_QUEUE_NAME));
+          assertEquals("Q_" + eventType.name(),
+              json.getJSONObject(ATSConstants.PRIMARY_FILTERS).getString(ATSConstants.DAG_QUEUE_NAME));
         } catch (JSONException ex) {
           fail("Exception: " + ex.getMessage() + " for type: " + eventType);
         }
@@ -244,8 +244,7 @@ public class TestHistoryEventJsonConversion {
     assertEquals(1, events.length());
 
     JSONObject evt = events.getJSONObject(0);
-    assertEquals(HistoryEventType.VERTEX_CONFIGURE_DONE.name(),
-        evt.getString(ATSConstants.EVENT_TYPE));
+    assertEquals(HistoryEventType.VERTEX_CONFIGURE_DONE.name(), evt.getString(ATSConstants.EVENT_TYPE));
 
     JSONObject evtInfo = evt.getJSONObject(ATSConstants.EVENT_INFO);
     assertEquals(1, evtInfo.getInt(ATSConstants.NUM_TASKS));
@@ -256,12 +255,8 @@ public class TestHistoryEventJsonConversion {
     assertNotNull(updatedEdgeMgrs.getJSONObject("a"));
     JSONObject updatedEdgeMgr = updatedEdgeMgrs.getJSONObject("a");
 
-    assertEquals(DataMovementType.CUSTOM.name(),
-        updatedEdgeMgr.getString(DAGUtils.DATA_MOVEMENT_TYPE_KEY));
+    assertEquals(DataMovementType.CUSTOM.name(), updatedEdgeMgr.getString(DAGUtils.DATA_MOVEMENT_TYPE_KEY));
     assertEquals("In", updatedEdgeMgr.getString(DAGUtils.EDGE_DESTINATION_CLASS_KEY));
     assertEquals("a.class", updatedEdgeMgr.getString(DAGUtils.EDGE_MANAGER_CLASS_KEY));
-
   }
-
-
 }

--- a/tez-dag/src/test/java/org/apache/tez/dag/history/recovery/TestRecoveryService.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/history/recovery/TestRecoveryService.java
@@ -18,9 +18,9 @@
  */
 package org.apache.tez.dag.history.recovery;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.conf.Configuration;
@@ -63,7 +64,8 @@ import org.apache.tez.dag.records.TezTaskID;
 import org.apache.tez.dag.records.TezVertexID;
 import org.apache.tez.hadoop.shim.DefaultHadoopShim;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestRecoveryService {
 
@@ -132,7 +134,8 @@ public class TestRecoveryService {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDrainEvents() throws Exception {
     setup(false, null);
     recoveryService.start();
@@ -145,7 +148,8 @@ public class TestRecoveryService {
     assertEquals(randEventCount, recoveryService.processedRecoveryEventCounter.get());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleDAGFinishedEvent() throws Exception {
     setup(false, null);
     recoveryService.start();
@@ -171,7 +175,8 @@ public class TestRecoveryService {
     recoveryService.stop();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSummaryPathExisted() throws Exception {
     setup(false, null);
     recoveryService.start();
@@ -188,7 +193,8 @@ public class TestRecoveryService {
     recoveryService.stop();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRecoveryPathExisted() throws Exception {
     setup(false, null);
     recoveryService.start();
@@ -205,7 +211,8 @@ public class TestRecoveryService {
     recoveryService.stop();
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRecoveryFlushOnMaxEvents() throws Exception {
     setup(true, new String[][] {
         {TezConfiguration.DAG_RECOVERY_MAX_UNFLUSHED_EVENTS, "10"},
@@ -230,7 +237,8 @@ public class TestRecoveryService {
     recoveryService.stop();
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testRecoveryFlushOnTimeoutEvents() throws Exception {
     setup(true, new String[][] {
       {TezConfiguration.DAG_RECOVERY_MAX_UNFLUSHED_EVENTS, "-1"},
@@ -258,7 +266,8 @@ public class TestRecoveryService {
     recoveryService.stop();
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testRecoveryFlush() throws Exception {
     setup(true, new String[][] {
       {TezConfiguration.DAG_RECOVERY_MAX_UNFLUSHED_EVENTS, "10"},
@@ -296,7 +305,8 @@ public class TestRecoveryService {
     recoveryService.stop();
   }
 
-  @Test(timeout=50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testRecoveryFlushOnStop() throws Exception {
     setup(true, new String[][] {
       {TezConfiguration.DAG_RECOVERY_MAX_UNFLUSHED_EVENTS, "-1"},
@@ -324,7 +334,8 @@ public class TestRecoveryService {
     verify(dagFos, times(1)).hflush();
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRecoveryFlushOnSummaryEvent() throws Exception {
     setup(true, new String[][] {
       {TezConfiguration.DAG_RECOVERY_MAX_UNFLUSHED_EVENTS, "-1"},

--- a/tez-dag/src/test/java/org/apache/tez/dag/history/utils/TestDAGUtils.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/history/utils/TestDAGUtils.java
@@ -18,12 +18,17 @@
  */
 package org.apache.tez.dag.history.utils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -49,8 +54,8 @@ import org.apache.tez.dag.records.TezVertexID;
 import org.apache.tez.runtime.api.OutputCommitter;
 
 import org.codehaus.jettison.json.JSONException;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestDAGUtils {
 
@@ -98,7 +103,8 @@ public class TestDAGUtils {
     return dag.createDag(conf, null, null, null, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   @SuppressWarnings("unchecked")
   public void testConvertDAGPlanToATSMap() throws IOException, JSONException {
     DAGPlan dagPlan = createDAG("testConvertDAGPlanToATSMap");
@@ -113,26 +119,26 @@ public class TestDAGUtils {
     idNameMap.put("vertex3", vId3);
 
     Map<String, Object> atsMap = DAGUtils.convertDAGPlanToATSMap(dagPlan);
-    Assert.assertTrue(atsMap.containsKey(DAGUtils.DAG_NAME_KEY));
-    Assert.assertEquals("DAG-testConvertDAGPlanToATSMap",
+    assertTrue(atsMap.containsKey(DAGUtils.DAG_NAME_KEY));
+    assertEquals("DAG-testConvertDAGPlanToATSMap",
         atsMap.get(DAGUtils.DAG_NAME_KEY));
-    Assert.assertTrue(atsMap.containsKey(DAGUtils.DAG_INFO_KEY));
-    Assert.assertTrue(atsMap.containsKey(DAGUtils.DAG_CONTEXT_KEY));
+    assertTrue(atsMap.containsKey(DAGUtils.DAG_INFO_KEY));
+    assertTrue(atsMap.containsKey(DAGUtils.DAG_CONTEXT_KEY));
     Map<String, String> contextMap = (Map<String, String>)atsMap.get(DAGUtils.DAG_CONTEXT_KEY);
-    Assert.assertEquals("context1", contextMap.get(ATSConstants.CONTEXT));
-    Assert.assertEquals("callerId1", contextMap.get(ATSConstants.CALLER_ID));
-    Assert.assertEquals("callerType1", contextMap.get(ATSConstants.CALLER_TYPE));
-    Assert.assertEquals("desc1", contextMap.get(ATSConstants.DESCRIPTION));
+    assertEquals("context1", contextMap.get(ATSConstants.CONTEXT));
+    assertEquals("callerId1", contextMap.get(ATSConstants.CALLER_ID));
+    assertEquals("callerType1", contextMap.get(ATSConstants.CALLER_TYPE));
+    assertEquals("desc1", contextMap.get(ATSConstants.DESCRIPTION));
 
-    Assert.assertEquals("dagInfo", atsMap.get(DAGUtils.DAG_INFO_KEY));
-    Assert.assertEquals(dagPlan.getName(), atsMap.get(DAGUtils.DAG_NAME_KEY));
-    Assert.assertTrue(atsMap.containsKey("version"));
-    Assert.assertEquals(2, atsMap.get("version"));
-    Assert.assertTrue(atsMap.containsKey(DAGUtils.VERTICES_KEY));
-    Assert.assertTrue(atsMap.containsKey(DAGUtils.EDGES_KEY));
-    Assert.assertTrue(atsMap.containsKey(DAGUtils.VERTEX_GROUPS_KEY));
+    assertEquals("dagInfo", atsMap.get(DAGUtils.DAG_INFO_KEY));
+    assertEquals(dagPlan.getName(), atsMap.get(DAGUtils.DAG_NAME_KEY));
+    assertTrue(atsMap.containsKey("version"));
+    assertEquals(2, atsMap.get("version"));
+    assertTrue(atsMap.containsKey(DAGUtils.VERTICES_KEY));
+    assertTrue(atsMap.containsKey(DAGUtils.EDGES_KEY));
+    assertTrue(atsMap.containsKey(DAGUtils.VERTEX_GROUPS_KEY));
 
-    Assert.assertEquals(3, ((Collection<?>) atsMap.get(DAGUtils.VERTICES_KEY)).size());
+    assertEquals(3, ((Collection<?>) atsMap.get(DAGUtils.VERTICES_KEY)).size());
 
     Set<String> inEdgeIds = new HashSet<String>();
     Set<String> outEdgeIds = new HashSet<String>();
@@ -142,10 +148,10 @@ public class TestDAGUtils {
 
     for (Object o : ((Collection<?>) atsMap.get(DAGUtils.VERTICES_KEY))) {
       Map<String, Object> v = (Map<String, Object>) o;
-      Assert.assertTrue(v.containsKey(DAGUtils.VERTEX_NAME_KEY));
+      assertTrue(v.containsKey(DAGUtils.VERTEX_NAME_KEY));
       String vName = (String)v.get(DAGUtils.VERTEX_NAME_KEY);
-      Assert.assertTrue(v.containsKey(DAGUtils.PROCESSOR_CLASS_KEY));
-      Assert.assertTrue(v.containsKey(DAGUtils.USER_PAYLOAD_AS_TEXT));
+      assertTrue(v.containsKey(DAGUtils.PROCESSOR_CLASS_KEY));
+      assertTrue(v.containsKey(DAGUtils.USER_PAYLOAD_AS_TEXT));
 
       if (v.containsKey(DAGUtils.IN_EDGE_IDS_KEY)) {
         inEdgeIds.addAll(((Collection<String>) v.get(DAGUtils.IN_EDGE_IDS_KEY)));
@@ -154,18 +160,18 @@ public class TestDAGUtils {
         outEdgeIds.addAll(((Collection<String>) v.get(DAGUtils.OUT_EDGE_IDS_KEY)));
       }
 
-      Assert.assertTrue(idNameMap.containsKey(vName));
+      assertTrue(idNameMap.containsKey(vName));
       String procPayload = vName + " Processor HistoryText";
-      Assert.assertEquals(procPayload, v.get(DAGUtils.USER_PAYLOAD_AS_TEXT));
+      assertEquals(procPayload, v.get(DAGUtils.USER_PAYLOAD_AS_TEXT));
 
       if (v.containsKey(DAGUtils.ADDITIONAL_INPUTS_KEY)) {
         additionalInputCount += ((Collection<?>) v.get(DAGUtils.ADDITIONAL_INPUTS_KEY)).size();
         for (Object input : ((Collection<?>) v.get(DAGUtils.ADDITIONAL_INPUTS_KEY))) {
           Map<String, Object> inputMap = (Map<String, Object>) input;
-          Assert.assertTrue(inputMap.containsKey(DAGUtils.NAME_KEY));
-          Assert.assertTrue(inputMap.containsKey(DAGUtils.CLASS_KEY));
-          Assert.assertFalse(inputMap.containsKey(DAGUtils.INITIALIZER_KEY));
-          Assert.assertEquals("input HistoryText", inputMap.get(DAGUtils.USER_PAYLOAD_AS_TEXT));
+          assertTrue(inputMap.containsKey(DAGUtils.NAME_KEY));
+          assertTrue(inputMap.containsKey(DAGUtils.CLASS_KEY));
+          assertFalse(inputMap.containsKey(DAGUtils.INITIALIZER_KEY));
+          assertEquals("input HistoryText", inputMap.get(DAGUtils.USER_PAYLOAD_AS_TEXT));
         }
       }
 
@@ -173,46 +179,46 @@ public class TestDAGUtils {
         additionalOutputCount += ((Collection<?>) v.get(DAGUtils.ADDITIONAL_OUTPUTS_KEY)).size();
         for (Object output : ((Collection<?>) v.get(DAGUtils.ADDITIONAL_OUTPUTS_KEY))) {
           Map<String, Object> outputMap = (Map<String, Object>) output;
-          Assert.assertTrue(outputMap.containsKey(DAGUtils.NAME_KEY));
-          Assert.assertTrue(outputMap.containsKey(DAGUtils.CLASS_KEY));
-          Assert.assertTrue(outputMap.containsKey(DAGUtils.INITIALIZER_KEY));
-          Assert.assertEquals("uvOut HistoryText", outputMap.get(DAGUtils.USER_PAYLOAD_AS_TEXT));
+          assertTrue(outputMap.containsKey(DAGUtils.NAME_KEY));
+          assertTrue(outputMap.containsKey(DAGUtils.CLASS_KEY));
+          assertTrue(outputMap.containsKey(DAGUtils.INITIALIZER_KEY));
+          assertEquals("uvOut HistoryText", outputMap.get(DAGUtils.USER_PAYLOAD_AS_TEXT));
         }
       }
     }
 
     // 1 input
-    Assert.assertEquals(1, additionalInputCount);
+    assertEquals(1, additionalInputCount);
     // 3 outputs due to vertex group
-    Assert.assertEquals(3, additionalOutputCount);
+    assertEquals(3, additionalOutputCount);
 
     // 1 edge translates to 2 due to vertex group
-    Assert.assertEquals(2, inEdgeIds.size());
-    Assert.assertEquals(2, outEdgeIds.size());
+    assertEquals(2, inEdgeIds.size());
+    assertEquals(2, outEdgeIds.size());
 
     for (Object o : ((Collection<?>) atsMap.get(DAGUtils.EDGES_KEY))) {
       Map<String, Object> e = (Map<String, Object>) o;
 
-      Assert.assertTrue(inEdgeIds.contains(e.get(DAGUtils.EDGE_ID_KEY)));
-      Assert.assertTrue(outEdgeIds.contains(e.get(DAGUtils.EDGE_ID_KEY)));
-      Assert.assertTrue(e.containsKey(DAGUtils.INPUT_VERTEX_NAME_KEY));
-      Assert.assertTrue(e.containsKey(DAGUtils.OUTPUT_VERTEX_NAME_KEY));
-      Assert.assertEquals(DataMovementType.SCATTER_GATHER.name(),
+      assertTrue(inEdgeIds.contains(e.get(DAGUtils.EDGE_ID_KEY)));
+      assertTrue(outEdgeIds.contains(e.get(DAGUtils.EDGE_ID_KEY)));
+      assertTrue(e.containsKey(DAGUtils.INPUT_VERTEX_NAME_KEY));
+      assertTrue(e.containsKey(DAGUtils.OUTPUT_VERTEX_NAME_KEY));
+      assertEquals(DataMovementType.SCATTER_GATHER.name(),
           e.get(DAGUtils.DATA_MOVEMENT_TYPE_KEY));
-      Assert.assertEquals(DataSourceType.PERSISTED.name(), e.get(DAGUtils.DATA_SOURCE_TYPE_KEY));
-      Assert.assertEquals(SchedulingType.SEQUENTIAL.name(), e.get(DAGUtils.SCHEDULING_TYPE_KEY));
-      Assert.assertEquals("dummy output class", e.get(DAGUtils.EDGE_SOURCE_CLASS_KEY));
-      Assert.assertEquals("dummy input class", e.get(DAGUtils.EDGE_DESTINATION_CLASS_KEY));
-      Assert.assertEquals("Dummy History Text", e.get(DAGUtils.OUTPUT_USER_PAYLOAD_AS_TEXT));
-      Assert.assertEquals("Dummy History Text", e.get(DAGUtils.INPUT_USER_PAYLOAD_AS_TEXT));
+      assertEquals(DataSourceType.PERSISTED.name(), e.get(DAGUtils.DATA_SOURCE_TYPE_KEY));
+      assertEquals(SchedulingType.SEQUENTIAL.name(), e.get(DAGUtils.SCHEDULING_TYPE_KEY));
+      assertEquals("dummy output class", e.get(DAGUtils.EDGE_SOURCE_CLASS_KEY));
+      assertEquals("dummy input class", e.get(DAGUtils.EDGE_DESTINATION_CLASS_KEY));
+      assertEquals("Dummy History Text", e.get(DAGUtils.OUTPUT_USER_PAYLOAD_AS_TEXT));
+      assertEquals("Dummy History Text", e.get(DAGUtils.INPUT_USER_PAYLOAD_AS_TEXT));
     }
 
     for (Object o : ((Collection<?>) atsMap.get(DAGUtils.VERTEX_GROUPS_KEY))) {
       Map<String, Object> e = (Map<String, Object>) o;
-      Assert.assertEquals("uv12", e.get(DAGUtils.VERTEX_GROUP_NAME_KEY));
-      Assert.assertTrue(e.containsKey(DAGUtils.VERTEX_GROUP_MEMBERS_KEY));
-      Assert.assertTrue(e.containsKey(DAGUtils.VERTEX_GROUP_OUTPUTS_KEY));
-      Assert.assertTrue(e.containsKey(DAGUtils.VERTEX_GROUP_EDGE_MERGED_INPUTS_KEY));
+      assertEquals("uv12", e.get(DAGUtils.VERTEX_GROUP_NAME_KEY));
+      assertTrue(e.containsKey(DAGUtils.VERTEX_GROUP_MEMBERS_KEY));
+      assertTrue(e.containsKey(DAGUtils.VERTEX_GROUP_OUTPUTS_KEY));
+      assertTrue(e.containsKey(DAGUtils.VERTEX_GROUP_EDGE_MERGED_INPUTS_KEY));
     }
   }
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/utils/TestSimple2LevelVersionComparator.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/utils/TestSimple2LevelVersionComparator.java
@@ -18,48 +18,55 @@
  */
 package org.apache.tez.dag.utils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestSimple2LevelVersionComparator {
 
   private final Simple2LevelVersionComparator comparator = new Simple2LevelVersionComparator();
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasicEqualChecks() {
-    Assert.assertEquals(0, comparator.compare("1-SNAPSHOT", "1-SNAPSHOT"));
-    Assert.assertEquals(0, comparator.compare("1.1-SNAPSHOT", "1.1-SNAPSHOT"));
-    Assert.assertEquals(0, comparator.compare("1.1.0-SNAPSHOT", "1.1.0-SNAPSHOT"));
-    Assert.assertEquals(0, comparator.compare("0.1.0", "0.1.0"));
-    Assert.assertEquals(0, comparator.compare("0.1", "0.1"));
-    Assert.assertEquals(0, comparator.compare("0.1.2", "0.1.3"));
-    Assert.assertEquals(0, comparator.compare("1.1.2", "1.1.5-RC"));
-    Assert.assertEquals(0, comparator.compare("1", "1"));
-    Assert.assertEquals(0, comparator.compare("1.1.x", "1.1.x"));
-    Assert.assertEquals(0, comparator.compare("1-SNAP.x", "1-SNAP.x"));
+    assertEquals(0, comparator.compare("1-SNAPSHOT", "1-SNAPSHOT"));
+    assertEquals(0, comparator.compare("1.1-SNAPSHOT", "1.1-SNAPSHOT"));
+    assertEquals(0, comparator.compare("1.1.0-SNAPSHOT", "1.1.0-SNAPSHOT"));
+    assertEquals(0, comparator.compare("0.1.0", "0.1.0"));
+    assertEquals(0, comparator.compare("0.1", "0.1"));
+    assertEquals(0, comparator.compare("0.1.2", "0.1.3"));
+    assertEquals(0, comparator.compare("1.1.2", "1.1.5-RC"));
+    assertEquals(0, comparator.compare("1", "1"));
+    assertEquals(0, comparator.compare("1.1.x", "1.1.x"));
+    assertEquals(0, comparator.compare("1-SNAP.x", "1-SNAP.x"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidVersions() {
-    Assert.assertEquals(-1, comparator.compare("x.1", "x.1"));
-    Assert.assertEquals(-1, comparator.compare("x.1", "0.1"));
-    Assert.assertEquals(-1, comparator.compare("1.x", "1.1"));
-    Assert.assertEquals(-1, comparator.compare("1.1", "x.1"));
-    Assert.assertEquals(-1, comparator.compare("1.1", "1.x"));
-    Assert.assertEquals(-1, comparator.compare("1.1", "Unknown"));
-    Assert.assertEquals(-1, comparator.compare("Unknown", "1.1"));
-    Assert.assertEquals(-1, comparator.compare("Unknown", "Unknown"));
+    assertEquals(-1, comparator.compare("x.1", "x.1"));
+    assertEquals(-1, comparator.compare("x.1", "0.1"));
+    assertEquals(-1, comparator.compare("1.x", "1.1"));
+    assertEquals(-1, comparator.compare("1.1", "x.1"));
+    assertEquals(-1, comparator.compare("1.1", "1.x"));
+    assertEquals(-1, comparator.compare("1.1", "Unknown"));
+    assertEquals(-1, comparator.compare("Unknown", "1.1"));
+    assertEquals(-1, comparator.compare("Unknown", "Unknown"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInequalityChecks() {
-    Assert.assertEquals(-1, comparator.compare("1.1", "2.1"));
-    Assert.assertEquals(1, comparator.compare("1.1", "0.1"));
-    Assert.assertEquals(1, comparator.compare("1.1.2", "0.1.2"));
-    Assert.assertEquals(-1, comparator.compare("1.1.9", "4.1.9"));
-    Assert.assertEquals(-1, comparator.compare("1.1-RC", "2.1.x"));
-    Assert.assertEquals(-1, comparator.compare("1.1", ""));
-    Assert.assertEquals(-1, comparator.compare("", "1.1"));
+    assertEquals(-1, comparator.compare("1.1", "2.1"));
+    assertEquals(1, comparator.compare("1.1", "0.1"));
+    assertEquals(1, comparator.compare("1.1.2", "0.1.2"));
+    assertEquals(-1, comparator.compare("1.1.9", "4.1.9"));
+    assertEquals(-1, comparator.compare("1.1-RC", "2.1.x"));
+    assertEquals(-1, comparator.compare("1.1", ""));
+    assertEquals(-1, comparator.compare("", "1.1"));
   }
 
 

--- a/tez-dag/src/test/java/org/apache/tez/dag/utils/TestTaskSpecificLaunchCmdOption.java
+++ b/tez-dag/src/test/java/org/apache/tez/dag/utils/TestTaskSpecificLaunchCmdOption.java
@@ -18,16 +18,18 @@
  */
 package org.apache.tez.dag.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.dag.api.TezConfiguration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTaskSpecificLaunchCmdOption {
   static Configuration conf = new Configuration();
@@ -43,7 +45,8 @@ public class TestTaskSpecificLaunchCmdOption {
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSpecificJavaOptions() {
     Random rnd = new Random();
     Configuration conf = new Configuration();
@@ -248,34 +251,36 @@ public class TestTaskSpecificLaunchCmdOption {
         rnd.nextInt(Integer.MAX_VALUE)));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConfigOptions() {
     Configuration conf = new Configuration();
     TaskSpecificLaunchCmdOption taskSpecificLaunchCmdOption = getOptions(conf, "", "");
     String optionStr = taskSpecificLaunchCmdOption.getTaskSpecificOption("", "", 0);
-    assertTrue(optionStr.trim().equals(""));
+    assertEquals("", optionStr.trim());
 
     taskSpecificLaunchCmdOption = getOptions(conf, "", "dir=__VERTEX_NAME__");
     optionStr = taskSpecificLaunchCmdOption.getTaskSpecificOption("", "Map 1", 0);
-    assertTrue(optionStr.equals("dir=Map1"));
+    assertEquals("dir=Map1", optionStr);
 
     taskSpecificLaunchCmdOption = getOptions(conf, "", "dir=__TASK_INDEX__");
     optionStr = taskSpecificLaunchCmdOption.getTaskSpecificOption("", "Map 1", 0);
-    assertTrue(optionStr.equals("dir=0"));
+    assertEquals("dir=0", optionStr);
 
     taskSpecificLaunchCmdOption = getOptions(conf, "v[1,3,4]", "dir=/tmp/__VERTEX_NAME__/__TASK_INDEX__");
     optionStr = taskSpecificLaunchCmdOption.getTaskSpecificOption("", "v", 1);
-    assertTrue(optionStr.equals("dir=/tmp/v/1"));
+    assertEquals("dir=/tmp/v/1", optionStr);
 
     optionStr = taskSpecificLaunchCmdOption.getTaskSpecificOption("", "v", 3);
-    assertTrue(optionStr.equals("dir=/tmp/v/3"));
+    assertEquals("dir=/tmp/v/3", optionStr);
 
     optionStr = taskSpecificLaunchCmdOption.getTaskSpecificOption("", "v", 4);
-    assertTrue(optionStr.equals("dir=/tmp/v/4"));
+    assertEquals("dir=/tmp/v/4", optionStr);
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSpecificLogOptions() {
     Configuration conf = new Configuration(false);
     conf.set(TezConfiguration.TEZ_TASK_SPECIFIC_LAUNCH_CMD_OPTS_LIST, "v1[0,2,5]");
@@ -299,7 +304,8 @@ public class TestTaskSpecificLaunchCmdOption {
     assertEquals(1, options.getTaskSpecificLogParams().length);
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSpecificLogOptionsWithCommandOptions() {
     Configuration conf = new Configuration(false);
     conf.set(TezConfiguration.TEZ_TASK_SPECIFIC_LAUNCH_CMD_OPTS_LIST, "v1[0,2,5]");
@@ -311,6 +317,6 @@ public class TestTaskSpecificLaunchCmdOption {
     assertTrue(options.hasModifiedLogProperties());
     assertTrue(options.hasModifiedTaskLaunchOpts());
     String optionStr = options.getTaskSpecificOption("", "v", 0);
-    assertTrue(optionStr.equals("-Xmx128m"));
+    assertEquals("-Xmx128m", optionStr);
   }
 }

--- a/tez-dag/src/test/java/org/apache/tez/test/VertexManagerPluginForTest.java
+++ b/tez-dag/src/test/java/org/apache/tez/test/VertexManagerPluginForTest.java
@@ -36,7 +36,6 @@ import org.apache.tez.runtime.api.Event;
 import org.apache.tez.runtime.api.TaskAttemptIdentifier;
 import org.apache.tez.runtime.api.events.VertexManagerEvent;
 
-
 public class VertexManagerPluginForTest extends VertexManagerPlugin {
   VertexManagerPluginForTestConfig pluginConfig = new VertexManagerPluginForTestConfig();
 

--- a/tez-dag/src/test/java/org/apache/tez/test/VertexManagerPluginForTest.java
+++ b/tez-dag/src/test/java/org/apache/tez/test/VertexManagerPluginForTest.java
@@ -36,6 +36,7 @@ import org.apache.tez.runtime.api.Event;
 import org.apache.tez.runtime.api.TaskAttemptIdentifier;
 import org.apache.tez.runtime.api.events.VertexManagerEvent;
 
+
 public class VertexManagerPluginForTest extends VertexManagerPlugin {
   VertexManagerPluginForTestConfig pluginConfig = new VertexManagerPluginForTestConfig();
 

--- a/tez-examples/pom.xml
+++ b/tez-examples/pom.xml
@@ -80,11 +80,6 @@
       <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
     </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   
   <build>

--- a/tez-ext-service-tests/pom.xml
+++ b/tez-ext-service-tests/pom.xml
@@ -58,10 +58,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -114,8 +110,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
   </dependencies>
 

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/TezTestServiceCommunicator.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/TezTestServiceCommunicator.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tez.dag.app;
 
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -41,6 +40,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.Message;
+
 
 public class TezTestServiceCommunicator extends AbstractService {
 

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/TezTestServiceCommunicator.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/TezTestServiceCommunicator.java
@@ -41,7 +41,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.Message;
 
-
 public class TezTestServiceCommunicator extends AbstractService {
 
   private final ConcurrentMap<String, TezTestServiceProtocolBlockingPB> hostProxies;

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/launcher/TezTestServiceContainerLauncherWithErrors.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/launcher/TezTestServiceContainerLauncherWithErrors.java
@@ -26,7 +26,6 @@ import org.apache.tez.serviceplugins.api.ContainerLauncher;
 import org.apache.tez.serviceplugins.api.ContainerLauncherContext;
 import org.apache.tez.serviceplugins.api.ContainerStopRequest;
 
-
 public class TezTestServiceContainerLauncherWithErrors extends ContainerLauncher {
 
   private final ErrorPluginConfiguration conf;

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/launcher/TezTestServiceContainerLauncherWithErrors.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/launcher/TezTestServiceContainerLauncherWithErrors.java
@@ -26,6 +26,7 @@ import org.apache.tez.serviceplugins.api.ContainerLauncher;
 import org.apache.tez.serviceplugins.api.ContainerLauncherContext;
 import org.apache.tez.serviceplugins.api.ContainerStopRequest;
 
+
 public class TezTestServiceContainerLauncherWithErrors extends ContainerLauncher {
 
   private final ErrorPluginConfiguration conf;

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/rm/TezTestServiceTaskSchedulerServiceWithErrors.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/rm/TezTestServiceTaskSchedulerServiceWithErrors.java
@@ -31,6 +31,7 @@ import org.apache.tez.serviceplugins.api.TaskAttemptEndReason;
 import org.apache.tez.serviceplugins.api.TaskScheduler;
 import org.apache.tez.serviceplugins.api.TaskSchedulerContext;
 
+
 public class TezTestServiceTaskSchedulerServiceWithErrors extends TaskScheduler {
 
   private final ErrorPluginConfiguration conf;

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/taskcomm/TezTestServiceTaskCommunicatorWithErrors.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/taskcomm/TezTestServiceTaskCommunicatorWithErrors.java
@@ -37,7 +37,6 @@ import org.apache.tez.serviceplugins.api.TaskAttemptEndReason;
 import org.apache.tez.serviceplugins.api.TaskCommunicator;
 import org.apache.tez.serviceplugins.api.TaskCommunicatorContext;
 
-
 public class TezTestServiceTaskCommunicatorWithErrors extends TaskCommunicator {
 
   private final ErrorPluginConfiguration conf;

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/taskcomm/TezTestServiceTaskCommunicatorWithErrors.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/dag/app/taskcomm/TezTestServiceTaskCommunicatorWithErrors.java
@@ -37,6 +37,7 @@ import org.apache.tez.serviceplugins.api.TaskAttemptEndReason;
 import org.apache.tez.serviceplugins.api.TaskCommunicator;
 import org.apache.tez.serviceplugins.api.TaskCommunicatorContext;
 
+
 public class TezTestServiceTaskCommunicatorWithErrors extends TaskCommunicator {
 
   private final ErrorPluginConfiguration conf;

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/examples/JoinValidateConfigured.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/examples/JoinValidateConfigured.java
@@ -18,13 +18,13 @@
  */
 package org.apache.tez.examples;
 
-
 import java.io.IOException;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.tez.dag.api.DAG;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.Vertex.VertexExecutionContext;
+
 
 public class JoinValidateConfigured extends JoinValidate {
 

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/examples/JoinValidateConfigured.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/examples/JoinValidateConfigured.java
@@ -25,7 +25,6 @@ import org.apache.tez.dag.api.DAG;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.Vertex.VertexExecutionContext;
 
-
 public class JoinValidateConfigured extends JoinValidate {
 
   private final VertexExecutionContext defaultExecutionContext;

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/service/ContainerRunner.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/service/ContainerRunner.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tez.service;
 
-
 import org.apache.tez.dag.api.TezException;
 import org.apache.tez.test.service.rpc.TezTestServiceProtocolProtos.RunContainerRequestProto;
 import org.apache.tez.test.service.rpc.TezTestServiceProtocolProtos.SubmitWorkRequestProto;

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/service/TezTestServiceConfConstants.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/service/TezTestServiceConfConstants.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tez.service;
 
+
 public final class TezTestServiceConfConstants {
 
   private static final String TEZ_TEST_SERVICE_PREFIX = "tez.test.service.";

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/service/TezTestServiceConfConstants.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/service/TezTestServiceConfConstants.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tez.service;
 
-
 public final class TezTestServiceConfConstants {
 
   private static final String TEZ_TEST_SERVICE_PREFIX = "tez.test.service.";

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/service/TezTestServiceProtocolBlockingPB.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/service/TezTestServiceProtocolBlockingPB.java
@@ -21,6 +21,7 @@ package org.apache.tez.service;
 import org.apache.hadoop.ipc.ProtocolInfo;
 import org.apache.tez.test.service.rpc.TezTestServiceProtocolProtos;
 
+
 @ProtocolInfo(protocolName = "org.apache.tez.service.TezTestServiceProtocolBlockingPB", protocolVersion = 1)
 public interface TezTestServiceProtocolBlockingPB extends TezTestServiceProtocolProtos.TezTestServiceProtocol.BlockingInterface {
 }

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/service/TezTestServiceProtocolBlockingPB.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/service/TezTestServiceProtocolBlockingPB.java
@@ -21,7 +21,6 @@ package org.apache.tez.service;
 import org.apache.hadoop.ipc.ProtocolInfo;
 import org.apache.tez.test.service.rpc.TezTestServiceProtocolProtos;
 
-
 @ProtocolInfo(protocolName = "org.apache.tez.service.TezTestServiceProtocolBlockingPB", protocolVersion = 1)
 public interface TezTestServiceProtocolBlockingPB extends TezTestServiceProtocolProtos.TezTestServiceProtocol.BlockingInterface {
 }

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/service/impl/TezTestServiceProtocolClientImpl.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/service/impl/TezTestServiceProtocolClientImpl.java
@@ -33,8 +33,6 @@ import org.apache.tez.test.service.rpc.TezTestServiceProtocolProtos.RunContainer
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 
-
-
 public class TezTestServiceProtocolClientImpl implements TezTestServiceProtocolBlockingPB {
 
   private final Configuration conf;

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/service/impl/TezTestServiceProtocolClientImpl.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/service/impl/TezTestServiceProtocolClientImpl.java
@@ -34,6 +34,7 @@ import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 
 
+
 public class TezTestServiceProtocolClientImpl implements TezTestServiceProtocolBlockingPB {
 
   private final Configuration conf;

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/tests/ExternalTezServiceTestHelper.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/tests/ExternalTezServiceTestHelper.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tez.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.Map;

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/tests/TestExtServicesWithLocalMode.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/tests/TestExtServicesWithLocalMode.java
@@ -18,11 +18,12 @@
  */
 package org.apache.tez.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -45,9 +46,10 @@ import org.apache.tez.serviceplugins.api.ServicePluginsDescriptor;
 import org.apache.tez.serviceplugins.api.TaskCommunicatorDescriptor;
 import org.apache.tez.serviceplugins.api.TaskSchedulerDescriptor;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,7 +81,7 @@ public class TestExtServicesWithLocalMode {
 
   private static volatile Configuration confForJobs;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
 
     localFs = FileSystem.getLocal(clusterConf).getRaw();
@@ -99,7 +101,7 @@ public class TestExtServicesWithLocalMode {
     confForJobs.set(TezConfiguration.TEZ_AM_STAGING_DIR, STAGING_DIR.toString());
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws IOException, TezException {
     if (tezTestServiceCluster != null) {
       tezTestServiceCluster.stop();
@@ -113,7 +115,8 @@ public class TestExtServicesWithLocalMode {
   }
 
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void test1() throws Exception {
 
     UserPayload userPayload = TezUtils.createUserPayloadFromConf(confForJobs);

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/tests/TestExternalTezServices.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/tests/TestExternalTezServices.java
@@ -18,9 +18,10 @@
  */
 package org.apache.tez.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.tez.common.TezUtils;
@@ -44,9 +45,10 @@ import org.apache.tez.serviceplugins.api.ServicePluginsDescriptor;
 import org.apache.tez.serviceplugins.api.TaskCommunicatorDescriptor;
 import org.apache.tez.serviceplugins.api.TaskSchedulerDescriptor;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +77,7 @@ public class TestExternalTezServices {
   private static String TEST_ROOT_DIR = "target" + Path.SEPARATOR + TestExternalTezServices.class.getName()
       + "-tmpDir";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
 
     extServiceTestHelper = new ExternalTezServiceTestHelper(TEST_ROOT_DIR);
@@ -111,83 +113,94 @@ public class TestExternalTezServices {
         .setupHashJoinData(SRC_DATA_DIR, dataPath1, dataPath2, HASH_JOIN_EXPECTED_RESULT_PATH, HASH_JOIN_OUTPUT_PATH);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws IOException, TezException {
     extServiceTestHelper.tearDownAll();
   }
 
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testAllInService() throws Exception {
     int expectedExternalSubmissions = 4 + 3; //4 for 4 src files, 3 for num reducers.
     runJoinValidate("AllInService", expectedExternalSubmissions, EXECUTION_CONTEXT_EXT_SERVICE_PUSH,
         EXECUTION_CONTEXT_EXT_SERVICE_PUSH, EXECUTION_CONTEXT_EXT_SERVICE_PUSH);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testAllInContainers() throws Exception {
     int expectedExternalSubmissions = 0; // All in containers
     runJoinValidate("AllInContainers", expectedExternalSubmissions, EXECUTION_CONTEXT_REGULAR_CONTAINERS,
         EXECUTION_CONTEXT_REGULAR_CONTAINERS, EXECUTION_CONTEXT_REGULAR_CONTAINERS);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testAllInAM() throws Exception {
     int expectedExternalSubmissions = 0; // All in AM
     runJoinValidate("AllInAM", expectedExternalSubmissions, EXECUTION_CONTEXT_IN_AM,
         EXECUTION_CONTEXT_IN_AM, EXECUTION_CONTEXT_IN_AM);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMixed1() throws Exception { // M-ExtService, R-containers
     int expectedExternalSubmissions = 4 + 0; //4 for 4 src files, 0 for num reducers.
     runJoinValidate("Mixed1", expectedExternalSubmissions, EXECUTION_CONTEXT_EXT_SERVICE_PUSH,
         EXECUTION_CONTEXT_EXT_SERVICE_PUSH, EXECUTION_CONTEXT_REGULAR_CONTAINERS);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMixed2() throws Exception { // M-Containers, R-ExtService
     int expectedExternalSubmissions = 0 + 3; // 3 for num reducers.
     runJoinValidate("Mixed2", expectedExternalSubmissions, EXECUTION_CONTEXT_REGULAR_CONTAINERS,
         EXECUTION_CONTEXT_REGULAR_CONTAINERS, EXECUTION_CONTEXT_EXT_SERVICE_PUSH);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMixed3() throws Exception { // M - service, R-AM
     int expectedExternalSubmissions = 4 + 0; //4 for 4 src files, 0 for num reducers (in-AM).
     runJoinValidate("Mixed3", expectedExternalSubmissions, EXECUTION_CONTEXT_EXT_SERVICE_PUSH,
         EXECUTION_CONTEXT_EXT_SERVICE_PUSH, EXECUTION_CONTEXT_IN_AM);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMixed4() throws Exception { // M - containers, R-AM
     int expectedExternalSubmissions = 0 + 0; // Nothing in external service.
     runJoinValidate("Mixed4", expectedExternalSubmissions, EXECUTION_CONTEXT_REGULAR_CONTAINERS,
         EXECUTION_CONTEXT_REGULAR_CONTAINERS, EXECUTION_CONTEXT_IN_AM);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMixed5() throws Exception { // M1 - containers, M2-extservice, R-AM
     int expectedExternalSubmissions = 2 + 0; // 2 for M2
     runJoinValidate("Mixed5", expectedExternalSubmissions, EXECUTION_CONTEXT_REGULAR_CONTAINERS,
         EXECUTION_CONTEXT_EXT_SERVICE_PUSH, EXECUTION_CONTEXT_IN_AM);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMixed6() throws Exception { // M - AM, R - Service
     int expectedExternalSubmissions = 0 + 3; // 3 for R in service
     runJoinValidate("Mixed6", expectedExternalSubmissions, EXECUTION_CONTEXT_IN_AM,
         EXECUTION_CONTEXT_IN_AM, EXECUTION_CONTEXT_EXT_SERVICE_PUSH);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMixed7() throws Exception { // M - AM, R - Containers
     int expectedExternalSubmissions = 0; // Nothing in ext service
     runJoinValidate("Mixed7", expectedExternalSubmissions, EXECUTION_CONTEXT_IN_AM,
         EXECUTION_CONTEXT_IN_AM, EXECUTION_CONTEXT_REGULAR_CONTAINERS);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testErrorPropagation() throws TezException, InterruptedException, IOException {
     runExceptionSimulation();
   }

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/tests/TestExternalTezServicesErrors.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/tests/TestExternalTezServicesErrors.java
@@ -18,12 +18,13 @@
  */
 package org.apache.tez.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -62,9 +63,10 @@ import org.apache.tez.serviceplugins.api.TaskSchedulerDescriptor;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +127,7 @@ public class TestExternalTezServicesErrors {
   private static String TEST_ROOT_DIR = "target" + Path.SEPARATOR + TestExternalTezServicesErrors.class.getName()
       + "-tmpDir";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
 
     extServiceTestHelper = new ExternalTezServiceTestHelper(TEST_ROOT_DIR);
@@ -202,33 +204,37 @@ public class TestExternalTezServicesErrors {
     extServiceTestHelper.shutdownSharedTezClient();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws IOException, TezException {
     extServiceTestHelper.tearDownAll();
   }
 
-  @Test(timeout = 90000)
+  @Test
+  @Timeout(value = 90000, unit = TimeUnit.MILLISECONDS)
   public void testContainerLauncherThrowError() throws Exception {
     testFatalError("_testContainerLauncherError_", EXECUTION_CONTEXT_LAUNCHER_THROW,
         SUFFIX_LAUNCHER, Lists.newArrayList("Service Error",
             DAGAppMasterEventType.CONTAINER_LAUNCHER_SERVICE_FATAL_ERROR.name()));
   }
 
-  @Test(timeout = 90000)
+  @Test
+  @Timeout(value = 90000, unit = TimeUnit.MILLISECONDS)
   public void testTaskCommunicatorThrowError() throws Exception {
     testFatalError("_testContainerLauncherError_", EXECUTION_CONTEXT_TASKCOMM_THROW,
         SUFFIX_TASKCOMM, Lists.newArrayList("Service Error",
             DAGAppMasterEventType.TASK_COMMUNICATOR_SERVICE_FATAL_ERROR.name()));
   }
 
-  @Test(timeout = 90000)
+  @Test
+  @Timeout(value = 90000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerThrowError() throws Exception {
     testFatalError("_testContainerLauncherError_", EXECUTION_CONTEXT_SCHEDULER_THROW,
         SUFFIX_SCHEDULER, Lists.newArrayList("Service Error",
             DAGAppMasterEventType.TASK_SCHEDULER_SERVICE_FATAL_ERROR.name()));
   }
 
-  @Test (timeout = 150000)
+  @Test
+  @Timeout(value = 150000, unit = TimeUnit.MILLISECONDS)
   public void testNonFatalErrors() throws IOException, TezException, InterruptedException {
     String methodName = "testNonFatalErrors";
     TezConfiguration tezClientConf = new TezConfiguration(extServiceTestHelper.getConfForJobs());
@@ -252,7 +258,8 @@ public class TestExternalTezServicesErrors {
     }
   }
 
-  @Test(timeout = 90000)
+  @Test
+  @Timeout(value = 90000, unit = TimeUnit.MILLISECONDS)
   public void testContainerLauncherReportFatalError() throws Exception {
     testFatalError("_testContainerLauncherReportFatalError_",
         EXECUTION_CONTEXT_LAUNCHER_REPORT_FATAL, SUFFIX_LAUNCHER, Lists
@@ -260,14 +267,16 @@ public class TestExternalTezServicesErrors {
                 ServicePluginErrorDefaults.INCONSISTENT_STATE.name()));
   }
 
-  @Test(timeout = 90000)
+  @Test
+  @Timeout(value = 90000, unit = TimeUnit.MILLISECONDS)
   public void testTaskCommReportFatalError() throws Exception {
     testFatalError("_testTaskCommReportFatalError_", EXECUTION_CONTEXT_TASKCOMM_REPORT_FATAL,
         SUFFIX_TASKCOMM, Lists.newArrayList(ErrorPluginConfiguration.REPORT_FATAL_ERROR_MESSAGE,
             ServicePluginErrorDefaults.INCONSISTENT_STATE.name()));
   }
 
-  @Test(timeout = 90000)
+  @Test
+  @Timeout(value = 90000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSchedulerReportFatalError() throws Exception {
     testFatalError("_testTaskSchedulerReportFatalError_",
         EXECUTION_CONTEXT_SCHEDULER_REPORT_FATAL, SUFFIX_SCHEDULER,

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/util/ProtoConverters.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/util/ProtoConverters.java
@@ -41,7 +41,6 @@ import org.apache.tez.test.service.rpc.TezTestServiceProtocolProtos.IOSpecProto;
 import org.apache.tez.test.service.rpc.TezTestServiceProtocolProtos.TaskSpecProto;
 import org.apache.tez.test.service.rpc.TezTestServiceProtocolProtos.TaskSpecProto.Builder;
 
-
 public final class ProtoConverters {
 
   private ProtoConverters() {}

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/util/ProtoConverters.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/util/ProtoConverters.java
@@ -41,6 +41,7 @@ import org.apache.tez.test.service.rpc.TezTestServiceProtocolProtos.IOSpecProto;
 import org.apache.tez.test.service.rpc.TezTestServiceProtocolProtos.TaskSpecProto;
 import org.apache.tez.test.service.rpc.TezTestServiceProtocolProtos.TaskSpecProto.Builder;
 
+
 public final class ProtoConverters {
 
   private ProtoConverters() {}

--- a/tez-mapreduce/pom.xml
+++ b/tez-mapreduce/pom.xml
@@ -124,9 +124,8 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
      <groupId>org.apache.commons</groupId>

--- a/tez-mapreduce/src/test/java/org/apache/hadoop/mapred/split/TestGroupedSplits.java
+++ b/tez-mapreduce/src/test/java/org/apache/hadoop/mapred/split/TestGroupedSplits.java
@@ -18,9 +18,13 @@
  */
 package org.apache.hadoop.mapred.split;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayOutputStream;
@@ -38,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.hadoop.conf.Configuration;
@@ -60,9 +65,9 @@ import org.apache.tez.mapreduce.grouper.TezSplitGrouper;
 
 import com.google.common.collect.Sets;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,7 +95,8 @@ public class TestGroupedSplits {
   // A reporter that does nothing
   private static final Reporter voidReporter = Reporter.NULL;
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testFormat() throws Exception {
     JobConf job = new JobConf(defaultConf);
 
@@ -125,10 +131,9 @@ public class TestGroupedSplits {
 
       // we should have a single split as the length is comfortably smaller than
       // the block size
-      assertEquals("We got more than one splits!", 1, splits.length);
+      assertEquals(1, splits.length, "We got more than one splits!");
       InputSplit split = splits[0];
-      assertEquals("It should be TezGroupedSplit",
-        TezGroupedSplit.class, split.getClass());
+      assertEquals(TezGroupedSplit.class, split.getClass(), "It should be TezGroupedSplit");
 
       // check the split
       BitSet bits = new BitSet(length);
@@ -144,7 +149,7 @@ public class TestGroupedSplits {
             LOG.warn("conflict with " + v +
                      " at position "+reader.getPos());
           }
-          assertFalse("Key in multiple partitions.", bits.get(v));
+          assertFalse(bits.get(v), "Key in multiple partitions.");
           bits.set(v);
           count++;
         }
@@ -152,7 +157,7 @@ public class TestGroupedSplits {
       } finally {
         reader.close();
       }
-      assertEquals("Some keys in no partition.", length, bits.cardinality());
+      assertEquals(length, bits.cardinality(), "Some keys in no partition.");
     }
   }
 
@@ -232,7 +237,7 @@ public class TestGroupedSplits {
     return result;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     MockDNSToSwitchMapping.initializeMockRackResolver();
   }
@@ -240,7 +245,8 @@ public class TestGroupedSplits {
   /**
    * Test using the gzip codec for reading
    */
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testGzip() throws IOException {
     JobConf job = new JobConf(defaultConf);
     CompressionCodec gzip = new GzipCodec();
@@ -267,14 +273,14 @@ public class TestGroupedSplits {
       if (j==1) {
         // j==1 covers single split corner case
         // and does not do grouping
-        assertEquals("compressed splits == " + j, j, splits.length);
+        assertEquals(j, splits.length, "compressed splits == " + j);
       }
       List<Text> results = new ArrayList<Text>();
       for (int i=0; i<splits.length; ++i) {
         List<Text> read = readSplit(format, splits[i], job);
         results.addAll(read);
       }
-      assertEquals("splits length", 11, results.size());
+      assertEquals(11, results.size(), "splits length");
 
       final String[] firstList =
         {"the quick", "brown", "fox jumped", "over", " the lazy", " dog"};
@@ -293,20 +299,21 @@ public class TestGroupedSplits {
         start = testResults(results, thirdList, start);
         break;
       default:
-        Assert.fail("unexpected first token - " + first);
+        fail("unexpected first token - " + first);
       }
     }
   }
 
   private static int testResults(List<Text> results, String[] first, int start) {
     for (int i = 0; i < first.length; i++) {
-      assertEquals("splits["+i+"]", first[i], results.get(start+i).toString());
+      assertEquals(first[i], results.get(start+i).toString(), "splits["+i+"]");
     }
     return first.length+start;
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testGroupedSplitSize() throws IOException {
     JobConf job = new JobConf(defaultConf);
     InputFormat mockWrappedFormat = mock(InputFormat.class);
@@ -379,7 +386,8 @@ public class TestGroupedSplits {
     }
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMaintainSplitOrdering() throws IOException {
     int numLocations = 3;
     String[] locations = new String[numLocations];
@@ -418,12 +426,13 @@ public class TestGroupedSplits {
       }
       // last one is rack split
       if (i==3) {
-        assertTrue(split.getRack() != null);
+        assertNotNull(split.getRack());
       }
     }
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRepeatableSplits() throws IOException {
     int numLocations = 3;
     String[] locations = new String[numLocations];
@@ -480,14 +489,15 @@ public class TestGroupedSplits {
       }
       if (i==3) {
         // check for rack split creation. Ensures repeatability holds for rack splits also
-        assertTrue(gSplit1.getRack() != null);
-        assertTrue(gSplit2.getRack() != null);
+        assertNotNull(gSplit1.getRack());
+        assertNotNull(gSplit2.getRack());
       }
     }
   }
 
 
-  @Test (timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testS3Scenario() throws IOException {
     //There can be multiple nodes in cluster, but locations would be "localhost" in s3
     String[] locations = {"localhost"};
@@ -538,7 +548,8 @@ public class TestGroupedSplits {
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testGroupedSplitWithDuplicates() throws IOException {
     JobConf job = new JobConf(defaultConf);
     InputFormat mockWrappedFormat = mock(InputFormat.class);
@@ -570,7 +581,8 @@ public class TestGroupedSplits {
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testGroupedSplitWithBadLocations() throws IOException {
     JobConf job = new JobConf(defaultConf);
     InputFormat mockWrappedFormat = mock(InputFormat.class);
@@ -609,7 +621,8 @@ public class TestGroupedSplits {
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
   // No grouping
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testGroupedSplitWithBadLocations2() throws IOException {
     JobConf job = new JobConf(defaultConf);
     InputFormat mockWrappedFormat = mock(InputFormat.class);
@@ -660,7 +673,7 @@ public class TestGroupedSplits {
         assertEquals(1, split.getLocations().length);
         assertTrue(split.getLocations()[0].equals(validLocation) || split.getLocations()[0].equals(validLocation2));
       } else {
-        Assert.assertNull(split.getLocations());
+        assertNull(split.getLocations());
       }
       ByteArrayOutputStream bOut = new ByteArrayOutputStream();
       split.write(new DataOutputStream(bOut));
@@ -668,7 +681,8 @@ public class TestGroupedSplits {
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testGroupedSplitWithEstimator() throws IOException {
     JobConf job = new JobConf(defaultConf);
 
@@ -737,7 +751,8 @@ public class TestGroupedSplits {
 
 
   // Splits get grouped
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testGroupingWithCustomLocations1() throws IOException {
 
     int numSplits = 3;
@@ -768,7 +783,7 @@ public class TestGroupedSplits {
 
     // Sanity. 1 group, with 3 splits.
     assertEquals(1, groupedSplits.length);
-    assertTrue(groupedSplits[0] instanceof  TezGroupedSplit);
+    assertInstanceOf(TezGroupedSplit.class, groupedSplits[0]);
     TezGroupedSplit groupedSplit = (TezGroupedSplit)groupedSplits[0];
     assertEquals(3, groupedSplit.getGroupedSplits().size());
 
@@ -778,7 +793,8 @@ public class TestGroupedSplits {
   }
 
   // Original splits returned.
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testGroupingWithCustomLocations2() throws IOException {
 
     int numSplits = 3;
@@ -810,7 +826,7 @@ public class TestGroupedSplits {
     // Sanity. 3 group, with 1 split each
     assertEquals(3, groupedSplits.length);
     for (int i = 0 ; i < 3 ; i++) {
-      assertTrue(groupedSplits[i] instanceof  TezGroupedSplit);
+      assertInstanceOf(TezGroupedSplit.class, groupedSplits[i]);
       TezGroupedSplit groupedSplit = (TezGroupedSplit)groupedSplits[i];
       assertEquals(1, groupedSplit.getGroupedSplits().size());
 
@@ -820,7 +836,8 @@ public class TestGroupedSplits {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testForceNodeLocalSplits() throws IOException {
     int numLocations = 7;
     long splitLen = 100L;

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/TezTestUtils.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/TezTestUtils.java
@@ -32,7 +32,6 @@ import org.apache.tez.dag.records.TezTaskID;
 import org.apache.tez.dag.records.TezVertexID;
 import org.apache.tez.runtime.api.InputInitializerContext;
 
-
 public final class TezTestUtils {
 
   private TezTestUtils() {}

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/TezTestUtils.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/TezTestUtils.java
@@ -32,6 +32,7 @@ import org.apache.tez.dag.records.TezTaskID;
 import org.apache.tez.dag.records.TezVertexID;
 import org.apache.tez.runtime.api.InputInitializerContext;
 
+
 public final class TezTestUtils {
 
   private TezTestUtils() {}

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/combine/TestMRCombiner.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/combine/TestMRCombiner.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tez.mapreduce.combine;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -49,7 +49,8 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.sort.impl.IFile.Writer;
 import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 public class TestMRCombiner {
 

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/combine/TestMRCombiner.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/combine/TestMRCombiner.java
@@ -51,7 +51,6 @@ import org.apache.tez.runtime.library.common.sort.impl.TezRawKeyValueIterator;
 
 import org.junit.jupiter.api.Test;
 
-
 public class TestMRCombiner {
 
   @Test

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/common/TestMRInputAMSplitGenerator.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/common/TestMRInputAMSplitGenerator.java
@@ -18,16 +18,18 @@
  */
 package org.apache.tez.mapreduce.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
@@ -52,31 +54,36 @@ import org.apache.tez.runtime.api.events.InputDataInformationEvent;
 
 import com.google.protobuf.ByteString;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestMRInputAMSplitGenerator {
 
   private static String SPLITS_LENGTHS = "splits.length";
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGroupSplitsDisabledSortSplitsEnabled()
       throws Exception {
     testGroupSplitsAndSortSplits(false, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGroupSplitsDisabledSortSplitsDisabled()
       throws Exception {
     testGroupSplitsAndSortSplits(false, false);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGroupSplitsEnabledSortSplitsEnabled()
       throws Exception {
     testGroupSplitsAndSortSplits(true, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGroupSplitsEnabledSortSplitsDisabled()
           throws Exception {
     testGroupSplitsAndSortSplits(true, false);
@@ -102,12 +109,12 @@ public class TestMRInputAMSplitGenerator {
 
     List<Event> events = splitGenerator.initialize();
 
-    assertTrue(events.get(0) instanceof InputConfigureVertexTasksEvent);
+    assertInstanceOf(InputConfigureVertexTasksEvent.class, events.get(0));
     boolean shuffled = false;
     InputSplit previousIs = null;
     int numRawInputSplits = 0;
     for (int i = 1; i < events.size(); i++) {
-      assertTrue(events.get(i) instanceof InputDataInformationEvent);
+      assertInstanceOf(InputDataInformationEvent.class, events.get(i));
       InputDataInformationEvent diEvent = (InputDataInformationEvent) (events.get(i));
       assertNull(diEvent.getDeserializedUserPayload());
       assertNotNull(diEvent.getUserPayload());
@@ -118,13 +125,12 @@ public class TestMRInputAMSplitGenerator {
       if (groupSplitsEnabled) {
         numRawInputSplits += ((TezGroupedSplit)is).getGroupedSplits().size();
         for (InputSplit inputSplit : ((TezGroupedSplit)is).getGroupedSplits()) {
-          assertTrue(inputSplit instanceof InputSplitForTest);
+          assertInstanceOf(InputSplitForTest.class, inputSplit);
         }
-        assertTrue(((TezGroupedSplit)is).getGroupedSplits().get(0)
-            instanceof InputSplitForTest);
+        assertInstanceOf(InputSplitForTest.class, ((TezGroupedSplit) is).getGroupedSplits().get(0));
       } else {
         numRawInputSplits++;
-        assertTrue(is instanceof InputSplitForTest);
+        assertInstanceOf(InputSplitForTest.class, is);
       }
       // The splits in the list returned from InputFormat has ascending
       // size in order.

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/common/TestMRInputSplitDistributor.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/common/TestMRInputSplitDistributor.java
@@ -18,15 +18,16 @@
  */
 package org.apache.tez.mapreduce.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.conf.Configuration;
@@ -47,11 +48,13 @@ import org.apache.tez.runtime.api.events.InputUpdatePayloadEvent;
 
 import com.google.protobuf.ByteString;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestMRInputSplitDistributor {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSerializedPayload() throws IOException {
 
     Configuration conf = new Configuration(false);
@@ -77,9 +80,9 @@ public class TestMRInputSplitDistributor {
     List<Event> events = splitDist.initialize();
 
     assertEquals(3, events.size());
-    assertTrue(events.get(0) instanceof InputUpdatePayloadEvent);
-    assertTrue(events.get(1) instanceof InputDataInformationEvent);
-    assertTrue(events.get(2) instanceof InputDataInformationEvent);
+    assertInstanceOf(InputUpdatePayloadEvent.class, events.get(0));
+    assertInstanceOf(InputDataInformationEvent.class, events.get(1));
+    assertInstanceOf(InputDataInformationEvent.class, events.get(2));
 
     InputDataInformationEvent diEvent1 = (InputDataInformationEvent) (events.get(1));
     InputDataInformationEvent diEvent2 = (InputDataInformationEvent) (events.get(2));
@@ -92,16 +95,17 @@ public class TestMRInputSplitDistributor {
 
     MRSplitProto event1Proto = MRSplitProto.parseFrom(ByteString.copyFrom(diEvent1.getUserPayload()));
     InputSplit is1 = MRInputUtils.getOldSplitDetailsFromEvent(event1Proto, new Configuration());
-    assertTrue(is1 instanceof InputSplitForTest);
+    assertInstanceOf(InputSplitForTest.class, is1);
     assertEquals(1, ((InputSplitForTest) is1).identifier);
 
     MRSplitProto event2Proto = MRSplitProto.parseFrom(ByteString.copyFrom(diEvent2.getUserPayload()));
     InputSplit is2 = MRInputUtils.getOldSplitDetailsFromEvent(event2Proto, new Configuration());
-    assertTrue(is2 instanceof InputSplitForTest);
+    assertInstanceOf(InputSplitForTest.class, is2);
     assertEquals(2, ((InputSplitForTest) is2).identifier);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDeserializedPayload() throws IOException {
 
     Configuration conf = new Configuration(false);
@@ -127,9 +131,9 @@ public class TestMRInputSplitDistributor {
     List<Event> events = splitDist.initialize();
 
     assertEquals(3, events.size());
-    assertTrue(events.get(0) instanceof InputUpdatePayloadEvent);
-    assertTrue(events.get(1) instanceof InputDataInformationEvent);
-    assertTrue(events.get(2) instanceof InputDataInformationEvent);
+    assertInstanceOf(InputUpdatePayloadEvent.class, events.get(0));
+    assertInstanceOf(InputDataInformationEvent.class, events.get(1));
+    assertInstanceOf(InputDataInformationEvent.class, events.get(2));
 
     InputDataInformationEvent diEvent1 = (InputDataInformationEvent) (events.get(1));
     InputDataInformationEvent diEvent2 = (InputDataInformationEvent) (events.get(2));
@@ -140,10 +144,10 @@ public class TestMRInputSplitDistributor {
     assertNotNull(diEvent1.getDeserializedUserPayload());
     assertNotNull(diEvent2.getDeserializedUserPayload());
 
-    assertTrue(diEvent1.getDeserializedUserPayload() instanceof InputSplitForTest);
+    assertInstanceOf(InputSplitForTest.class, diEvent1.getDeserializedUserPayload());
     assertEquals(1, ((InputSplitForTest) diEvent1.getDeserializedUserPayload()).identifier);
 
-    assertTrue(diEvent2.getDeserializedUserPayload() instanceof InputSplitForTest);
+    assertInstanceOf(InputSplitForTest.class, diEvent2.getDeserializedUserPayload());
     assertEquals(2, ((InputSplitForTest) diEvent2.getDeserializedUserPayload()).identifier);
   }
 

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestConfigTranslationMRToTez.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestConfigTranslationMRToTez.java
@@ -18,19 +18,23 @@
  */
 package org.apache.tez.mapreduce.hadoop;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.tez.runtime.library.common.ConfigUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestConfigTranslationMRToTez {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Tests derived keys - i.e. the actual key is not set, but the value is
   // derived from a fallback key.
   public void testComplexKeys() {
@@ -50,7 +54,8 @@ public class TestConfigTranslationMRToTez {
         .getIntermediateInputKeyComparator(confVertex1).getClass().getName());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMRToTezKeyTranslation() {
     JobConf confVertex1 = new JobConf();
     confVertex1.set(MRJobConfig.MAP_OUTPUT_KEY_CLASS,

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestDeprecatedKeys.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestDeprecatedKeys.java
@@ -18,9 +18,12 @@
  */
 package org.apache.tez.mapreduce.hadoop;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.tez.dag.api.TezConfiguration;
@@ -28,11 +31,13 @@ import org.apache.tez.dag.library.vertexmanager.ShuffleVertexManager;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.Constants;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestDeprecatedKeys {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void verifyReduceKeyTranslation() {
     JobConf jobConf = new JobConf();
 
@@ -61,15 +66,16 @@ public class TestDeprecatedKeys {
     assertEquals(0.22f,
         jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MERGE_PERCENT, 0),
         0.01f);
-    assertEquals(true, jobConf.getBoolean(
+    assertTrue(jobConf.getBoolean(
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_MEMTOMEM, false));
     assertEquals(0.33f,
         jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, 0),
         0.01f);
-    assertEquals(false, jobConf.getBoolean(TezConfiguration.TEZ_USER_CLASSPATH_FIRST, true));
+    assertFalse(jobConf.getBoolean(TezConfiguration.TEZ_USER_CLASSPATH_FIRST, true));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   /**
    * Set of keys that can be overridden at tez runtime
    */
@@ -113,22 +119,24 @@ public class TestDeprecatedKeys {
 
     assertEquals(1000, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_FACTOR, 0));
     assertEquals(200, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 100));
-    assertEquals(true, jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD, false));
+    assertTrue(jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD, false));
     assertEquals(20, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES, 0));
     assertEquals(10, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_INDEX_CACHE_MEMORY_LIMIT_BYTES, 0));
     assertEquals(20, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_COMBINE_MIN_SPILLS, 0));
     assertEquals(10, jobConf.getInt(Constants.TEZ_RUNTIME_TASK_MEMORY, 0));
     assertEquals(10, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_PARALLEL_COPIES, 0));
     assertEquals(10, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_FAILURES_LIMIT, 0));
-    assertEquals(true, jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_NOTIFY_READERROR, false));
+    assertTrue(
+        jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_NOTIFY_READERROR, false));
     assertEquals(10, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_CONNECT_TIMEOUT, 0));
     assertEquals(10, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_READ_TIMEOUT, 0));
-    assertEquals(true, jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_SSL, false));
+    assertTrue(jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_SSL, false));
     assertEquals(10.0f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 0.0f), 0.0f);
     assertEquals(10.0f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 0.0f), 0.0f);
     assertEquals(10.0f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MERGE_PERCENT, 0.0f), 0.0f);
     assertEquals(10, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMTOMEM_SEGMENTS, 0));
-    assertEquals(true, jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_MEMTOMEM, false));
+    assertTrue(
+        jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_MEMTOMEM, false));
     assertEquals(10.0f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, 0.0f), 0.0f);
     assertEquals("DefaultSorter", jobConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_INTERNAL_SORTER_CLASS, ""));
     assertEquals("groupComparator", jobConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_GROUP_COMPARATOR_CLASS, ""));
@@ -136,7 +144,7 @@ public class TestDeprecatedKeys {
     assertEquals("DefaultSorter", jobConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_INTERNAL_SORTER_CLASS, ""));
     assertTrue(jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS, false));
     assertEquals(0.95f, jobConf.getFloat(ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION, 0.0f), 0.0f);
-    assertEquals(false, jobConf.getBoolean(TezConfiguration.TEZ_USER_CLASSPATH_FIRST, true));
+    assertFalse(jobConf.getBoolean(TezConfiguration.TEZ_USER_CLASSPATH_FIRST, true));
 
     assertNull(jobConf.get(MRConfig.MAPRED_IFILE_READAHEAD));
     assertNull(jobConf.get(MRConfig.MAPRED_IFILE_READAHEAD_BYTES));

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestDeprecatedKeys.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestDeprecatedKeys.java
@@ -53,23 +53,14 @@ public class TestDeprecatedKeys {
 
     MRHelpers.translateMRConfToTez(jobConf);
 
-    assertEquals(0.4f, jobConf.getFloat(
-        TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 0f), 0.01f);
+    assertEquals(0.4f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 0f), 0.01f);
     assertEquals(20000l, jobConf.getLong(Constants.TEZ_RUNTIME_TASK_MEMORY, 0));
-    assertEquals(2000,
-        jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_FACTOR, 0));
-    assertEquals(0.55f, jobConf.getFloat(
-        TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 0), 0.01f);
-    assertEquals(0.60f,
-        jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMTOMEM_SEGMENTS, 0),
-        0.01f);
-    assertEquals(0.22f,
-        jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MERGE_PERCENT, 0),
-        0.01f);
-    assertTrue(jobConf.getBoolean(
-        TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_MEMTOMEM, false));
-    assertEquals(0.33f,
-        jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, 0),
+    assertEquals(2000, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_FACTOR, 0));
+    assertEquals(0.55f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 0), 0.01f);
+    assertEquals(0.60f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMTOMEM_SEGMENTS, 0), 0.01f);
+    assertEquals(0.22f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MERGE_PERCENT, 0), 0.01f);
+    assertTrue(jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_MEMTOMEM, false));
+    assertEquals(0.33f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, 0),
         0.01f);
     assertFalse(jobConf.getBoolean(TezConfiguration.TEZ_USER_CLASSPATH_FIRST, true));
   }
@@ -126,8 +117,7 @@ public class TestDeprecatedKeys {
     assertEquals(10, jobConf.getInt(Constants.TEZ_RUNTIME_TASK_MEMORY, 0));
     assertEquals(10, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_PARALLEL_COPIES, 0));
     assertEquals(10, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_FAILURES_LIMIT, 0));
-    assertTrue(
-        jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_NOTIFY_READERROR, false));
+    assertTrue(jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_NOTIFY_READERROR, false));
     assertEquals(10, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_CONNECT_TIMEOUT, 0));
     assertEquals(10, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_READ_TIMEOUT, 0));
     assertTrue(jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_SSL, false));
@@ -135,9 +125,9 @@ public class TestDeprecatedKeys {
     assertEquals(10.0f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 0.0f), 0.0f);
     assertEquals(10.0f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MERGE_PERCENT, 0.0f), 0.0f);
     assertEquals(10, jobConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMTOMEM_SEGMENTS, 0));
-    assertTrue(
-        jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_MEMTOMEM, false));
-    assertEquals(10.0f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, 0.0f), 0.0f);
+    assertTrue(jobConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_MEMTOMEM, false));
+    assertEquals(10.0f, jobConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, 0.0f),
+        0.0f);
     assertEquals("DefaultSorter", jobConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_INTERNAL_SORTER_CLASS, ""));
     assertEquals("groupComparator", jobConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_GROUP_COMPARATOR_CLASS, ""));
     assertEquals("SecondaryComparator", jobConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_SECONDARY_COMPARATOR_CLASS, ""));

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestMRHelpers.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestMRHelpers.java
@@ -18,9 +18,15 @@
  */
 package org.apache.tez.mapreduce.hadoop;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
@@ -31,8 +37,8 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.tez.dag.api.TezConstants;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestMRHelpers {
 
@@ -47,53 +53,56 @@ public class TestMRHelpers {
     return conf;
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMapJavaOptions() {
     Configuration conf = createConfForJavaOptsTest();
     String opts = MRHelpers.getJavaOptsForMRMapper(conf);
 
-    Assert.assertTrue(opts.contains("fooMapAdminOpts"));
-    Assert.assertTrue(opts.contains(" fooMapJavaOpts "));
-    Assert.assertFalse(opts.contains("fooReduceAdminOpts "));
-    Assert.assertFalse(opts.contains(" fooReduceJavaOpts "));
-    Assert.assertTrue(opts.indexOf("fooMapAdminOpts")
+    assertTrue(opts.contains("fooMapAdminOpts"));
+    assertTrue(opts.contains(" fooMapJavaOpts "));
+    assertFalse(opts.contains("fooReduceAdminOpts "));
+    assertFalse(opts.contains(" fooReduceJavaOpts "));
+    assertTrue(opts.indexOf("fooMapAdminOpts")
         < opts.indexOf("fooMapJavaOpts"));
-    Assert.assertTrue(opts.contains(" -D"
+    assertTrue(opts.contains(" -D"
         + TezConstants.TEZ_ROOT_LOGGER_NAME + "=FATAL"));
-    Assert.assertFalse(opts.contains(" -D"
+    assertFalse(opts.contains(" -D"
         + TezConstants.TEZ_ROOT_LOGGER_NAME + "=TRACE"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testReduceJavaOptions() {
     Configuration conf = createConfForJavaOptsTest();
     String opts = MRHelpers.getJavaOptsForMRReducer(conf);
 
-    Assert.assertFalse(opts.contains("fooMapAdminOpts"));
-    Assert.assertFalse(opts.contains(" fooMapJavaOpts "));
-    Assert.assertTrue(opts.contains("fooReduceAdminOpts"));
-    Assert.assertTrue(opts.contains(" fooReduceJavaOpts "));
-    Assert.assertTrue(opts.indexOf("fooReduceAdminOpts")
+    assertFalse(opts.contains("fooMapAdminOpts"));
+    assertFalse(opts.contains(" fooMapJavaOpts "));
+    assertTrue(opts.contains("fooReduceAdminOpts"));
+    assertTrue(opts.contains(" fooReduceJavaOpts "));
+    assertTrue(opts.indexOf("fooReduceAdminOpts")
         < opts.indexOf("fooReduceJavaOpts"));
-    Assert.assertFalse(opts.contains(" -D"
+    assertFalse(opts.contains(" -D"
         + TezConstants.TEZ_ROOT_LOGGER_NAME + "=FATAL"));
-    Assert.assertTrue(opts.contains(" -D"
+    assertTrue(opts.contains(" -D"
         + TezConstants.TEZ_ROOT_LOGGER_NAME + "=TRACE"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testContainerResourceConstruction() {
     JobConf conf = new JobConf(new Configuration());
     Resource mapResource = MRHelpers.getResourceForMRMapper(conf);
     Resource reduceResource = MRHelpers.getResourceForMRReducer(conf);
 
-    Assert.assertEquals(MRJobConfig.DEFAULT_MAP_CPU_VCORES,
+    assertEquals(MRJobConfig.DEFAULT_MAP_CPU_VCORES,
         mapResource.getVirtualCores());
-    Assert.assertEquals(MRJobConfig.DEFAULT_MAP_MEMORY_MB,
+    assertEquals(MRJobConfig.DEFAULT_MAP_MEMORY_MB,
         mapResource.getMemory());
-    Assert.assertEquals(MRJobConfig.DEFAULT_REDUCE_CPU_VCORES,
+    assertEquals(MRJobConfig.DEFAULT_REDUCE_CPU_VCORES,
         reduceResource.getVirtualCores());
-    Assert.assertEquals(MRJobConfig.DEFAULT_REDUCE_MEMORY_MB,
+    assertEquals(MRJobConfig.DEFAULT_REDUCE_MEMORY_MB,
         reduceResource.getMemory());
 
     conf.setInt(MRJobConfig.MAP_CPU_VCORES, 2);
@@ -104,10 +113,10 @@ public class TestMRHelpers {
     mapResource = MRHelpers.getResourceForMRMapper(conf);
     reduceResource = MRHelpers.getResourceForMRReducer(conf);
 
-    Assert.assertEquals(2, mapResource.getVirtualCores());
-    Assert.assertEquals(123, mapResource.getMemory());
-    Assert.assertEquals(20, reduceResource.getVirtualCores());
-    Assert.assertEquals(1234, reduceResource.getMemory());
+    assertEquals(2, mapResource.getVirtualCores());
+    assertEquals(123, mapResource.getMemory());
+    assertEquals(20, reduceResource.getVirtualCores());
+    assertEquals(1234, reduceResource.getMemory());
   }
 
   private Configuration setupConfigForMREnvTest() {
@@ -125,61 +134,65 @@ public class TestMRHelpers {
   }
 
   private void testCommonEnvSettingsForMRTasks(Map<String, String> env) {
-    Assert.assertTrue(env.containsKey("foo"));
-    Assert.assertTrue(env.containsKey("bar"));
-    Assert.assertTrue(env.containsKey(Environment.LD_LIBRARY_PATH.name()));
-    Assert.assertTrue(env.containsKey(Environment.SHELL.name()));
-    Assert.assertTrue(env.containsKey("HADOOP_ROOT_LOGGER"));
+    assertTrue(env.containsKey("foo"));
+    assertTrue(env.containsKey("bar"));
+    assertTrue(env.containsKey(Environment.LD_LIBRARY_PATH.name()));
+    assertTrue(env.containsKey(Environment.SHELL.name()));
+    assertTrue(env.containsKey("HADOOP_ROOT_LOGGER"));
 
     /* On non-windows platform ensure that LD_LIBRARY_PATH is being set and PWD is present.
      * on windows platform LD_LIBRARY_PATH is not applicable. check the PATH is being appended
      * by the user setting (ex user may set HADOOP_HOME\\bin.
      */
     if (!Shell.WINDOWS) {
-      Assert.assertEquals("$PWD:$TEZ_ADMIN_ENV_TEST/lib/native",
+      assertEquals("$PWD:$TEZ_ADMIN_ENV_TEST/lib/native",
           env.get(Environment.LD_LIBRARY_PATH.name()));
     } else {
-      Assert.assertTrue(env.get(Environment.PATH.name()).contains(";%TEZ_ADMIN_ENV%\\bin"));
+      assertTrue(env.get(Environment.PATH.name()).contains(";%TEZ_ADMIN_ENV%\\bin"));
     }
 
 //    TEZ-273 will reinstate this or similar.
 //    for (String val : YarnConfiguration.DEFAULT_YARN_APPLICATION_CLASSPATH) {
-//      Assert.assertTrue(env.get(Environment.CLASSPATH.name()).contains(val));
+//      assertTrue(env.get(Environment.CLASSPATH.name()).contains(val));
 //    }
-//    Assert.assertTrue(0 ==
+//    assertTrue(0 ==
 //        env.get(Environment.CLASSPATH.name()).indexOf(Environment.PWD.$()));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMREnvSetupForMap() {
     Configuration conf = setupConfigForMREnvTest();
     Map<String, String> env = new HashMap<String, String>();
     MRHelpers.updateEnvBasedOnMRTaskEnv(conf, env, true);
     testCommonEnvSettingsForMRTasks(env);
-    Assert.assertEquals("map1", env.get("foo"));
-    Assert.assertEquals("map2", env.get("bar"));
+    assertEquals("map1", env.get("foo"));
+    assertEquals("map2", env.get("bar"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMREnvSetupForReduce() {
     Configuration conf = setupConfigForMREnvTest();
     Map<String, String> env = new HashMap<String, String>();
     MRHelpers.updateEnvBasedOnMRTaskEnv(conf, env, false);
     testCommonEnvSettingsForMRTasks(env);
-    Assert.assertEquals("red1", env.get("foo"));
-    Assert.assertEquals("red2", env.get("bar"));
+    assertEquals("red1", env.get("foo"));
+    assertEquals("red2", env.get("bar"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMRAMJavaOpts() {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_ADMIN_COMMAND_OPTS, " -Dadminfoobar   ");
     conf.set(MRJobConfig.MR_AM_COMMAND_OPTS, "  -Duserfoo  ");
     String opts = MRHelpers.getJavaOptsForMRAM(conf);
-    Assert.assertEquals("-Dadminfoobar -Duserfoo", opts);
+    assertEquals("-Dadminfoobar -Duserfoo", opts);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMRAMEnvironmentSetup() {
     Configuration conf = new Configuration();
     conf.set(MRJobConfig.MR_AM_ADMIN_USER_ENV, "foo=bar,admin1=foo1");
@@ -187,12 +200,13 @@ public class TestMRHelpers {
     Map<String, String> env =
         new HashMap<String, String>();
     MRHelpers.updateEnvBasedOnMRAMEnv(conf, env);
-    Assert.assertEquals("foo1", env.get("admin1"));
-    Assert.assertEquals("foo2", env.get("user"));
-    Assert.assertEquals(("bar" + File.pathSeparator + "bar2"), env.get("foo"));
+    assertEquals("foo1", env.get("admin1"));
+    assertEquals("foo2", env.get("user"));
+    assertEquals(("bar" + File.pathSeparator + "bar2"), env.get("foo"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTranslateMRConfToTez() {
     Configuration conf = new Configuration(false);
     conf.setLong(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 1000);
@@ -200,18 +214,18 @@ public class TestMRHelpers {
 
     Configuration conf1 = new Configuration(conf);
     MRHelpers.translateMRConfToTez(conf1);
-    Assert.assertNull(conf1.get(org.apache.tez.mapreduce.hadoop.MRJobConfig.IO_SORT_MB));
-    Assert.assertEquals(1000, conf1.getLong(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 0));
+    assertNull(conf1.get(org.apache.tez.mapreduce.hadoop.MRJobConfig.IO_SORT_MB));
+    assertEquals(1000, conf1.getLong(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 0));
 
     Configuration conf2 = new Configuration(conf);
     MRHelpers.translateMRConfToTez(conf2, true);
-    Assert.assertNull(conf2.get(org.apache.tez.mapreduce.hadoop.MRJobConfig.IO_SORT_MB));
-    Assert.assertEquals(1000, conf2.getLong(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 0));
+    assertNull(conf2.get(org.apache.tez.mapreduce.hadoop.MRJobConfig.IO_SORT_MB));
+    assertEquals(1000, conf2.getLong(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 0));
 
     Configuration conf3 = new Configuration(conf);
     MRHelpers.translateMRConfToTez(conf3, false);
-    Assert.assertNull(conf3.get(org.apache.tez.mapreduce.hadoop.MRJobConfig.IO_SORT_MB));
-    Assert.assertEquals(500, conf3.getLong(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 0));
+    assertNull(conf3.get(org.apache.tez.mapreduce.hadoop.MRJobConfig.IO_SORT_MB));
+    assertEquals(500, conf3.getLong(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 0));
   }
 
 }

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestMRHelpers.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestMRHelpers.java
@@ -63,12 +63,9 @@ public class TestMRHelpers {
     assertTrue(opts.contains(" fooMapJavaOpts "));
     assertFalse(opts.contains("fooReduceAdminOpts "));
     assertFalse(opts.contains(" fooReduceJavaOpts "));
-    assertTrue(opts.indexOf("fooMapAdminOpts")
-        < opts.indexOf("fooMapJavaOpts"));
-    assertTrue(opts.contains(" -D"
-        + TezConstants.TEZ_ROOT_LOGGER_NAME + "=FATAL"));
-    assertFalse(opts.contains(" -D"
-        + TezConstants.TEZ_ROOT_LOGGER_NAME + "=TRACE"));
+    assertTrue(opts.indexOf("fooMapAdminOpts") < opts.indexOf("fooMapJavaOpts"));
+    assertTrue(opts.contains(" -D" + TezConstants.TEZ_ROOT_LOGGER_NAME + "=FATAL"));
+    assertFalse(opts.contains(" -D" + TezConstants.TEZ_ROOT_LOGGER_NAME + "=TRACE"));
   }
 
   @Test
@@ -81,12 +78,9 @@ public class TestMRHelpers {
     assertFalse(opts.contains(" fooMapJavaOpts "));
     assertTrue(opts.contains("fooReduceAdminOpts"));
     assertTrue(opts.contains(" fooReduceJavaOpts "));
-    assertTrue(opts.indexOf("fooReduceAdminOpts")
-        < opts.indexOf("fooReduceJavaOpts"));
-    assertFalse(opts.contains(" -D"
-        + TezConstants.TEZ_ROOT_LOGGER_NAME + "=FATAL"));
-    assertTrue(opts.contains(" -D"
-        + TezConstants.TEZ_ROOT_LOGGER_NAME + "=TRACE"));
+    assertTrue(opts.indexOf("fooReduceAdminOpts") < opts.indexOf("fooReduceJavaOpts"));
+    assertFalse(opts.contains(" -D" + TezConstants.TEZ_ROOT_LOGGER_NAME + "=FATAL"));
+    assertTrue(opts.contains(" -D" + TezConstants.TEZ_ROOT_LOGGER_NAME + "=TRACE"));
   }
 
   @Test
@@ -96,14 +90,10 @@ public class TestMRHelpers {
     Resource mapResource = MRHelpers.getResourceForMRMapper(conf);
     Resource reduceResource = MRHelpers.getResourceForMRReducer(conf);
 
-    assertEquals(MRJobConfig.DEFAULT_MAP_CPU_VCORES,
-        mapResource.getVirtualCores());
-    assertEquals(MRJobConfig.DEFAULT_MAP_MEMORY_MB,
-        mapResource.getMemory());
-    assertEquals(MRJobConfig.DEFAULT_REDUCE_CPU_VCORES,
-        reduceResource.getVirtualCores());
-    assertEquals(MRJobConfig.DEFAULT_REDUCE_MEMORY_MB,
-        reduceResource.getMemory());
+    assertEquals(MRJobConfig.DEFAULT_MAP_CPU_VCORES, mapResource.getVirtualCores());
+    assertEquals(MRJobConfig.DEFAULT_MAP_MEMORY_MB, mapResource.getMemory());
+    assertEquals(MRJobConfig.DEFAULT_REDUCE_CPU_VCORES, reduceResource.getVirtualCores());
+    assertEquals(MRJobConfig.DEFAULT_REDUCE_MEMORY_MB, reduceResource.getMemory());
 
     conf.setInt(MRJobConfig.MAP_CPU_VCORES, 2);
     conf.setInt(MRJobConfig.MAP_MEMORY_MB, 123);
@@ -145,8 +135,7 @@ public class TestMRHelpers {
      * by the user setting (ex user may set HADOOP_HOME\\bin.
      */
     if (!Shell.WINDOWS) {
-      assertEquals("$PWD:$TEZ_ADMIN_ENV_TEST/lib/native",
-          env.get(Environment.LD_LIBRARY_PATH.name()));
+      assertEquals("$PWD:$TEZ_ADMIN_ENV_TEST/lib/native", env.get(Environment.LD_LIBRARY_PATH.name()));
     } else {
       assertTrue(env.get(Environment.PATH.name()).contains(";%TEZ_ADMIN_ENV%\\bin"));
     }

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestMRInputHelpers.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestMRInputHelpers.java
@@ -128,10 +128,8 @@ public class TestMRInputHelpers {
 
     DataSourceDescriptor dataSource = generateDataSourceDescriptorMapReduce(newSplitsDir);
 
-    assertTrue(dataSource.getAdditionalLocalFiles()
-        .containsKey(MRInputHelpers.JOB_SPLIT_RESOURCE_NAME));
-    assertTrue(dataSource.getAdditionalLocalFiles()
-        .containsKey(MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME));
+    assertTrue(dataSource.getAdditionalLocalFiles().containsKey(MRInputHelpers.JOB_SPLIT_RESOURCE_NAME));
+    assertTrue(dataSource.getAdditionalLocalFiles().containsKey(MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME));
 
     RemoteIterator<LocatedFileStatus> files =
         remoteFs.listFiles(newSplitsDir, false);
@@ -165,10 +163,8 @@ public class TestMRInputHelpers {
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldSplitsGen() throws Exception {
     DataSourceDescriptor dataSource = generateDataSourceDescriptorMapRed(oldSplitsDir);
-    assertTrue(
-        dataSource.getAdditionalLocalFiles().containsKey(MRInputHelpers.JOB_SPLIT_RESOURCE_NAME));
-    assertTrue(dataSource.getAdditionalLocalFiles()
-        .containsKey(MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME));
+    assertTrue(dataSource.getAdditionalLocalFiles().containsKey(MRInputHelpers.JOB_SPLIT_RESOURCE_NAME));
+    assertTrue(dataSource.getAdditionalLocalFiles().containsKey(MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME));
 
     RemoteIterator<LocatedFileStatus> files =
         remoteFs.listFiles(oldSplitsDir, false);
@@ -206,10 +202,8 @@ public class TestMRInputHelpers {
     Map<String, LocalResource> localResources = dataSource.getAdditionalLocalFiles();
 
     assertEquals(2, localResources.size());
-    assertTrue(localResources.containsKey(
-        MRInputHelpers.JOB_SPLIT_RESOURCE_NAME));
-    assertTrue(localResources.containsKey(
-        MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME));
+    assertTrue(localResources.containsKey(MRInputHelpers.JOB_SPLIT_RESOURCE_NAME));
+    assertTrue(localResources.containsKey(MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME));
   }
 
   @Test
@@ -299,10 +293,8 @@ public class TestMRInputHelpers {
     Map<String, LocalResource> localResources = dataSource.getAdditionalLocalFiles();
 
     assertEquals(2, localResources.size());
-    assertTrue(localResources.containsKey(
-        MRInputHelpers.JOB_SPLIT_RESOURCE_NAME));
-    assertTrue(localResources.containsKey(
-        MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME));
+    assertTrue(localResources.containsKey(MRInputHelpers.JOB_SPLIT_RESOURCE_NAME));
+    assertTrue(localResources.containsKey(MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME));
 
     for (LocalResource lr : localResources.values()) {
       assertFalse(lr.getResource().getScheme().contains(remoteFs.getScheme()));

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestMRInputHelpers.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/hadoop/TestMRInputHelpers.java
@@ -18,6 +18,11 @@
  */
 package org.apache.tez.mapreduce.hadoop;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -25,6 +30,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -49,11 +55,11 @@ import org.apache.tez.runtime.api.events.InputDataInformationEvent;
 
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestMRInputHelpers {
 
@@ -69,7 +75,7 @@ public class TestMRInputHelpers {
   private static Path testRootDir;
   private static Path localTestRootDir;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     testRootDir = new Path(Files.createTempDirectory(TestMRHelpers.class.getName()).toString());
     localTestRootDir = new Path(Files.createTempDirectory(TestMRHelpers.class.getName() + "-local").toString());
@@ -107,7 +113,7 @@ public class TestMRInputHelpers {
     remoteFs.mkdirs(new Path("/tmp/splitsDirOld/"));
     testFilePath = remoteFs.makeQualified(new Path("/tmp/input/test.xml"));
     FileStatus fsStatus = remoteFs.getFileStatus(testFilePath);
-    Assert.assertTrue(fsStatus.getLen() > 0);
+    assertTrue(fsStatus.getLen() > 0);
 
     oldSplitsDir = remoteFs.makeQualified(new Path("/tmp/splitsDirOld/"));
     newSplitsDir = remoteFs.makeQualified(new Path("/tmp/splitsDirNew/"));
@@ -116,14 +122,15 @@ public class TestMRInputHelpers {
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNewSplitsGen() throws Exception {
 
     DataSourceDescriptor dataSource = generateDataSourceDescriptorMapReduce(newSplitsDir);
 
-    Assert.assertTrue(dataSource.getAdditionalLocalFiles()
+    assertTrue(dataSource.getAdditionalLocalFiles()
         .containsKey(MRInputHelpers.JOB_SPLIT_RESOURCE_NAME));
-    Assert.assertTrue(dataSource.getAdditionalLocalFiles()
+    assertTrue(dataSource.getAdditionalLocalFiles()
         .containsKey(MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME));
 
     RemoteIterator<LocatedFileStatus> files =
@@ -142,24 +149,25 @@ public class TestMRInputHelpers {
       } else if (fName.equals(MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME)) {
         foundMetaFile = true;
       } else {
-        Assert.fail("Found invalid file in splits dir, filename=" + fName);
+        fail("Found invalid file in splits dir, filename=" + fName);
       }
-      Assert.assertTrue(status.getLen() > 0);
+      assertTrue(status.getLen() > 0);
     }
 
-    Assert.assertEquals(2, totalFilesFound);
-    Assert.assertTrue(foundSplitsFile);
-    Assert.assertTrue(foundMetaFile);
+    assertEquals(2, totalFilesFound);
+    assertTrue(foundSplitsFile);
+    assertTrue(foundMetaFile);
 
     verifyLocationHints(newSplitsDir, dataSource.getLocationHint().getTaskLocationHints());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldSplitsGen() throws Exception {
     DataSourceDescriptor dataSource = generateDataSourceDescriptorMapRed(oldSplitsDir);
-    Assert.assertTrue(
+    assertTrue(
         dataSource.getAdditionalLocalFiles().containsKey(MRInputHelpers.JOB_SPLIT_RESOURCE_NAME));
-    Assert.assertTrue(dataSource.getAdditionalLocalFiles()
+    assertTrue(dataSource.getAdditionalLocalFiles()
         .containsKey(MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME));
 
     RemoteIterator<LocatedFileStatus> files =
@@ -178,28 +186,29 @@ public class TestMRInputHelpers {
       } else if (fName.equals(MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME)) {
         foundMetaFile = true;
       } else {
-        Assert.fail("Found invalid file in splits dir, filename=" + fName);
+        fail("Found invalid file in splits dir, filename=" + fName);
       }
-      Assert.assertTrue(status.getLen() > 0);
+      assertTrue(status.getLen() > 0);
     }
 
-    Assert.assertEquals(2, totalFilesFound);
-    Assert.assertTrue(foundSplitsFile);
-    Assert.assertTrue(foundMetaFile);
+    assertEquals(2, totalFilesFound);
+    assertTrue(foundSplitsFile);
+    assertTrue(foundMetaFile);
 
     verifyLocationHints(oldSplitsDir, dataSource.getLocationHint().getTaskLocationHints());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInputSplitLocalResourceCreation() throws Exception {
     DataSourceDescriptor dataSource = generateDataSourceDescriptorMapRed(oldSplitsDir);
 
     Map<String, LocalResource> localResources = dataSource.getAdditionalLocalFiles();
 
-    Assert.assertEquals(2, localResources.size());
-    Assert.assertTrue(localResources.containsKey(
+    assertEquals(2, localResources.size());
+    assertTrue(localResources.containsKey(
         MRInputHelpers.JOB_SPLIT_RESOURCE_NAME));
-    Assert.assertTrue(localResources.containsKey(
+    assertTrue(localResources.containsKey(
         MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME));
   }
 
@@ -211,7 +220,7 @@ public class TestMRInputHelpers {
         InputDataInformationEvent.createWithSerializedPayload(0, proto.toByteString().asReadOnlyByteBuffer());
     MRSplitProto protoFromEvent = MRInputHelpers.getProto(initEvent, new JobConf(conf));
 
-    Assert.assertEquals(proto, protoFromEvent);
+    assertEquals(proto, protoFromEvent);
   }
 
   @Test
@@ -227,16 +236,16 @@ public class TestMRInputHelpers {
     }
 
     // event file is present on fs
-    Assert.assertTrue("Event file should be present on fs", localFs.exists(serializedPath));
+    assertTrue(localFs.exists(serializedPath), "Event file should be present on fs");
 
     InputDataInformationEvent initEvent =
         InputDataInformationEvent.createWithSerializedPath(0, serializedPath.toUri().toString());
     MRSplitProto protoFromEvent = MRInputHelpers.getProto(initEvent, new JobConf(conf));
 
-    Assert.assertEquals(proto, protoFromEvent);
+    assertEquals(proto, protoFromEvent);
 
     // event file is deleted after read
-    Assert.assertFalse("Event file should be deleted after read", localFs.exists(serializedPath));
+    assertFalse(localFs.exists(serializedPath), "Event file should be deleted after read");
   }
 
   private void verifyLocationHints(Path inputSplitsDir,
@@ -255,7 +264,7 @@ public class TestMRInputHelpers {
       );
     }
 
-    Assert.assertEquals(locationHints, actual);
+    assertEquals(locationHints, actual);
   }
 
   private DataSourceDescriptor generateDataSourceDescriptorMapReduce(Path inputSplitsDir)
@@ -280,7 +289,8 @@ public class TestMRInputHelpers {
     return MRInputHelpers.configureMRInputWithLegacySplitGeneration(jobConf, inputSplitsDir, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInputSplitLocalResourceCreationWithDifferentFS() throws Exception {
     Path splitsDir = localFs.resolvePath(localTestRootDir);
 
@@ -288,23 +298,23 @@ public class TestMRInputHelpers {
 
     Map<String, LocalResource> localResources = dataSource.getAdditionalLocalFiles();
 
-    Assert.assertEquals(2, localResources.size());
-    Assert.assertTrue(localResources.containsKey(
+    assertEquals(2, localResources.size());
+    assertTrue(localResources.containsKey(
         MRInputHelpers.JOB_SPLIT_RESOURCE_NAME));
-    Assert.assertTrue(localResources.containsKey(
+    assertTrue(localResources.containsKey(
         MRInputHelpers.JOB_SPLIT_METAINFO_RESOURCE_NAME));
 
     for (LocalResource lr : localResources.values()) {
-      Assert.assertFalse(lr.getResource().getScheme().contains(remoteFs.getScheme()));
+      assertFalse(lr.getResource().getScheme().contains(remoteFs.getScheme()));
     }
   }
 
-  @Before
+  @BeforeEach
   public void before() throws IOException {
     localFs.mkdirs(localTestRootDir);
   }
 
-  @After
+  @AfterEach
   public void after() throws IOException {
     localFs.delete(localTestRootDir, true);
   }

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/MRInputForTest.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/MRInputForTest.java
@@ -21,7 +21,6 @@ package org.apache.tez.mapreduce.input;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.runtime.api.InputContext;
 
-
 /**
  * This is used for inspecting jobConf in test.
  */

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/MRInputForTest.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/MRInputForTest.java
@@ -21,6 +21,7 @@ package org.apache.tez.mapreduce.input;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.runtime.api.InputContext;
 
+
 /**
  * This is used for inspecting jobConf in test.
  */

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/MultiMRInputForTest.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/MultiMRInputForTest.java
@@ -21,7 +21,6 @@ package org.apache.tez.mapreduce.input;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.runtime.api.InputContext;
 
-
 /**
  * This is used for inspecting jobConf in test.
  */

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/MultiMRInputForTest.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/MultiMRInputForTest.java
@@ -21,6 +21,7 @@ package org.apache.tez.mapreduce.input;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.runtime.api.InputContext;
 
+
 /**
  * This is used for inspecting jobConf in test.
  */

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/TestMRInput.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/TestMRInput.java
@@ -18,10 +18,11 @@
  */
 package org.apache.tez.mapreduce.input;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -33,6 +34,7 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.conf.Configuration;
@@ -54,11 +56,13 @@ import org.apache.tez.runtime.api.InputContext;
 import org.apache.tez.runtime.api.InputStatisticsReporter;
 import org.apache.tez.runtime.api.events.InputDataInformationEvent;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestMRInput {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void test0PhysicalInputs() throws IOException {
     InputContext inputContext = mock(InputContext.class);
 
@@ -92,7 +96,7 @@ public class TestMRInput {
       mrInput.handleEvents(events);
       fail("HandleEvents should cause an input with 0 physical inputs to fail");
     } catch (Exception e) {
-      assertTrue(e instanceof IllegalStateException);
+      assertInstanceOf(IllegalStateException.class, e);
     }
   }
 
@@ -113,7 +117,8 @@ public class TestMRInput {
   private static final String TEST_ATTRIBUTES_TASK_ID_STRING = "task_0_0000_1000_2000_003000";
   private static final String TEST_ATTRIBUTES_TASK_ATTEMPT_ID_STRING = "attempt_0_0000_1000_2000_003000_4000";
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAttributesInJobConf() throws Exception {
     InputContext inputContext = mock(InputContext.class);
     doReturn(TEST_ATTRIBUTES_DAG_INDEX).when(inputContext).getDagIdentifier();
@@ -155,7 +160,8 @@ public class TestMRInput {
     assertTrue(TestInputFormat.invoked.get());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConfigMerge() throws Exception {
     JobConf jobConf = new JobConf(false);
     jobConf.set("payload-key", "payload-value");

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/TestMultiMRInput.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/input/TestMultiMRInput.java
@@ -18,9 +18,10 @@
  */
 package org.apache.tez.mapreduce.input;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -35,6 +36,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.conf.Configuration;
@@ -62,9 +64,10 @@ import org.apache.tez.runtime.api.InputContext;
 import org.apache.tez.runtime.api.events.InputDataInformationEvent;
 import org.apache.tez.runtime.library.api.KeyValueReader;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,14 +91,15 @@ public class TestMultiMRInput {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     LOG.info("Setup. Using test dir: " + TEST_ROOT_DIR);
     localFs.delete(TEST_ROOT_DIR, true);
     localFs.mkdirs(TEST_ROOT_DIR);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void test0PhysicalInputs() throws Exception {
 
     Path workDir = new Path(TEST_ROOT_DIR, "testSingleSplit");
@@ -118,11 +122,12 @@ public class TestMultiMRInput {
       mMrInput.handleEvents(events);
       fail("HandleEvents should cause an input with 0 physical inputs to fail");
     } catch (Exception e) {
-      assertTrue(e instanceof IllegalStateException);
+      assertInstanceOf(IllegalStateException.class, e);
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConfigMerge() throws Exception {
     JobConf jobConf = new JobConf(false);
     jobConf.set("payload-key", "payload-value");
@@ -141,7 +146,8 @@ public class TestMultiMRInput {
     assertEquals("payload-value", mergedConfig.get("payload-key"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSingleSplit() throws Exception {
 
     Path workDir = new Path(TEST_ROOT_DIR, "testSingleSplit");
@@ -210,7 +216,8 @@ public class TestMultiMRInput {
     assertReaders(input, data, 1, inputLength.get());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleSplits() throws Exception {
 
     Path workDir = new Path(TEST_ROOT_DIR, "testMultipleSplits");
@@ -278,7 +285,8 @@ public class TestMultiMRInput {
     assertEquals(expectedReaderCounts, readerCount);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testExtraEvents() throws Exception {
     Path workDir = new Path(TEST_ROOT_DIR, "testExtraEvents");
     JobConf jobConf = new JobConf(defaultConf);
@@ -354,7 +362,7 @@ public class TestMultiMRInput {
     return inputContext;
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanUp() throws IOException {
     localFs.delete(TEST_ROOT_DIR, true);
   }

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/lib/TestKVReadersWithMR.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/lib/TestKVReadersWithMR.java
@@ -18,15 +18,16 @@
  */
 package org.apache.tez.mapreduce.lib;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
@@ -39,8 +40,9 @@ import org.apache.tez.common.counters.TezCounters;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.runtime.api.InputContext;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestKVReadersWithMR {
 
@@ -48,14 +50,15 @@ public class TestKVReadersWithMR {
   private TezCounters counters;
   private TezCounter inputRecordCounter;
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf = new JobConf();
     counters = new TezCounters();
     inputRecordCounter = counters.findCounter(TaskCounter.INPUT_RECORDS_PROCESSED);
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testMRReaderMapred() throws IOException {
     //empty
     testWithSpecificNumberOfKV(0);
@@ -78,7 +81,7 @@ public class TestKVReadersWithMR {
       records++;
       verify(mockContext, times(records)).notifyProgress();
     }
-    assertTrue(kvPairs == records);
+    assertEquals(kvPairs, records);
 
     //reading again should fail
     try {
@@ -101,7 +104,7 @@ public class TestKVReadersWithMR {
       records++;
       verify(mockContext, times(records)).notifyProgress();
     }
-    assertTrue(kvPairs == records);
+    assertEquals(kvPairs, records);
 
     //reading again should fail
     try {

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMROutput.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMROutput.java
@@ -18,7 +18,12 @@
  */
 package org.apache.tez.mapreduce.output;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import java.io.BufferedWriter;
@@ -28,6 +33,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -74,22 +80,24 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 
 public class TestMROutput {
 
   static File tmpDir;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass () {
     tmpDir = Files.createTempDir();
     tmpDir.deleteOnExit();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNewAPI_TextOutputFormat() throws Exception {
     Configuration conf = new Configuration();
     conf.setBoolean(MRConfig.IS_MAP_PROCESSOR, true);
@@ -103,8 +111,8 @@ public class TestMROutput {
     MROutput output = new MROutput(outputContext, 2);
     output.initialize();
 
-    assertEquals(true, output.isMapperOutput);
-    assertEquals(true, output.useNewApi);
+    assertTrue(output.isMapperOutput);
+    assertTrue(output.useNewApi);
     assertEquals(TextOutputFormat.class, output.newOutputFormat.getClass());
     assertNull(output.oldOutputFormat);
     assertNotNull(output.newApiTaskAttemptContext);
@@ -150,12 +158,13 @@ public class TestMROutput {
     output.initialize();
     String invalidDAGID = "invalid default";
     String dagID = output.jobConf.get(MRJobConfig.JOB_COMMITTER_UUID, invalidDAGID);
-    assertNotEquals(dagID, invalidDAGID);
-    assertNotEquals(output.jobConf.get(org.apache.hadoop.mapred.JobContext.TASK_ATTEMPT_ID), dagID);
+    assertNotEquals(invalidDAGID, dagID);
+    assertNotEquals(dagID, output.jobConf.get(org.apache.hadoop.mapred.JobContext.TASK_ATTEMPT_ID));
     assertEquals(dagID, Utils.getDAGID(outputContext));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldAPI_TextOutputFormat() throws Exception {
     Configuration conf = new Configuration();
     conf.setBoolean(MRConfig.IS_MAP_PROCESSOR, false);
@@ -170,8 +179,8 @@ public class TestMROutput {
     MROutput output = new MROutput(outputContext, 2);
     output.initialize();
 
-    assertEquals(false, output.isMapperOutput);
-    assertEquals(false, output.useNewApi);
+    assertFalse(output.isMapperOutput);
+    assertFalse(output.useNewApi);
     assertEquals(org.apache.hadoop.mapred.TextOutputFormat.class, output.oldOutputFormat.getClass());
     assertNull(output.newOutputFormat);
     assertNotNull(output.oldApiTaskAttemptContext);
@@ -181,7 +190,8 @@ public class TestMROutput {
     assertEquals(org.apache.hadoop.mapred.FileOutputCommitter.class, output.committer.getClass());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNewAPI_SequenceFileOutputFormat() throws Exception {
     JobConf conf = new JobConf();
     conf.setOutputKeyClass(NullWritable.class);
@@ -195,7 +205,7 @@ public class TestMROutput {
         new Configuration(false));
     MROutput output = new MROutput(outputContext, 2);
     output.initialize();
-    assertEquals(true, output.useNewApi);
+    assertTrue(output.useNewApi);
     assertEquals(SequenceFileOutputFormat.class, output.newOutputFormat.getClass());
     assertNull(output.oldOutputFormat);
     assertEquals(NullWritable.class, output.newApiTaskAttemptContext.getOutputKeyClass());
@@ -206,7 +216,8 @@ public class TestMROutput {
     assertEquals(FileOutputCommitter.class, output.committer.getClass());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldAPI_SequenceFileOutputFormat() throws Exception {
     JobConf conf = new JobConf();
     conf.setOutputKeyClass(NullWritable.class);
@@ -221,7 +232,7 @@ public class TestMROutput {
         new Configuration(false));
     MROutput output = new MROutput(outputContext, 2);
     output.initialize();
-    assertEquals(false, output.useNewApi);
+    assertFalse(output.useNewApi);
     assertEquals(org.apache.hadoop.mapred.SequenceFileOutputFormat.class, output.oldOutputFormat.getClass());
     assertNull(output.newOutputFormat);
     assertEquals(NullWritable.class, output.oldApiTaskAttemptContext.getOutputKeyClass());
@@ -234,7 +245,8 @@ public class TestMROutput {
 
   // test to try and use the WorkOutputPathOutputFormat - this checks that the getDefaultWorkFile is
   // set while creating recordWriters
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNewAPI_WorkOutputPathOutputFormat() throws Exception {
     Configuration conf = new Configuration();
     conf.setBoolean(MRConfig.IS_MAP_PROCESSOR, true);
@@ -248,8 +260,8 @@ public class TestMROutput {
     MROutput output = new MROutput(outputContext, 2);
     output.initialize();
 
-    assertEquals(true, output.isMapperOutput);
-    assertEquals(true, output.useNewApi);
+    assertTrue(output.isMapperOutput);
+    assertTrue(output.useNewApi);
     assertEquals(NewAPI_WorkOutputPathReadingOutputFormat.class, output.newOutputFormat.getClass());
     assertNull(output.oldOutputFormat);
     assertNotNull(output.newApiTaskAttemptContext);
@@ -261,7 +273,8 @@ public class TestMROutput {
 
   // test to try and use the WorkOutputPathOutputFormat - this checks that the workOutput path is
   // set while creating recordWriters
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldAPI_WorkOutputPathOutputFormat() throws Exception {
     Configuration conf = new Configuration();
     conf.setBoolean(MRConfig.IS_MAP_PROCESSOR, false);
@@ -275,8 +288,8 @@ public class TestMROutput {
     MROutput output = new MROutput(outputContext, 2);
     output.initialize();
 
-    assertEquals(false, output.isMapperOutput);
-    assertEquals(false, output.useNewApi);
+    assertFalse(output.isMapperOutput);
+    assertFalse(output.useNewApi);
     assertEquals(OldAPI_WorkOutputPathReadingOutputFormat.class, output.oldOutputFormat.getClass());
     assertNull(output.newOutputFormat);
     assertNotNull(output.oldApiTaskAttemptContext);
@@ -458,7 +471,7 @@ public class TestMROutput {
 
   }
 
-  @Ignore
+  @Disabled
   @Test
   public void testPerf() throws Exception {
     Configuration conf = new Configuration();

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMROutputConfigBuilder.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMROutputConfigBuilder.java
@@ -18,7 +18,10 @@
  */
 package org.apache.tez.mapreduce.output;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.lib.db.DBOutputFormat;
@@ -26,12 +29,14 @@ import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
 import org.apache.tez.dag.api.TezUncheckedException;
 import org.apache.tez.mapreduce.hadoop.MRJobConfig;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 
 public class TestMROutputConfigBuilder {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNewAPI() {
     Configuration conf = new Configuration();
     try {
@@ -48,7 +53,8 @@ public class TestMROutputConfigBuilder {
     MROutput.createConfigBuilder(conf, DBOutputFormat.class).build();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNewAPI_ThroughConf() {
     Configuration conf = new Configuration();
     try {
@@ -85,7 +91,8 @@ public class TestMROutputConfigBuilder {
     MROutput.createConfigBuilder(conf, null).build();
   }
 
-  @Test(timeout = 5000 )
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldAPI() {
     Configuration conf = new Configuration();
     try {
@@ -103,7 +110,8 @@ public class TestMROutputConfigBuilder {
     MROutput.createConfigBuilder(conf, org.apache.hadoop.mapred.lib.db.DBOutputFormat.class).build();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldAPI_ThroughConf() {
     Configuration conf = new Configuration();
     conf.setBoolean(MRJobConfig.NEW_API_REDUCER_CONFIG, false);

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMROutputConfigBuilder.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMROutputConfigBuilder.java
@@ -32,7 +32,6 @@ import org.apache.tez.mapreduce.hadoop.MRJobConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
-
 public class TestMROutputConfigBuilder {
 
   @Test

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMROutputLegacy.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMROutputLegacy.java
@@ -18,13 +18,16 @@
  */
 package org.apache.tez.mapreduce.output;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -45,14 +48,16 @@ import org.apache.tez.mapreduce.committer.MROutputCommitter;
 import org.apache.tez.mapreduce.hadoop.MRConfig;
 import org.apache.tez.runtime.api.OutputContext;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestMROutputLegacy {
   private static final File TEST_DIR = new File(System.getProperty("test.build.data"),
       TestMROutputLegacy.class.getName()).getAbsoluteFile();
 
   // simulate the behavior of translating MR to DAG using MR old API
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldAPI_MR() throws Exception {
     String outputPath = TEST_DIR.getAbsolutePath();
     JobConf conf = new JobConf();
@@ -71,7 +76,7 @@ public class TestMROutputLegacy {
     OutputContext outputContext = createMockOutputContext(sink.getOutputDescriptor().getUserPayload());
     MROutputLegacy output = new MROutputLegacy(outputContext, 2);
     output.initialize();
-    assertEquals(false, output.useNewApi);
+    assertFalse(output.useNewApi);
     assertEquals(org.apache.hadoop.mapred.SequenceFileOutputFormat.class, output.oldOutputFormat.getClass());
     assertNull(output.newOutputFormat);
     assertEquals(NullWritable.class, output.oldApiTaskAttemptContext.getOutputKeyClass());
@@ -83,7 +88,8 @@ public class TestMROutputLegacy {
   }
 
   // simulate the behavior of translating MR to DAG using MR new API
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNewAPI_MR() throws Exception {
     String outputPath = TEST_DIR.getAbsolutePath();
     Job job = Job.getInstance();
@@ -103,7 +109,7 @@ public class TestMROutputLegacy {
     OutputContext outputContext = createMockOutputContext(sink.getOutputDescriptor().getUserPayload());
     MROutputLegacy output = new MROutputLegacy(outputContext, 2);
     output.initialize();
-    assertEquals(true, output.useNewApi);
+    assertTrue(output.useNewApi);
     assertEquals(SequenceFileOutputFormat.class, output.newOutputFormat.getClass());
     assertNull(output.oldOutputFormat);
     assertEquals(NullWritable.class, output.newApiTaskAttemptContext.getOutputKeyClass());
@@ -115,7 +121,8 @@ public class TestMROutputLegacy {
   }
 
   // simulate the behavior of translating Mapper-only job to DAG using MR old API
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldAPI_MapperOnly() throws Exception {
     String outputPath = TEST_DIR.getAbsolutePath();
     JobConf conf = new JobConf();
@@ -134,7 +141,7 @@ public class TestMROutputLegacy {
     OutputContext outputContext = createMockOutputContext(sink.getOutputDescriptor().getUserPayload());
     MROutputLegacy output = new MROutputLegacy(outputContext, 2);
     output.initialize();
-    assertEquals(false, output.useNewApi);
+    assertFalse(output.useNewApi);
     assertEquals(org.apache.hadoop.mapred.SequenceFileOutputFormat.class, output.oldOutputFormat.getClass());
     assertNull(output.newOutputFormat);
     assertEquals(NullWritable.class, output.oldApiTaskAttemptContext.getOutputKeyClass());
@@ -146,7 +153,8 @@ public class TestMROutputLegacy {
   }
 
   //simulate the behavior of translating mapper-only job to DAG using MR new API
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNewAPI_MapperOnly() throws Exception {
     String outputPath = TEST_DIR.getAbsolutePath();
     Job job = Job.getInstance();
@@ -166,7 +174,7 @@ public class TestMROutputLegacy {
     OutputContext outputContext = createMockOutputContext(sink.getOutputDescriptor().getUserPayload());
     MROutputLegacy output = new MROutputLegacy(outputContext, 2);
     output.initialize();
-    assertEquals(true, output.useNewApi);
+    assertTrue(output.useNewApi);
     assertEquals(SequenceFileOutputFormat.class, output.newOutputFormat.getClass());
     assertNull(output.oldOutputFormat);
     assertEquals(NullWritable.class, output.newApiTaskAttemptContext.getOutputKeyClass());

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMultiMROutput.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/output/TestMultiMROutput.java
@@ -18,14 +18,16 @@
  */
 package org.apache.tez.mapreduce.output;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -42,70 +44,79 @@ import org.apache.tez.mapreduce.hadoop.MRConfig;
 import org.apache.tez.runtime.api.OutputContext;
 import org.apache.tez.runtime.api.OutputStatisticsReporter;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 
 public class TestMultiMROutput {
   private static final File TEST_DIR = new File(System.getProperty("test.build.data"),
       TestMultiMROutput.class.getName()).getAbsoluteFile();
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNewAPI_TextOutputFormat() throws Exception {
     validate(true, TextOutputFormat.class, true, FileOutputCommitter.class,
         false);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldAPI_TextOutputFormat() throws Exception {
     validate(false, org.apache.hadoop.mapred.TextOutputFormat.class, false,
         org.apache.hadoop.mapred.FileOutputCommitter.class, false);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNewAPI_SequenceFileOutputFormat() throws Exception {
     validate(true, SequenceFileOutputFormat.class, false,
         FileOutputCommitter.class, false);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldAPI_SequenceFileOutputFormat() throws Exception {
     validate(false, org.apache.hadoop.mapred.SequenceFileOutputFormat.class,
         false, org.apache.hadoop.mapred.FileOutputCommitter.class, false);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNewAPI_LazySequenceFileOutputFormat() throws Exception {
     validate(true, SequenceFileOutputFormat.class, false,
         FileOutputCommitter.class, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldAPI_LazySequenceFileOutputFormat() throws Exception {
     validate(false, org.apache.hadoop.mapred.SequenceFileOutputFormat.class,
         false, org.apache.hadoop.mapred.FileOutputCommitter.class, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNewAPI_LazyTextOutputFormat() throws Exception {
     validate(true, TextOutputFormat.class, false,
         FileOutputCommitter.class, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOldAPI_LazyTextOutputFormat() throws Exception {
     validate(false, org.apache.hadoop.mapred.TextOutputFormat.class, false,
         org.apache.hadoop.mapred.FileOutputCommitter.class, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidBasePath() throws Exception {
     MultiMROutput outputs = createMROutputs(SequenceFileOutputFormat.class,
         false, true);
     try {
       outputs.getWriter().write(new Text(Integer.toString(0)),
           new Text("foo"), "/tmp");
-      Assert.assertTrue(false); // should not come here
+      fail(); // should not come here
     } catch (UnsupportedOperationException uoe) {
     }
   }

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/processor/map/TestMapProcessor.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/processor/map/TestMapProcessor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tez.mapreduce.processor.map;
 
-
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -67,9 +66,10 @@ import org.apache.tez.runtime.library.common.task.local.output.TezTaskOutput;
 import org.apache.tez.runtime.library.common.task.local.output.TezTaskOutputFiles;
 import org.apache.tez.runtime.library.output.OrderedPartitionedKVOutput;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,13 +120,14 @@ public class TestMapProcessor {
     return  mapOutputFile;
   }
 
-  @Before
-  @After
+  @BeforeEach
+  @AfterEach
   public void cleanup() throws Exception {
     localFs.delete(workDir, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMapProcessor() throws Exception {
     String dagName = "mrdag0";
     String vertexName = MultiStageMRConfigUtil.getInitialMapVertexName();
@@ -175,7 +176,7 @@ public class TestMapProcessor {
 
       // TODO NEWTEZ FIXME OutputCommitter verification
 //    MRTask mrTask = (MRTask)t.getProcessor();
-//    Assert.assertEquals(TezNullOutputCommitter.class.getName(), mrTask
+//    assertEquals(TezNullOutputCommitter.class.getName(), mrTask
 //        .getCommitter().getClass().getName());
 //    t.close();
 
@@ -227,7 +228,8 @@ public class TestMapProcessor {
     }
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testMapProcessorProgress() throws Exception {
     String dagName = "mrdag0";
     String vertexName = MultiStageMRConfigUtil.getInitialMapVertexName();

--- a/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/processor/reduce/TestReduceProcessor.java
+++ b/tez-mapreduce/src/test/java/org/apache/tez/mapreduce/processor/reduce/TestReduceProcessor.java
@@ -18,6 +18,8 @@
  */
 package org.apache.tez.mapreduce.processor.reduce;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -26,6 +28,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -80,10 +83,10 @@ import org.apache.tez.runtime.library.output.OrderedPartitionedKVOutput;
 
 import com.google.common.collect.HashMultimap;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,13 +125,14 @@ public class TestReduceProcessor {
     job.setInt(MRJobConfig.FILEOUTPUTCOMMITTER_ALGORITHM_VERSION, 1);
   }
 
-  @Before
-  @After
+  @BeforeEach
+  @AfterEach
   public void cleanup() throws Exception {
     localFs.delete(workDir, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testReduceProcessor() throws Exception {
     final String dagName = "mrdag0";
     String mapVertexName = MultiStageMRConfigUtil.getInitialMapVertexName();
@@ -171,12 +175,12 @@ public class TestReduceProcessor {
     mapTask.close();
 
     // One VME, One DME
-    Assert.assertEquals(2, testUmbilical.getEvents().size());
-    Assert.assertEquals(EventType.VERTEX_MANAGER_EVENT, testUmbilical.getEvents().get(0).getEventType());
-    Assert.assertEquals(EventType.COMPOSITE_DATA_MOVEMENT_EVENT, testUmbilical.getEvents().get(1).getEventType());
+    assertEquals(2, testUmbilical.getEvents().size());
+    assertEquals(EventType.VERTEX_MANAGER_EVENT, testUmbilical.getEvents().get(0).getEventType());
+    assertEquals(EventType.COMPOSITE_DATA_MOVEMENT_EVENT, testUmbilical.getEvents().get(1).getEventType());
 
     CompositeDataMovementEvent cdmEvent = (CompositeDataMovementEvent) testUmbilical.getEvents().get(1).getEvent();
-    Assert.assertEquals(1, cdmEvent.getCount());
+    assertEquals(1, cdmEvent.getCount());
     DataMovementEvent dme = cdmEvent.getEvents().iterator().next();
     dme.setTargetIndex(0);
 
@@ -248,7 +252,7 @@ public class TestReduceProcessor {
     // MRTask mrTask = (MRTask)t.getProcessor();
     // TODO NEWTEZ Verify the partitioner has not been created
     // Likely not applicable anymore.
-    // Assert.assertNull(mrTask.getPartitioner());
+    // assertNull(mrTask.getPartitioner());
 
 
 
@@ -267,7 +271,7 @@ public class TestReduceProcessor {
     long prev = Long.MIN_VALUE;
     while (reader.next(key, value)) {
       if (prev != Long.MIN_VALUE) {
-        Assert.assertTrue(prev < key.get());
+        assertTrue(prev < key.get());
         prev = key.get();
       }
     }

--- a/tez-plugins/tez-aux-services/pom.xml
+++ b/tez-plugins/tez-aux-services/pom.xml
@@ -143,13 +143,8 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/tez-plugins/tez-aux-services/src/test/java/org/apache/tez/auxservices/TestIndexCache.java
+++ b/tez-plugins/tez-aux-services/src/test/java/org/apache/tez/auxservices/TestIndexCache.java
@@ -19,7 +19,9 @@
 package org.apache.tez.auxservices;
 
 import static org.apache.tez.auxservices.IndexCache.INDEX_CACHE_MB;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.DataOutputStream;
 import java.io.FileNotFoundException;
@@ -38,15 +40,15 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.tez.runtime.library.common.Constants;
 import org.apache.tez.runtime.library.common.sort.impl.TezIndexRecord;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestIndexCache {
   private Configuration conf;
   private FileSystem fs;
   private Path p;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf).getRaw();
@@ -249,7 +251,7 @@ public class TestIndexCache {
       }
       getInfoThread.join();
       removeMapThread.join();
-      assertEquals(true, cache.checkTotalMemoryUsed());
+      assertTrue(cache.checkTotalMemoryUsed());
     }
   }
 

--- a/tez-plugins/tez-aux-services/src/test/java/org/apache/tez/auxservices/TestShuffleHandler.java
+++ b/tez-plugins/tez-aux-services/src/test/java/org/apache/tez/auxservices/TestShuffleHandler.java
@@ -19,10 +19,12 @@
 package org.apache.tez.auxservices;
 
 import static io.netty.buffer.Unpooled.wrappedBuffer;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
@@ -46,6 +48,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -74,6 +77,8 @@ import org.apache.hadoop.yarn.server.api.ApplicationInitializationContext;
 import org.apache.hadoop.yarn.server.api.ApplicationTerminationContext;
 import org.apache.hadoop.yarn.server.api.AuxiliaryLocalPathHandler;
 import org.apache.hadoop.yarn.server.records.Version;
+import org.apache.tez.auxservices.ShuffleHandler.ReduceMapFileCount;
+import org.apache.tez.auxservices.ShuffleHandler.TimeoutHandler;
 import org.apache.tez.common.security.JobTokenIdentifier;
 import org.apache.tez.common.security.JobTokenSecretManager;
 import org.apache.tez.dag.api.TezConfiguration;
@@ -95,14 +100,16 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpHeaders.Names;
+import io.netty.handler.codec.http.HttpHeaders.Values;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -266,7 +273,8 @@ public class TestShuffleHandler {
    *
    * @throws Exception exception
    */
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSerializeMeta()  throws Exception {
     assertEquals(1, ShuffleHandler.deserializeMetaData(
         ShuffleHandler.serializeMetaData(1)));
@@ -281,7 +289,8 @@ public class TestShuffleHandler {
    *
    * @throws Exception exception
    */
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testShuffleMetrics() throws Exception {
     MetricsSystem ms = new MetricsSystemImpl();
     ShuffleHandler sh = new ShuffleHandler(ms);
@@ -319,7 +328,8 @@ public class TestShuffleHandler {
    *
    * @throws Exception exception.
    */
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testClientClosesConnection() throws Exception {
     final AtomicBoolean failureEncountered = new AtomicBoolean(false);
     Configuration conf = getInitialConf();
@@ -400,15 +410,14 @@ public class TestShuffleHandler {
         ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
     conn.connect();
     DataInputStream input = new DataInputStream(conn.getInputStream());
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
-    Assert.assertEquals("close", conn.getHeaderField(HttpHeaders.Names.CONNECTION));
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals("close", conn.getHeaderField(HttpHeaders.Names.CONNECTION));
     ShuffleHeader header = new ShuffleHeader();
     header.readFields(input);
     input.close();
 
     shuffleHandler.close();
-    Assert.assertTrue("sendError called when client closed connection",
-        !failureEncountered.get());
+    assertFalse(failureEncountered.get(), "sendError called when client closed connection");
   }
 
   static class LastSocketAddress {
@@ -421,7 +430,8 @@ public class TestShuffleHandler {
     }
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testKeepAlive() throws Exception {
     final AtomicBoolean failureEncountered = new AtomicBoolean(false);
     Configuration conf = getInitialConf();
@@ -529,11 +539,11 @@ public class TestShuffleHandler {
       ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
     conn.connect();
     DataInputStream input = new DataInputStream(conn.getInputStream());
-    Assert.assertEquals(HttpHeaders.Values.KEEP_ALIVE,
-      conn.getHeaderField(HttpHeaders.Names.CONNECTION));
-    Assert.assertEquals("timeout=1",
-      conn.getHeaderField(HttpHeaders.Values.KEEP_ALIVE));
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(Values.KEEP_ALIVE,
+      conn.getHeaderField(Names.CONNECTION));
+    assertEquals("timeout=1",
+      conn.getHeaderField(Values.KEEP_ALIVE));
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     ShuffleHeader header = new ShuffleHeader();
     header.readFields(input);
     byte[] buffer = new byte[1024];
@@ -552,19 +562,19 @@ public class TestShuffleHandler {
       ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
     conn.connect();
     input = new DataInputStream(conn.getInputStream());
-    Assert.assertEquals(HttpHeaders.Values.KEEP_ALIVE,
-      conn.getHeaderField(HttpHeaders.Names.CONNECTION));
-    Assert.assertEquals("timeout=1",
-      conn.getHeaderField(HttpHeaders.Values.KEEP_ALIVE));
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    assertEquals(Values.KEEP_ALIVE,
+      conn.getHeaderField(Names.CONNECTION));
+    assertEquals("timeout=1",
+      conn.getHeaderField(Values.KEEP_ALIVE));
+    assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     header = new ShuffleHeader();
     header.readFields(input);
     input.close();
     SocketAddress secondAddress = lastSocketAddress.getSocketAddress();
-    Assert.assertNotNull("Initial shuffle address should not be null", firstAddress);
-    Assert.assertNotNull("Keep-Alive shuffle address should not be null", secondAddress);
-    Assert.assertEquals("Initial shuffle address and keep-alive shuffle "
-        + "address should be the same", firstAddress, secondAddress);
+    assertNotNull(firstAddress, "Initial shuffle address should not be null");
+    assertNotNull(secondAddress, "Keep-Alive shuffle address should not be null");
+    assertEquals(firstAddress, secondAddress, "Initial shuffle address and keep-alive shuffle "
+        + "address should be the same");
     shuffleHandler.close();
   }
 
@@ -598,8 +608,7 @@ public class TestShuffleHandler {
           ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
       conn.connect();
       conn.getInputStream();
-      Assert.assertTrue("socket should be set KEEP_ALIVE",
-          shuffleHandler.isSocketKeepAlive());
+      assertTrue(shuffleHandler.isSocketKeepAlive(), "socket should be set KEEP_ALIVE");
     } finally {
       if (conn != null) {
         conn.disconnect();
@@ -614,7 +623,8 @@ public class TestShuffleHandler {
    *
    * @throws Exception exception
    */
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testIncompatibleShuffleVersion() throws Exception {
     final int failureNum = 3;
     Configuration conf = getInitialConf();
@@ -634,7 +644,7 @@ public class TestShuffleHandler {
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
           i == 1 ? "1.0.0" : "1.0.1");
       conn.connect();
-      Assert.assertEquals(
+      assertEquals(
           HttpURLConnection.HTTP_BAD_REQUEST, conn.getResponseCode());
     }
 
@@ -646,7 +656,8 @@ public class TestShuffleHandler {
    *
    * @throws Exception exception
    */
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testMaxConnections() throws Exception {
 
     Configuration conf = getInitialConf();
@@ -731,21 +742,21 @@ public class TestShuffleHandler {
     //Ensure first connections are okay
     conns[0].getInputStream();
     int rc = conns[0].getResponseCode();
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, rc);
+    assertEquals(HttpURLConnection.HTTP_OK, rc);
 
     conns[1].getInputStream();
     rc = conns[1].getResponseCode();
-    Assert.assertEquals(HttpURLConnection.HTTP_OK, rc);
+    assertEquals(HttpURLConnection.HTTP_OK, rc);
 
     // This connection should be closed because it to above the limit
     try {
       conns[2].getInputStream();
       rc = conns[2].getResponseCode();
-      Assert.fail("Expected a SocketException");
+      fail("Expected a SocketException");
     } catch (SocketException se) {
       LOG.info("Expected - connection should not be open");
     } catch (Exception e) {
-      Assert.fail("Expected a SocketException");
+      fail("Expected a SocketException");
     }
 
     shuffleHandler.close();
@@ -754,7 +765,8 @@ public class TestShuffleHandler {
   /**
    * Validate the ranged fetch works as expected
    */
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testRangedFetch() throws IOException {
     Configuration conf = getInitialConf();
     conf.setInt(ShuffleHandler.MAX_SHUFFLE_CONNECTIONS, 3);
@@ -806,8 +818,8 @@ public class TestShuffleHandler {
         for (int i = 0; i < partitionCount; i++) {
           ShuffleHeader header = new ShuffleHeader();
           header.readFields(is);
-          Assert.assertEquals("Incorrect map id", "attempt_12345_1_m_1_0", header.getMapId());
-          Assert.assertEquals("Incorrect reduce id", i, header.getPartition());
+          assertEquals("attempt_12345_1_m_1_0", header.getMapId(), "Incorrect map id");
+          assertEquals(i, header.getPartition(), "Incorrect reduce id");
           headers.add(header);
         }
         for (ShuffleHeader header: headers) {
@@ -817,9 +829,9 @@ public class TestShuffleHandler {
         succeeded = true;
         // Read one more byte to force EOF
         is.readByte();
-        Assert.fail("More fetch bytes that expected in stream");
+        fail("More fetch bytes that expected in stream");
       } catch (EOFException e) {
-        Assert.assertTrue("Failed to copy ranged fetch", succeeded);
+        assertTrue(succeeded, "Failed to copy ranged fetch");
       }
 
     } finally {
@@ -831,7 +843,8 @@ public class TestShuffleHandler {
   /**
    * Validate the ranged fetch works as expected for different amount of map attempts and reduce ranges.
    */
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testRangedFetchMultipleAttempts() throws IOException {
     runMultiAttemptMultiRangeShuffleTest(/*attemptRange*/1, /*reduceRange*/1);
     runMultiAttemptMultiRangeShuffleTest(/*attemptRange*/5, /*reduceRange*/1);
@@ -901,22 +914,22 @@ public class TestShuffleHandler {
           for (int i = reducerIdStart; i <= reducerIdEnd; i++) {
             ShuffleHeader header = new ShuffleHeader();
             header.readFields(is);
-            Assert.assertEquals("Incorrect map id", attempt, header.getMapId());
-            Assert.assertEquals("Incorrect reduce id", i, header.getPartition());
+            assertEquals(attempt, header.getMapId(), "Incorrect map id");
+            assertEquals(i, header.getPartition(), "Incorrect reduce id");
             headers.add(header);
           }
           for (ShuffleHeader header : headers) {
             byte[] bytes = new byte[(int) header.getCompressedLength()];
             is.read(bytes);
-            Assert.assertEquals(TEST_PARTITION_DATA_STRING, new String(bytes));
+            assertEquals(TEST_PARTITION_DATA_STRING, new String(bytes));
           }
         }
         succeeded = true;
         // Read one more byte to force EOF
         is.readByte();
-        Assert.fail("More fetch bytes that expected in stream");
+        fail("More fetch bytes that expected in stream");
       } catch (EOFException e) {
-        Assert.assertTrue("Failed to copy ranged fetch", succeeded);
+        assertTrue(succeeded, "Failed to copy ranged fetch");
       }
 
     } finally {
@@ -931,7 +944,8 @@ public class TestShuffleHandler {
    *
    * @throws Exception exception
    */
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100000, unit = TimeUnit.MILLISECONDS)
   public void testMapFileAccess() throws IOException {
     // This will run only in NativeIO is enabled as SecureIOUtils need it
     assumeTrue(NativeIO.isAvailable());
@@ -991,7 +1005,7 @@ public class TestShuffleHandler {
       String message =
           "Owner '" + owner + "' for path " + fileMap.get(0).getAbsolutePath()
               + " did not match expected owner '" + user + "'";
-      Assert.assertTrue((new String(byteArr)).contains(message));
+      assertTrue((new String(byteArr)).contains(message));
     } finally {
       shuffleHandler.close();
       FileUtil.fullyDelete(TEST_DIR);
@@ -1079,7 +1093,7 @@ public class TestShuffleHandler {
 
       // verify we are authorized to shuffle
       int rc = getShuffleResponseCode(shuffle, jt);
-      Assert.assertEquals(HttpURLConnection.HTTP_OK, rc);
+      assertEquals(HttpURLConnection.HTTP_OK, rc);
 
       // emulate shuffle handler restart
       shuffle.close();
@@ -1090,12 +1104,12 @@ public class TestShuffleHandler {
 
       // verify we are still authorized to shuffle to the old application
       rc = getShuffleResponseCode(shuffle, jt);
-      Assert.assertEquals(HttpURLConnection.HTTP_OK, rc);
+      assertEquals(HttpURLConnection.HTTP_OK, rc);
 
       // shutdown app and verify access is lost
       shuffle.stopApplication(new ApplicationTerminationContext(appId));
       rc = getShuffleResponseCode(shuffle, jt);
-      Assert.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, rc);
+      assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, rc);
 
       // emulate shuffle handler restart
       shuffle.close();
@@ -1106,7 +1120,7 @@ public class TestShuffleHandler {
 
       // verify we still don't have access
       rc = getShuffleResponseCode(shuffle, jt);
-      Assert.assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, rc);
+      assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, rc);
     } finally {
       if (shuffle != null) {
         shuffle.close();
@@ -1145,7 +1159,7 @@ public class TestShuffleHandler {
 
       // verify we are authorized to shuffle
       int rc = getShuffleResponseCode(shuffle, jt);
-      Assert.assertEquals(HttpURLConnection.HTTP_OK, rc);
+      assertEquals(HttpURLConnection.HTTP_OK, rc);
 
       // emulate shuffle handler restart
       shuffle.close();
@@ -1156,15 +1170,15 @@ public class TestShuffleHandler {
 
       // verify we are still authorized to shuffle to the old application
       rc = getShuffleResponseCode(shuffle, jt);
-      Assert.assertEquals(HttpURLConnection.HTTP_OK, rc);
+      assertEquals(HttpURLConnection.HTTP_OK, rc);
       Version version = Version.newInstance(1, 0);
-      Assert.assertEquals(version, shuffle.getCurrentVersion());
+      assertEquals(version, shuffle.getCurrentVersion());
 
       // emulate shuffle handler restart with compatible version
       Version version11 = Version.newInstance(1, 1);
       // update version info before close shuffle
       shuffle.storeVersion(version11);
-      Assert.assertEquals(version11, shuffle.loadVersion());
+      assertEquals(version11, shuffle.loadVersion());
       shuffle.close();
       shuffle = new ShuffleHandler();
       shuffle.setRecoveryPath(new Path(tmpDir.toString()));
@@ -1172,15 +1186,15 @@ public class TestShuffleHandler {
       shuffle.start();
       // shuffle version will be override by CURRENT_VERSION_INFO after restart
       // successfully.
-      Assert.assertEquals(version, shuffle.loadVersion());
+      assertEquals(version, shuffle.loadVersion());
       // verify we are still authorized to shuffle to the old application
       rc = getShuffleResponseCode(shuffle, jt);
-      Assert.assertEquals(HttpURLConnection.HTTP_OK, rc);
+      assertEquals(HttpURLConnection.HTTP_OK, rc);
 
       // emulate shuffle handler restart with incompatible version
       Version version21 = Version.newInstance(2, 1);
       shuffle.storeVersion(version21);
-      Assert.assertEquals(version21, shuffle.loadVersion());
+      assertEquals(version21, shuffle.loadVersion());
       shuffle.close();
       shuffle = new ShuffleHandler();
       shuffle.setRecoveryPath(new Path(tmpDir.toString()));
@@ -1188,10 +1202,9 @@ public class TestShuffleHandler {
 
       try {
         shuffle.start();
-        Assert.fail("Incompatible version, should expect fail here.");
+        fail("Incompatible version, should expect fail here.");
       } catch (ServiceStateException e) {
-        Assert.assertTrue("Exception message mismatch",
-        e.getMessage().contains("Incompatible version for state DB schema:"));
+        assertTrue(e.getMessage().contains("Incompatible version for state DB schema:"), "Exception message mismatch");
       }
 
     } finally {
@@ -1224,7 +1237,8 @@ public class TestShuffleHandler {
     return rc;
   }
 
-  @Test(timeout = 100000)
+  @Test
+  @Timeout(value = 100000, unit = TimeUnit.MILLISECONDS)
   public void testGetMapOutputInfo() throws Exception {
     final AtomicBoolean failureEncountered = new AtomicBoolean(false);
     Configuration conf = getInitialConf();
@@ -1321,15 +1335,15 @@ public class TestShuffleHandler {
       } catch (EOFException e) {
         // ignore
       }
-      Assert.assertEquals("sendError called due to shuffle error",
-          false, failureEncountered.get());
+      assertFalse(failureEncountered.get(), "sendError called due to shuffle error");
     } finally {
       shuffleHandler.close();
       FileUtil.fullyDelete(TEST_DIR);
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDagDelete() throws Exception {
     final AtomicBoolean failureEncountered = new AtomicBoolean(false);
     Configuration conf = getInitialConf();
@@ -1400,17 +1414,16 @@ public class TestShuffleHandler {
                   ShuffleHandler.USERCACHE, user,
                   ShuffleHandler.APPCACHE, appId.toString(),"dag_1/"});
       File dagDir = new File(dagDirStr);
-      Assert.assertTrue("Dag Directory does not exist!", dagDir.exists());
+      assertTrue(dagDir.exists(), "Dag Directory does not exist!");
       conn.connect();
       try {
         DataInputStream is = new DataInputStream(conn.getInputStream());
         is.close();
-        Assert.assertFalse("Dag Directory was not deleted!", dagDir.exists());
+        assertFalse(dagDir.exists(), "Dag Directory was not deleted!");
       } catch (EOFException e) {
         // ignore
       }
-      Assert.assertEquals("sendError called due to shuffle error",
-          false, failureEncountered.get());
+      assertFalse(failureEncountered.get(), "sendError called due to shuffle error");
     } finally {
       shuffleHandler.close();
       FileUtil.fullyDelete(TEST_DIR);
@@ -1433,7 +1446,7 @@ public class TestShuffleHandler {
     String vertexDirStr = StringUtils.join(Path.SEPARATOR, new String[] { TEST_DIR.getAbsolutePath(),
         ShuffleHandler.USERCACHE, user, ShuffleHandler.APPCACHE, appId.toString(), "dag_1/output/" + appAttemptId});
     File vertexDir = new File(vertexDirStr);
-    Assert.assertFalse("vertex directory should not be present", vertexDir.exists());
+    assertFalse(vertexDir.exists(), "vertex directory should not be present");
     createShuffleHandlerFiles(TEST_DIR, user, appId.toString(), appAttemptId,
             conf, fileMap);
     ShuffleHandler shuffleHandler = new ShuffleHandler() {
@@ -1486,12 +1499,12 @@ public class TestShuffleHandler {
               ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
               ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
-      Assert.assertTrue("Attempt Directory does not exist!", vertexDir.exists());
+      assertTrue(vertexDir.exists(), "Attempt Directory does not exist!");
       conn.connect();
       try {
         DataInputStream is = new DataInputStream(conn.getInputStream());
         is.close();
-        Assert.assertFalse("Vertex Directory was not deleted", vertexDir.exists());
+        assertFalse(vertexDir.exists(), "Vertex Directory was not deleted");
       } catch (EOFException e) {
         fail("Encountered Exception!" + e.getMessage());
       }
@@ -1501,7 +1514,8 @@ public class TestShuffleHandler {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFailedTaskAttemptDelete() throws Exception {
     final ArrayList<Throwable> failures = new ArrayList<Throwable>(1);
     Configuration conf = getInitialConf();
@@ -1520,7 +1534,7 @@ public class TestShuffleHandler {
                             ShuffleHandler.USERCACHE, user,
                             ShuffleHandler.APPCACHE, appId.toString(), "dag_1/output/", appAttemptId});
     File taskAttemptDir = new File(taskAttemptDirStr);
-    Assert.assertFalse("Task Attempt Directory should not exist", taskAttemptDir.exists());
+    assertFalse(taskAttemptDir.exists(), "Task Attempt Directory should not exist");
     createShuffleHandlerFiles(TEST_DIR, user, appId.toString(), appAttemptId,
         conf, fileMap);
     ShuffleHandler shuffleHandler = new ShuffleHandler() {
@@ -1573,24 +1587,24 @@ public class TestShuffleHandler {
           ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
           ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
-      Assert.assertTrue("Task Attempt Directory does not exist!", taskAttemptDir.exists());
+      assertTrue(taskAttemptDir.exists(), "Task Attempt Directory does not exist!");
       conn.connect();
       try {
         DataInputStream is = new DataInputStream(conn.getInputStream());
         is.close();
-        Assert.assertFalse("Task Attempt file was not deleted!", taskAttemptDir.exists());
+        assertFalse(taskAttemptDir.exists(), "Task Attempt file was not deleted!");
       } catch (EOFException e) {
         // ignore
       }
-      Assert.assertEquals("sendError called due to shuffle error",
-          0, failures.size());
+      assertEquals(0, failures.size(), "sendError called due to shuffle error");
     } finally {
       shuffleHandler.close();
       FileUtil.fullyDelete(TEST_DIR);
     }
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testUnauthenticatedDeleteIsRejected() throws Exception {
     Configuration conf = getInitialConf();
     conf.setInt(ShuffleHandler.MAX_SHUFFLE_CONNECTIONS, 3);
@@ -1641,7 +1655,7 @@ public class TestShuffleHandler {
                   appAttemptId});
       File taskAttemptDir = new File(taskAttemptDirStr);
 
-      Assert.assertTrue("Dag Directory does not exist!", dagDir.exists());
+      assertTrue(dagDir.exists(), "Dag Directory does not exist!");
       HttpURLConnection conn = (HttpURLConnection) URI.create(baseUrl
           + "/mapOutput?dagAction=delete&job=job_12345_0001&dag=1").toURL().openConnection();
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
@@ -1649,11 +1663,13 @@ public class TestShuffleHandler {
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
           ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
       conn.connect();
-      Assert.assertEquals("Unauthenticated dag delete should return 401",
-          HttpURLConnection.HTTP_UNAUTHORIZED, conn.getResponseCode());
-      Assert.assertTrue(
-          "Dag Directory should NOT have been deleted after unauthenticated request",
-          dagDir.exists());
+      assertEquals(
+          HttpURLConnection.HTTP_UNAUTHORIZED,
+          conn.getResponseCode(),
+          "Unauthenticated dag delete should return 401");
+      assertTrue(
+          dagDir.exists(),
+          "Dag Directory should NOT have been deleted after unauthenticated request");
 
       conn = (HttpURLConnection) URI.create(baseUrl
           + "/mapOutput?vertexAction=delete&job=job_12345_0001&dag=1&vertex=00").toURL().openConnection();
@@ -1662,13 +1678,15 @@ public class TestShuffleHandler {
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
           ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
       conn.connect();
-      Assert.assertEquals("Unauthenticated vertex delete should return 401",
-          HttpURLConnection.HTTP_UNAUTHORIZED, conn.getResponseCode());
-      Assert.assertTrue(
-          "Dag Directory should NOT have been deleted after unauthenticated vertex delete request",
-          dagDir.exists());
+      assertEquals(
+          HttpURLConnection.HTTP_UNAUTHORIZED,
+          conn.getResponseCode(),
+          "Unauthenticated vertex delete should return 401");
+      assertTrue(
+          dagDir.exists(),
+          "Dag Directory should NOT have been deleted after unauthenticated vertex delete request");
 
-      Assert.assertTrue("Task Attempt Directory does not exist!", taskAttemptDir.exists());
+      assertTrue(taskAttemptDir.exists(), "Task Attempt Directory does not exist!");
       conn = (HttpURLConnection) URI.create(baseUrl
           + "/mapOutput?taskAttemptAction=delete&job=job_12345_0001&dag=1&map="
           + appAttemptId).toURL().openConnection();
@@ -1677,21 +1695,24 @@ public class TestShuffleHandler {
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
           ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
       conn.connect();
-      Assert.assertEquals("Unauthenticated task attempt delete should return 401",
-          HttpURLConnection.HTTP_UNAUTHORIZED, conn.getResponseCode());
-      Assert.assertTrue(
-          "Task Attempt Directory should NOT have been deleted after unauthenticated request",
-          taskAttemptDir.exists());
+      assertEquals(
+          HttpURLConnection.HTTP_UNAUTHORIZED,
+          conn.getResponseCode(),
+          "Unauthenticated task attempt delete should return 401");
+      assertTrue(
+          taskAttemptDir.exists(),
+          "Task Attempt Directory should NOT have been deleted after unauthenticated request");
     } finally {
       shuffleHandler.close();
       FileUtil.fullyDelete(TEST_DIR);
     }
   }
 
-  @Test(timeout = 4000)
+  @Test
+  @Timeout(value = 4000, unit = TimeUnit.MILLISECONDS)
   public void testSendMapCount() throws Exception {
-    final List<ShuffleHandler.ReduceMapFileCount> listenerList =
-        new ArrayList<ShuffleHandler.ReduceMapFileCount>();
+    final List<ReduceMapFileCount> listenerList =
+        new ArrayList<ReduceMapFileCount>();
 
     final ChannelHandlerContext mockCtx =
         mock(ChannelHandlerContext.class);
@@ -1702,8 +1723,8 @@ public class TestShuffleHandler {
     final FullHttpRequest httpRequest = createHttpRequest();
     final ChannelFuture mockFuture = createMockChannelFuture(mockCh,
         listenerList);
-    final ShuffleHandler.TimeoutHandler timerHandler =
-        new ShuffleHandler.TimeoutHandler();
+    final TimeoutHandler timerHandler =
+        new TimeoutHandler();
 
     // Mock Netty Channel Context and Channel behavior
     doReturn(mockCh).when(mockCtx).channel();
@@ -1720,14 +1741,12 @@ public class TestShuffleHandler {
     int maxOpenFiles =conf.getInt(ShuffleHandler.SHUFFLE_MAX_SESSION_OPEN_FILES,
         ShuffleHandler.DEFAULT_SHUFFLE_MAX_SESSION_OPEN_FILES);
     sh.getShuffle(conf).channelRead(mockCtx, httpRequest);
-    assertTrue("Number of Open files should not exceed the configured " +
-            "value!-Not Expected",
-        listenerList.size() <= maxOpenFiles);
+    assertTrue(listenerList.size() <= maxOpenFiles, "Number of Open files should not exceed the configured " +
+            "value!-Not Expected");
     while(!listenerList.isEmpty()) {
       listenerList.remove(0).operationComplete(mockFuture);
-      assertTrue("Number of Open files should not exceed the configured " +
-              "value!-Not Expected",
-          listenerList.size() <= maxOpenFiles);
+      assertTrue(listenerList.size() <= maxOpenFiles, "Number of Open files should not exceed the configured " +
+              "value!-Not Expected");
     }
     sh.close();
   }
@@ -1755,7 +1774,7 @@ public class TestShuffleHandler {
           httpConnectionParams, "testFetcher", shuffleHandler.secretManager);
 
       boolean connectSucceeded = httpConnection.connect();
-      Assert.assertTrue(connectSucceeded);
+      assertTrue(connectSucceeded);
 
       input = httpConnection.getInputStream();
       httpConnection.validate();
@@ -1764,12 +1783,12 @@ public class TestShuffleHandler {
       header.readFields(input);
 
       // message is encoded in the shuffle header, and can be checked by fetchers
-      Assert.assertEquals(
+      assertEquals(
           ShuffleHandlerError.DISK_ERROR_EXCEPTION + ": " + MockShuffleHandlerWithFatalDiskError.MESSAGE,
           header.getMapId());
-      Assert.assertEquals(-1, header.getCompressedLength());
-      Assert.assertEquals(-1, header.getUncompressedLength());
-      Assert.assertEquals(-1, header.getPartition());
+      assertEquals(-1, header.getCompressedLength());
+      assertEquals(-1, header.getUncompressedLength());
+      assertEquals(-1, header.getPartition());
     } finally {
       if (input != null) {
         input.close();
@@ -1817,7 +1836,7 @@ public class TestShuffleHandler {
     shuffleHandler.serviceInit(conf);
     try {
       shuffleHandler.serviceStart();
-      Assert.assertEquals(port, shuffleHandler.getPort());
+      assertEquals(port, shuffleHandler.getPort());
     } finally {
       shuffleHandler.close();
     }
@@ -1830,7 +1849,7 @@ public class TestShuffleHandler {
     shuffleHandler.serviceInit(conf);
     try {
       shuffleHandler.serviceStart();
-      Assert.assertTrue("ShuffleHandler should use a random chosen port", shuffleHandler.getPort() > 0);
+      assertTrue(shuffleHandler.getPort() > 0, "ShuffleHandler should use a random chosen port");
     } finally {
       shuffleHandler.close();
     }

--- a/tez-plugins/tez-aux-services/src/test/java/org/apache/tez/auxservices/TestShuffleHandler.java
+++ b/tez-plugins/tez-aux-services/src/test/java/org/apache/tez/auxservices/TestShuffleHandler.java
@@ -539,10 +539,8 @@ public class TestShuffleHandler {
       ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
     conn.connect();
     DataInputStream input = new DataInputStream(conn.getInputStream());
-    assertEquals(Values.KEEP_ALIVE,
-      conn.getHeaderField(Names.CONNECTION));
-    assertEquals("timeout=1",
-      conn.getHeaderField(Values.KEEP_ALIVE));
+    assertEquals(Values.KEEP_ALIVE, conn.getHeaderField(Names.CONNECTION));
+    assertEquals("timeout=1", conn.getHeaderField(Values.KEEP_ALIVE));
     assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     ShuffleHeader header = new ShuffleHeader();
     header.readFields(input);
@@ -562,10 +560,8 @@ public class TestShuffleHandler {
       ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
     conn.connect();
     input = new DataInputStream(conn.getInputStream());
-    assertEquals(Values.KEEP_ALIVE,
-      conn.getHeaderField(Names.CONNECTION));
-    assertEquals("timeout=1",
-      conn.getHeaderField(Values.KEEP_ALIVE));
+    assertEquals(Values.KEEP_ALIVE, conn.getHeaderField(Names.CONNECTION));
+    assertEquals("timeout=1", conn.getHeaderField(Values.KEEP_ALIVE));
     assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
     header = new ShuffleHeader();
     header.readFields(input);
@@ -1663,13 +1659,9 @@ public class TestShuffleHandler {
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
           ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
       conn.connect();
-      assertEquals(
-          HttpURLConnection.HTTP_UNAUTHORIZED,
-          conn.getResponseCode(),
+      assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, conn.getResponseCode(),
           "Unauthenticated dag delete should return 401");
-      assertTrue(
-          dagDir.exists(),
-          "Dag Directory should NOT have been deleted after unauthenticated request");
+      assertTrue(dagDir.exists(), "Dag Directory should NOT have been deleted after unauthenticated request");
 
       conn = (HttpURLConnection) URI.create(baseUrl
           + "/mapOutput?vertexAction=delete&job=job_12345_0001&dag=1&vertex=00").toURL().openConnection();
@@ -1678,12 +1670,9 @@ public class TestShuffleHandler {
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
           ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
       conn.connect();
-      assertEquals(
-          HttpURLConnection.HTTP_UNAUTHORIZED,
-          conn.getResponseCode(),
+      assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, conn.getResponseCode(),
           "Unauthenticated vertex delete should return 401");
-      assertTrue(
-          dagDir.exists(),
+      assertTrue(dagDir.exists(),
           "Dag Directory should NOT have been deleted after unauthenticated vertex delete request");
 
       assertTrue(taskAttemptDir.exists(), "Task Attempt Directory does not exist!");
@@ -1695,12 +1684,9 @@ public class TestShuffleHandler {
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
           ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
       conn.connect();
-      assertEquals(
-          HttpURLConnection.HTTP_UNAUTHORIZED,
-          conn.getResponseCode(),
+      assertEquals(HttpURLConnection.HTTP_UNAUTHORIZED, conn.getResponseCode(),
           "Unauthenticated task attempt delete should return 401");
-      assertTrue(
-          taskAttemptDir.exists(),
+      assertTrue(taskAttemptDir.exists(),
           "Task Attempt Directory should NOT have been deleted after unauthenticated request");
     } finally {
       shuffleHandler.close();
@@ -1741,12 +1727,12 @@ public class TestShuffleHandler {
     int maxOpenFiles =conf.getInt(ShuffleHandler.SHUFFLE_MAX_SESSION_OPEN_FILES,
         ShuffleHandler.DEFAULT_SHUFFLE_MAX_SESSION_OPEN_FILES);
     sh.getShuffle(conf).channelRead(mockCtx, httpRequest);
-    assertTrue(listenerList.size() <= maxOpenFiles, "Number of Open files should not exceed the configured " +
-            "value!-Not Expected");
-    while(!listenerList.isEmpty()) {
-      listenerList.remove(0).operationComplete(mockFuture);
-      assertTrue(listenerList.size() <= maxOpenFiles, "Number of Open files should not exceed the configured " +
-              "value!-Not Expected");
+    assertTrue(listenerList.size() <= maxOpenFiles,
+        "Number of Open files should not exceed the configured " + "value!-Not Expected");
+    while (!listenerList.isEmpty()) {
+      listenerList.removeFirst().operationComplete(mockFuture);
+      assertTrue(listenerList.size() <= maxOpenFiles,
+          "Number of Open files should not exceed the configured " + "value!-Not Expected");
     }
     sh.close();
   }
@@ -1783,8 +1769,7 @@ public class TestShuffleHandler {
       header.readFields(input);
 
       // message is encoded in the shuffle header, and can be checked by fetchers
-      assertEquals(
-          ShuffleHandlerError.DISK_ERROR_EXCEPTION + ": " + MockShuffleHandlerWithFatalDiskError.MESSAGE,
+      assertEquals(ShuffleHandlerError.DISK_ERROR_EXCEPTION + ": " + MockShuffleHandlerWithFatalDiskError.MESSAGE,
           header.getMapId());
       assertEquals(-1, header.getCompressedLength());
       assertEquals(-1, header.getUncompressedLength());

--- a/tez-plugins/tez-aux-services/src/test/java/org/apache/tez/auxservices/TestShuffleHandlerJobs.java
+++ b/tez-plugins/tez-aux-services/src/test/java/org/apache/tez/auxservices/TestShuffleHandlerJobs.java
@@ -17,11 +17,16 @@
  * under the License.
  */
 package org.apache.tez.auxservices;
+
 import static org.apache.tez.test.TestTezJobs.generateOrderedWordCountInput;
 import static org.apache.tez.test.TestTezJobs.verifyOutput;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -40,10 +45,10 @@ import org.apache.tez.examples.OrderedWordCount;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.test.MiniTezCluster;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +63,7 @@ public class TestShuffleHandlerJobs {
   private static FileSystem remoteFs;
   private static int NUM_NMS = 5;
   private static int NUM_DNS = 5;
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     try {
       conf.setInt(YarnConfiguration.RM_AM_MAX_ATTEMPTS, 1);
@@ -94,7 +99,7 @@ public class TestShuffleHandlerJobs {
 
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (tezCluster != null) {
       tezCluster.stop();
@@ -105,7 +110,8 @@ public class TestShuffleHandlerJobs {
       dfsCluster = null;
     }
   }
-  @Test(timeout = 300000)
+  @Test
+  @Timeout(value = 300000, unit = TimeUnit.MILLISECONDS)
   public void testOrderedWordCount() throws Exception {
     String inputDirStr = "/tmp/owc-input/";
     Path inputDir = new Path(inputDirStr);
@@ -128,8 +134,8 @@ public class TestShuffleHandlerJobs {
     tezSession.start();
     try {
       final OrderedWordCount job = new OrderedWordCount();
-      Assert.assertTrue("OrderedWordCount failed", job.run(tezConf, new String[]{"-counter",
-              inputDirStr, outputDirStr, "10"}, tezSession)==0);
+      assertEquals(0, job.run(tezConf, new String[]{"-counter",
+          inputDirStr, outputDirStr, "10"}, tezSession), "OrderedWordCount failed");
       verifyOutput(outputDir, remoteFs);
       tezSession.stop();
       ClientRMService rmService = tezCluster.getResourceManager().getClientRMService();
@@ -158,9 +164,9 @@ public class TestShuffleHandlerJobs {
         String dagPathStr = appPath + "/dag_1";
 
         File fs = new File(dagPathStr);
-        Assert.assertFalse(fs.exists());
+        assertFalse(fs.exists());
         fs = new File(appPath);
-        Assert.assertTrue(fs.exists());
+        assertTrue(fs.exists());
       }
     } finally {
       remoteFs.delete(stagingDirPath, true);

--- a/tez-plugins/tez-aux-services/src/test/java/org/apache/tez/auxservices/TestShuffleHandlerJobs.java
+++ b/tez-plugins/tez-aux-services/src/test/java/org/apache/tez/auxservices/TestShuffleHandlerJobs.java
@@ -134,8 +134,8 @@ public class TestShuffleHandlerJobs {
     tezSession.start();
     try {
       final OrderedWordCount job = new OrderedWordCount();
-      assertEquals(0, job.run(tezConf, new String[]{"-counter",
-          inputDirStr, outputDirStr, "10"}, tezSession), "OrderedWordCount failed");
+      assertEquals(0, job.run(tezConf, new String[]{"-counter", inputDirStr, outputDirStr, "10"}, tezSession),
+          "OrderedWordCount failed");
       verifyOutput(outputDir, remoteFs);
       tezSession.stop();
       ClientRMService rmService = tezCluster.getResourceManager().getClientRMService();

--- a/tez-plugins/tez-history-parser/pom.xml
+++ b/tez-plugins/tez-history-parser/pom.xml
@@ -143,9 +143,8 @@
      <artifactId>commons-collections4</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
@@ -155,16 +154,6 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/TestHistoryParser.java
+++ b/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/TestHistoryParser.java
@@ -257,11 +257,9 @@ public class TestHistoryParser {
   private void checkConfig(DagInfo dagInfo) {
     assertNotNull(dagInfo, "DagInfo is " + dagInfo);
     // Check configs
-    assertFalse(
-        dagInfo.getAppConfig().isEmpty(), "DagInfo config size=" + dagInfo.getAppConfig().size());
+    assertFalse(dagInfo.getAppConfig().isEmpty(), "DagInfo config size=" + dagInfo.getAppConfig().size());
     // Sample config element
-    assertTrue(
-        Integer.parseInt(dagInfo.getAppConfig().get("dfs.replication")) > 0,
+    assertTrue(Integer.parseInt(dagInfo.getAppConfig().get("dfs.replication")) > 0,
         "DagInfo config=" + dagInfo.getAppConfig());
   }
 
@@ -269,10 +267,8 @@ public class TestHistoryParser {
     //Job specific
     assertEquals(2, dagInfo.getNumVertices());
     assertEquals("WordCount", dagInfo.getName());
-    assertEquals(dagInfo.getVertex(TOKENIZER).getProcessorClassName(),
-        TokenProcessor.class.getName());
-    assertEquals(dagInfo.getVertex(SUMMATION).getProcessorClassName(),
-        SumProcessor.class.getName());
+    assertEquals(dagInfo.getVertex(TOKENIZER).getProcessorClassName(), TokenProcessor.class.getName());
+    assertEquals(dagInfo.getVertex(SUMMATION).getProcessorClassName(), SumProcessor.class.getName());
     assertTrue(dagInfo.getFinishTime() > dagInfo.getStartTime());
     assertEquals(1, dagInfo.getEdges().size());
     EdgeInfo edgeInfo = dagInfo.getEdges().iterator().next();
@@ -301,8 +297,8 @@ public class TestHistoryParser {
         assertTrue(taskInfo.getMinTaskAttemptDuration() >= 0);
         assertTrue(taskInfo.getAvgTaskAttemptDuration() >= 0);
         assertNotNull(taskInfo.getLastTaskAttemptToFinish());
-        assertTrue(taskInfo.getContainersMapping().size() > 0);
-        assertTrue(taskInfo.getSuccessfulTaskAttempts().size() > 0);
+        assertFalse(taskInfo.getContainersMapping().isEmpty());
+        assertFalse(taskInfo.getSuccessfulTaskAttempts().isEmpty());
         assertEquals(0, taskInfo.getFailedTaskAttempts().size());
         assertEquals(0, taskInfo.getKilledTaskAttempts().size());
         assertTrue(taskInfo.getFinishTime() > taskInfo.getStartTime());
@@ -402,13 +398,13 @@ public class TestHistoryParser {
     //Dag specific
     VertexInfo summationVertex = dagInfo.getVertex(SUMMATION);
     assertEquals(1, summationVertex.getFailedTasks().size()); //1 task, 4 attempts failed
-    assertEquals(4, summationVertex.getFailedTasks().get(0).getFailedTaskAttempts().size());
+    assertEquals(4, summationVertex.getFailedTasks().getFirst().getFailedTaskAttempts().size());
     assertEquals(summationVertex.getStatus(), VertexState.FAILED.toString());
 
     assertEquals(1, dagInfo.getFailedVertices().size());
-    assertEquals(SUMMATION, dagInfo.getFailedVertices().get(0).getVertexName());
+    assertEquals(SUMMATION, dagInfo.getFailedVertices().getFirst().getVertexName());
     assertEquals(1, dagInfo.getSuccessfullVertices().size());
-    assertEquals(TOKENIZER, dagInfo.getSuccessfullVertices().get(0).getVertexName());
+    assertEquals(TOKENIZER, dagInfo.getSuccessfullVertices().getFirst().getVertexName());
 
     assertEquals(dagInfo.getStatus(), DAGState.FAILED.toString());
 
@@ -582,8 +578,8 @@ public class TestHistoryParser {
     assertNotNull(info1.getTaskInfo());
     assertNotNull(info2.getTaskInfo());
     assertEquals(info1.getStatus(), info2.getStatus());
-    assertEquals(info1.getTaskInfo().getVertexInfo().getVertexName(), info2.getTaskInfo()
-        .getVertexInfo().getVertexName());
+    assertEquals(info1.getTaskInfo().getVertexInfo().getVertexName(),
+        info2.getTaskInfo().getVertexInfo().getVertexName());
 
     //Verify counters
     isCountersSame(info1, info2);

--- a/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/TestHistoryParser.java
+++ b/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/TestHistoryParser.java
@@ -18,7 +18,11 @@
  */
 package org.apache.tez.history;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -56,7 +60,7 @@ import org.apache.tez.dag.api.DAG;
 import org.apache.tez.dag.api.DataSinkDescriptor;
 import org.apache.tez.dag.api.DataSourceDescriptor;
 import org.apache.tez.dag.api.Edge;
-import org.apache.tez.dag.api.EdgeProperty;
+import org.apache.tez.dag.api.EdgeProperty.DataMovementType;
 import org.apache.tez.dag.api.ProcessorDescriptor;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.TezException;
@@ -71,6 +75,8 @@ import org.apache.tez.dag.history.logging.ats.ATSHistoryLoggingService;
 import org.apache.tez.dag.history.logging.impl.SimpleHistoryLoggingService;
 import org.apache.tez.dag.records.TezDAGID;
 import org.apache.tez.examples.WordCount;
+import org.apache.tez.examples.WordCount.SumProcessor;
+import org.apache.tez.examples.WordCount.TokenProcessor;
 import org.apache.tez.history.parser.ATSFileParser;
 import org.apache.tez.history.parser.SimpleHistoryParser;
 import org.apache.tez.history.parser.datamodel.BaseInfo;
@@ -94,9 +100,9 @@ import org.apache.tez.tests.MiniTezClusterWithTimeline;
 
 import com.google.common.collect.Sets;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestHistoryParser {
 
@@ -122,7 +128,7 @@ public class TestHistoryParser {
   private static String DOWNLOAD_DIR = TEST_ROOT_DIR + Path.SEPARATOR + "download";
   private static String yarnTimelineAddress;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupCluster() throws Exception {
     conf = new Configuration();
     conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_EDITS_NOEDITLOGCHANNELFLUSH, false);
@@ -136,7 +142,7 @@ public class TestHistoryParser {
     setupTezCluster();
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdownCluster() {
     try {
       if (miniDFSCluster != null) {
@@ -155,7 +161,7 @@ public class TestHistoryParser {
     }
   }
 
-  // @Before
+  // @BeforeAll
   public static void setupTezCluster() throws Exception {
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_CONNECT_TIMEOUT, 3 * 1000);
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_READ_TIMEOUT, 3 * 1000);
@@ -207,7 +213,7 @@ public class TestHistoryParser {
     String[] args = { "--dagId=" + dagId, "--downloadDir=" + DOWNLOAD_DIR, "--yarnTimelineAddress=" + yarnTimelineAddress };
 
     int result = ATSImportTool.process(args);
-    assertTrue(result == 0);
+    assertEquals(0, result);
 
     //Parse ATS data and verify results
     DagInfo dagInfoFromATS = getDagInfo(dagId);
@@ -244,44 +250,44 @@ public class TestHistoryParser {
     //Now parse via SimpleHistory
     SimpleHistoryParser parser = new SimpleHistoryParser(Arrays.asList(localFile));
     DagInfo dagInfo = parser.getDAGData(dagId);
-    assertTrue(dagInfo.getDagId().equals(dagId));
+    assertEquals(dagInfo.getDagId(), dagId);
     return dagInfo;
   }
 
   private void checkConfig(DagInfo dagInfo) {
-    assertTrue("DagInfo is " + dagInfo, dagInfo != null);
-    //Check configs
-    assertTrue("DagInfo config size=" + dagInfo.getAppConfig().size(),
-        dagInfo.getAppConfig().size() > 0);
-    //Sample config element
-    assertTrue("DagInfo config=" + dagInfo.getAppConfig(),
-        Integer.parseInt(dagInfo.getAppConfig().get("dfs.replication")) > 0);
+    assertNotNull(dagInfo, "DagInfo is " + dagInfo);
+    // Check configs
+    assertFalse(
+        dagInfo.getAppConfig().isEmpty(), "DagInfo config size=" + dagInfo.getAppConfig().size());
+    // Sample config element
+    assertTrue(
+        Integer.parseInt(dagInfo.getAppConfig().get("dfs.replication")) > 0,
+        "DagInfo config=" + dagInfo.getAppConfig());
   }
 
   private void verifyJobSpecificInfo(DagInfo dagInfo) {
     //Job specific
-    assertTrue(dagInfo.getNumVertices() == 2);
-    assertTrue(dagInfo.getName().equals("WordCount"));
-    assertTrue(dagInfo.getVertex(TOKENIZER).getProcessorClassName().equals(
-        WordCount.TokenProcessor.class.getName()));
-    assertTrue(dagInfo.getVertex(SUMMATION).getProcessorClassName()
-        .equals(WordCount.SumProcessor.class.getName()));
+    assertEquals(2, dagInfo.getNumVertices());
+    assertEquals("WordCount", dagInfo.getName());
+    assertEquals(dagInfo.getVertex(TOKENIZER).getProcessorClassName(),
+        TokenProcessor.class.getName());
+    assertEquals(dagInfo.getVertex(SUMMATION).getProcessorClassName(),
+        SumProcessor.class.getName());
     assertTrue(dagInfo.getFinishTime() > dagInfo.getStartTime());
-    assertTrue(dagInfo.getEdges().size() == 1);
+    assertEquals(1, dagInfo.getEdges().size());
     EdgeInfo edgeInfo = dagInfo.getEdges().iterator().next();
-    assertTrue(edgeInfo.getDataMovementType().
-        equals(EdgeProperty.DataMovementType.SCATTER_GATHER.toString()));
-    assertTrue(edgeInfo.getSourceVertex().getVertexName().equals(TOKENIZER));
-    assertTrue(edgeInfo.getDestinationVertex().getVertexName().equals(SUMMATION));
-    assertTrue(edgeInfo.getInputVertexName().equals(TOKENIZER));
-    assertTrue(edgeInfo.getOutputVertexName().equals(SUMMATION));
-    assertTrue(edgeInfo.getEdgeSourceClass().equals(OrderedPartitionedKVOutput.class.getName()));
-    assertTrue(edgeInfo.getEdgeDestinationClass().equals(OrderedGroupedKVInput.class.getName()));
-    assertTrue(dagInfo.getVertices().size() == 2);
+    assertEquals(edgeInfo.getDataMovementType(), DataMovementType.SCATTER_GATHER.toString());
+    assertEquals(TOKENIZER, edgeInfo.getSourceVertex().getVertexName());
+    assertEquals(SUMMATION, edgeInfo.getDestinationVertex().getVertexName());
+    assertEquals(TOKENIZER, edgeInfo.getInputVertexName());
+    assertEquals(SUMMATION, edgeInfo.getOutputVertexName());
+    assertEquals(edgeInfo.getEdgeSourceClass(), OrderedPartitionedKVOutput.class.getName());
+    assertEquals(edgeInfo.getEdgeDestinationClass(), OrderedGroupedKVInput.class.getName());
+    assertEquals(2, dagInfo.getVertices().size());
     String lastSourceTA = null;
     String lastDataEventSourceTA = null;
     for (VertexInfo vertexInfo : dagInfo.getVertices()) {
-      assertTrue(vertexInfo.getKilledTasksCount() == 0);
+      assertEquals(0, vertexInfo.getKilledTasksCount());
       assertTrue(vertexInfo.getInitRequestedTime() > 0);
       assertTrue(vertexInfo.getInitTime() > 0);
       assertTrue(vertexInfo.getStartRequestedTime() > 0);
@@ -290,15 +296,15 @@ public class TestHistoryParser {
       assertTrue(vertexInfo.getFinishTime() > vertexInfo.getStartTime());
       long finishTime = 0;
       for (TaskInfo taskInfo : vertexInfo.getTasks()) {
-        assertTrue(taskInfo.getNumberOfTaskAttempts() == 1);
+        assertEquals(1, taskInfo.getNumberOfTaskAttempts());
         assertTrue(taskInfo.getMaxTaskAttemptDuration() >= 0);
         assertTrue(taskInfo.getMinTaskAttemptDuration() >= 0);
         assertTrue(taskInfo.getAvgTaskAttemptDuration() >= 0);
-        assertTrue(taskInfo.getLastTaskAttemptToFinish() != null);
+        assertNotNull(taskInfo.getLastTaskAttemptToFinish());
         assertTrue(taskInfo.getContainersMapping().size() > 0);
         assertTrue(taskInfo.getSuccessfulTaskAttempts().size() > 0);
-        assertTrue(taskInfo.getFailedTaskAttempts().size() == 0);
-        assertTrue(taskInfo.getKilledTaskAttempts().size() == 0);
+        assertEquals(0, taskInfo.getFailedTaskAttempts().size());
+        assertEquals(0, taskInfo.getKilledTaskAttempts().size());
         assertTrue(taskInfo.getFinishTime() > taskInfo.getStartTime());
         List<TaskAttemptInfo> attempts = taskInfo.getTaskAttempts();
         if (vertexInfo.getVertexName().equals(TOKENIZER)) {
@@ -316,7 +322,7 @@ public class TestHistoryParser {
               lastDataEventSourceTA = item.getTaskAttemptId();
             } else {
               // all attempts should have the same last data event source TA
-              assertTrue(lastDataEventSourceTA.equals(item.getTaskAttemptId()));
+              assertEquals(lastDataEventSourceTA, item.getTaskAttemptId());
             }
           }
         }
@@ -327,20 +333,20 @@ public class TestHistoryParser {
           assertTrue(attemptInfo.getFinishTime() > attemptInfo.getStartTime());
         }
       }
-      assertTrue(vertexInfo.getLastTaskToFinish() != null);
+      assertNotNull(vertexInfo.getLastTaskToFinish());
       if (vertexInfo.getVertexName().equals(TOKENIZER)) {
-        assertTrue(vertexInfo.getInputEdges().size() == 0);
-        assertTrue(vertexInfo.getOutputEdges().size() == 1);
-        assertTrue(vertexInfo.getOutputVertices().size() == 1);
-        assertTrue(vertexInfo.getInputVertices().size() == 0);
+        assertEquals(0, vertexInfo.getInputEdges().size());
+        assertEquals(1, vertexInfo.getOutputEdges().size());
+        assertEquals(1, vertexInfo.getOutputVertices().size());
+        assertEquals(0, vertexInfo.getInputVertices().size());
       } else {
-        assertTrue(vertexInfo.getInputEdges().size() == 1);
-        assertTrue(vertexInfo.getOutputEdges().size() == 0);
-        assertTrue(vertexInfo.getOutputVertices().size() == 0);
-        assertTrue(vertexInfo.getInputVertices().size() == 1);
+        assertEquals(1, vertexInfo.getInputEdges().size());
+        assertEquals(0, vertexInfo.getOutputEdges().size());
+        assertEquals(0, vertexInfo.getOutputVertices().size());
+        assertEquals(1, vertexInfo.getInputVertices().size());
       }
     }
-    assertTrue(lastSourceTA.equals(lastDataEventSourceTA));
+    assertEquals(lastSourceTA, lastDataEventSourceTA);
   }
 
   /**
@@ -383,7 +389,7 @@ public class TestHistoryParser {
     String[] args = { "--dagId=" + dagId, "--downloadDir=" + DOWNLOAD_DIR, "--yarnTimelineAddress=" + yarnTimelineAddress };
 
     int result = ATSImportTool.process(args);
-    assertTrue(result == 0);
+    assertEquals(0, result);
 
     //Parse ATS data
     DagInfo dagInfo = getDagInfo(dagId);
@@ -395,16 +401,16 @@ public class TestHistoryParser {
 
     //Dag specific
     VertexInfo summationVertex = dagInfo.getVertex(SUMMATION);
-    assertTrue(summationVertex.getFailedTasks().size() == 1); //1 task, 4 attempts failed
-    assertTrue(summationVertex.getFailedTasks().get(0).getFailedTaskAttempts().size() == 4);
-    assertTrue(summationVertex.getStatus().equals(VertexState.FAILED.toString()));
+    assertEquals(1, summationVertex.getFailedTasks().size()); //1 task, 4 attempts failed
+    assertEquals(4, summationVertex.getFailedTasks().get(0).getFailedTaskAttempts().size());
+    assertEquals(summationVertex.getStatus(), VertexState.FAILED.toString());
 
-    assertTrue(dagInfo.getFailedVertices().size() == 1);
-    assertTrue(dagInfo.getFailedVertices().get(0).getVertexName().equals(SUMMATION));
-    assertTrue(dagInfo.getSuccessfullVertices().size() == 1);
-    assertTrue(dagInfo.getSuccessfullVertices().get(0).getVertexName().equals(TOKENIZER));
+    assertEquals(1, dagInfo.getFailedVertices().size());
+    assertEquals(SUMMATION, dagInfo.getFailedVertices().get(0).getVertexName());
+    assertEquals(1, dagInfo.getSuccessfullVertices().size());
+    assertEquals(TOKENIZER, dagInfo.getSuccessfullVertices().get(0).getVertexName());
 
-    assertTrue(dagInfo.getStatus().equals(DAGState.FAILED.toString()));
+    assertEquals(dagInfo.getStatus(), DAGState.FAILED.toString());
 
     verifyCounter(dagInfo.getCounter(DAGCounter.NUM_FAILED_TASKS.toString()), null, 4);
     verifyCounter(dagInfo.getCounter(DAGCounter.NUM_SUCCEEDED_TASKS.toString()), null, 1);
@@ -425,8 +431,8 @@ public class TestHistoryParser {
       for (TaskAttemptInfo attemptInfo : taskInfo.getTaskAttempts()) {
         if (lastAttempt != null) {
           // failed attempt should be causal TA of next attempt
-          assertTrue(lastAttempt.getTaskAttemptId().equals(attemptInfo.getCreationCausalTA()));
-          assertTrue(lastAttempt.getTerminationCause() != null);
+          assertEquals(lastAttempt.getTaskAttemptId(), attemptInfo.getCreationCausalTA());
+          assertNotNull(lastAttempt.getTerminationCause());
         }
         lastAttempt = attemptInfo;
       }
@@ -453,26 +459,26 @@ public class TestHistoryParser {
   }
 
   private void isVertexEqual(VertexInfo vertexInfo1, VertexInfo vertexInfo2) {
-    assertTrue(vertexInfo1 != null);
-    assertTrue(vertexInfo2 != null);
-    assertTrue(vertexInfo1.getVertexName().equals(vertexInfo2.getVertexName()));
-    assertTrue(vertexInfo1.getProcessorClassName().equals(vertexInfo2.getProcessorClassName()));
-    assertTrue(vertexInfo1.getNumTasks() == vertexInfo2.getNumTasks());
-    assertTrue(vertexInfo1.getCompletedTasksCount() == vertexInfo2.getCompletedTasksCount());
-    assertTrue(vertexInfo1.getStatus().equals(vertexInfo2.getStatus()));
+    assertNotNull(vertexInfo1);
+    assertNotNull(vertexInfo2);
+    assertEquals(vertexInfo1.getVertexName(), vertexInfo2.getVertexName());
+    assertEquals(vertexInfo1.getProcessorClassName(), vertexInfo2.getProcessorClassName());
+    assertEquals(vertexInfo1.getNumTasks(), vertexInfo2.getNumTasks());
+    assertEquals(vertexInfo1.getCompletedTasksCount(), vertexInfo2.getCompletedTasksCount());
+    assertEquals(vertexInfo1.getStatus(), vertexInfo2.getStatus());
 
     isEdgeEqual(vertexInfo1.getInputEdges(), vertexInfo2.getInputEdges());
     isEdgeEqual(vertexInfo1.getOutputEdges(), vertexInfo2.getOutputEdges());
 
-    assertTrue(vertexInfo1.getInputVertices().size() == vertexInfo2.getInputVertices().size());
-    assertTrue(vertexInfo1.getOutputVertices().size() == vertexInfo2.getOutputVertices().size());
+    assertEquals(vertexInfo1.getInputVertices().size(), vertexInfo2.getInputVertices().size());
+    assertEquals(vertexInfo1.getOutputVertices().size(), vertexInfo2.getOutputVertices().size());
 
-    assertTrue(vertexInfo1.getNumTasks() == vertexInfo2.getNumTasks());
+    assertEquals(vertexInfo1.getNumTasks(), vertexInfo2.getNumTasks());
     isTaskEqual(vertexInfo1.getTasks(), vertexInfo2.getTasks());
   }
 
   private void isVertexEqual(List<VertexInfo> vertexList1, List<VertexInfo> vertexList2) {
-    assertTrue("Vertices sizes should be the same", vertexList1.size() == vertexList2.size());
+    assertEquals(vertexList1.size(), vertexList2.size(), "Vertices sizes should be the same");
     Iterator<VertexInfo> it1 = vertexList1.iterator();
     Iterator<VertexInfo> it2 = vertexList2.iterator();
     while (it1.hasNext()) {
@@ -484,15 +490,15 @@ public class TestHistoryParser {
   }
 
   private void isEdgeEqual(EdgeInfo edgeInfo1, EdgeInfo edgeInfo2) {
-    assertTrue(edgeInfo1 != null);
-    assertTrue(edgeInfo2 != null);
+    assertNotNull(edgeInfo1);
+    assertNotNull(edgeInfo2);
     String info1 = edgeInfo1.toString();
     String info2 = edgeInfo1.toString();
-    assertTrue(info1.equals(info2));
+    assertEquals(info1, info2);
   }
 
   private void isEdgeEqual(Collection<EdgeInfo> info1, Collection<EdgeInfo> info2) {
-    assertTrue("sizes should be the same", info1.size() == info1.size());
+    assertEquals(info1.size(), info1.size(), "sizes should be the same");
     Iterator<EdgeInfo> it1 = info1.iterator();
     Iterator<EdgeInfo> it2 = info2.iterator();
     while (it1.hasNext()) {
@@ -502,7 +508,7 @@ public class TestHistoryParser {
   }
 
   private void isTaskEqual(Collection<TaskInfo> info1, Collection<TaskInfo> info2) {
-    assertTrue("sizes should be the same", info1.size() == info1.size());
+    assertEquals(info1.size(), info1.size(), "sizes should be the same");
     Iterator<TaskInfo> it1 = info1.iterator();
     Iterator<TaskInfo> it2 = info2.iterator();
     while (it1.hasNext()) {
@@ -512,14 +518,13 @@ public class TestHistoryParser {
   }
 
   private void isTaskEqual(TaskInfo taskInfo1, TaskInfo taskInfo2) {
-    assertTrue(taskInfo1 != null);
-    assertTrue(taskInfo2 != null);
-    assertTrue(taskInfo1.getVertexInfo() != null);
-    assertTrue(taskInfo2.getVertexInfo() != null);
-    assertTrue(taskInfo1.getStatus().equals(taskInfo2.getStatus()));
-    assertTrue(
-        taskInfo1.getVertexInfo().getVertexName()
-            .equals(taskInfo2.getVertexInfo().getVertexName()));
+    assertNotNull(taskInfo1);
+    assertNotNull(taskInfo2);
+    assertNotNull(taskInfo1.getVertexInfo());
+    assertNotNull(taskInfo2.getVertexInfo());
+    assertEquals(taskInfo1.getStatus(), taskInfo2.getStatus());
+    assertEquals(taskInfo1.getVertexInfo().getVertexName(),
+        taskInfo2.getVertexInfo().getVertexName());
     isTaskAttemptEqual(taskInfo1.getTaskAttempts(), taskInfo2.getTaskAttempts());
 
     //Verify counters
@@ -556,13 +561,13 @@ public class TestHistoryParser {
 
       //check if other counter has the same value
       assertTrue(counter2.containsKey(entry.getKey()));
-      assertTrue(counter2.get(entry.getKey()).getValue() == val);
+      assertEquals(counter2.get(entry.getKey()).getValue(), val);
     }
   }
 
   private void isTaskAttemptEqual(Collection<TaskAttemptInfo> info1,
       Collection<TaskAttemptInfo> info2) {
-    assertTrue("sizes should be the same", info1.size() == info1.size());
+    assertEquals(info1.size(), info1.size(), "sizes should be the same");
     Iterator<TaskAttemptInfo> it1 = info1.iterator();
     Iterator<TaskAttemptInfo> it2 = info2.iterator();
     while (it1.hasNext()) {
@@ -572,13 +577,13 @@ public class TestHistoryParser {
   }
 
   private void isTaskAttemptEqual(TaskAttemptInfo info1, TaskAttemptInfo info2) {
-    assertTrue(info1 != null);
-    assertTrue(info2 != null);
-    assertTrue(info1.getTaskInfo() != null);
-    assertTrue(info2.getTaskInfo() != null);
-    assertTrue(info1.getStatus().equals(info2.getStatus()));
-    assertTrue(info1.getTaskInfo().getVertexInfo().getVertexName().equals(info2.getTaskInfo()
-        .getVertexInfo().getVertexName()));
+    assertNotNull(info1);
+    assertNotNull(info2);
+    assertNotNull(info1.getTaskInfo());
+    assertNotNull(info2.getTaskInfo());
+    assertEquals(info1.getStatus(), info2.getStatus());
+    assertEquals(info1.getTaskInfo().getVertexInfo().getVertexName(), info2.getTaskInfo()
+        .getVertexInfo().getVertexName());
 
     //Verify counters
     isCountersSame(info1, info2);
@@ -608,7 +613,7 @@ public class TestHistoryParser {
         + Path.SEPARATOR + dagId + ".zip");
     ATSFileParser parser = new ATSFileParser(Arrays.asList(downloadedFile));
     DagInfo dagInfo = parser.getDAGData(dagId);
-    assertTrue(dagInfo.getDagId().equals(dagId));
+    assertEquals(dagInfo.getDagId(), dagId);
     return dagInfo;
   }
 
@@ -618,10 +623,10 @@ public class TestHistoryParser {
     for (Map.Entry<String, TezCounter> entry : counterMap.entrySet()) {
       if (counterGroupName != null) {
         if (entry.getKey().equals(counterGroupName)) {
-          assertTrue(entry.getValue().getValue() == expectedVal);
+          assertEquals(entry.getValue().getValue(), expectedVal);
         }
       } else {
-        assertTrue(entry.getValue().getValue() == expectedVal);
+        assertEquals(entry.getValue().getValue(), expectedVal);
       }
     }
   }
@@ -709,17 +714,17 @@ public class TestHistoryParser {
   private void verifyDagInfo(DagInfo dagInfo, boolean ats) {
     if (ats) {
       VersionInfo versionInfo = dagInfo.getVersionInfo();
-      assertTrue(versionInfo != null); //should be present post 0.5.4
-      assertTrue(versionInfo.getVersion() != null);
-      assertTrue(versionInfo.getRevision() != null);
-      assertTrue(versionInfo.getBuildTime() != null);
+      assertNotNull(versionInfo); //should be present post 0.5.4
+      assertNotNull(versionInfo.getVersion());
+      assertNotNull(versionInfo.getRevision());
+      assertNotNull(versionInfo.getBuildTime());
     }
 
-    assertTrue(dagInfo.getUserName() != null);
-    assertTrue(!dagInfo.getUserName().isEmpty());
+    assertNotNull(dagInfo.getUserName());
+    assertFalse(dagInfo.getUserName().isEmpty());
     assertTrue(dagInfo.getStartTime() > 0);
     assertTrue(dagInfo.getFinishTimeInterval() > 0);
-    assertTrue(dagInfo.getStartTimeInterval() == 0);
+    assertEquals(0, dagInfo.getStartTimeInterval());
     assertTrue(dagInfo.getStartTime() > 0);
     if (dagInfo.getStatus().equalsIgnoreCase(DAGState.SUCCEEDED.toString())) {
       assertTrue(dagInfo.getFinishTime() >= dagInfo.getStartTime());
@@ -741,15 +746,15 @@ public class TestHistoryParser {
     }
 
     VertexInfo fastestVertex = dagInfo.getFastestVertex();
-    assertTrue(fastestVertex != null);
+    assertNotNull(fastestVertex);
 
     if (dagInfo.getStatus().equals(DAGState.SUCCEEDED)) {
-      assertTrue(dagInfo.getSlowestVertex() != null);
+      assertNotNull(dagInfo.getSlowestVertex());
     }
   }
 
   private void verifyVertex(VertexInfo vertexInfo, boolean hasFailedTasks) {
-    assertTrue(vertexInfo != null);
+    assertNotNull(vertexInfo);
     if (hasFailedTasks) {
       assertTrue(vertexInfo.getFailedTasksCount() > 0);
     }
@@ -757,19 +762,19 @@ public class TestHistoryParser {
     assertTrue(vertexInfo.getStartTime() > 0);
     assertTrue(vertexInfo.getFinishTimeInterval() > 0);
     assertTrue(vertexInfo.getStartTimeInterval() < vertexInfo.getFinishTimeInterval());
-    assertTrue(vertexInfo.getVertexName() != null);
+    assertNotNull(vertexInfo.getVertexName());
     if (!hasFailedTasks) {
       assertTrue(vertexInfo.getFinishTime() > 0);
-      assertTrue(vertexInfo.getFailedTasks().size() == 0);
-      assertTrue(vertexInfo.getSucceededTasksCount() == vertexInfo.getSuccessfulTasks().size());
-      assertTrue(vertexInfo.getFailedTasksCount() == 0);
+      assertEquals(0, vertexInfo.getFailedTasks().size());
+      assertEquals(vertexInfo.getSucceededTasksCount(), vertexInfo.getSuccessfulTasks().size());
+      assertEquals(0, vertexInfo.getFailedTasksCount());
       assertTrue(vertexInfo.getAvgTaskDuration() > 0);
       assertTrue(vertexInfo.getMaxTaskDuration() > 0);
       assertTrue(vertexInfo.getMinTaskDuration() > 0);
       assertTrue(vertexInfo.getTimeTaken() > 0);
       assertTrue(vertexInfo.getStatus().equalsIgnoreCase(VertexState.SUCCEEDED.toString()));
       assertTrue(vertexInfo.getCompletedTasksCount() > 0);
-      assertTrue(vertexInfo.getFirstTaskToStart() != null);
+      assertNotNull(vertexInfo.getFirstTaskToStart());
       assertTrue(vertexInfo.getSucceededTasksCount() > 0);
       assertTrue(vertexInfo.getTasks().size() > 0);
       assertTrue(vertexInfo.getFinishTime() > vertexInfo.getStartTime());
@@ -785,30 +790,30 @@ public class TestHistoryParser {
       verifyTask(taskInfo, true);
     }
 
-    assertTrue(vertexInfo.getProcessorClassName() != null);
-    assertTrue(vertexInfo.getStatus() != null);
-    assertTrue(vertexInfo.getDagInfo() != null);
+    assertNotNull(vertexInfo.getProcessorClassName());
+    assertNotNull(vertexInfo.getStatus());
+    assertNotNull(vertexInfo.getDagInfo());
     assertTrue(vertexInfo.getInitTimeInterval() > 0);
     assertTrue(vertexInfo.getNumTasks() > 0);
   }
 
   private void verifyTask(TaskInfo taskInfo, boolean hasFailedAttempts) {
-    assertTrue(taskInfo != null);
-    assertTrue(taskInfo.getStatus() != null);
+    assertNotNull(taskInfo);
+    assertNotNull(taskInfo.getStatus());
     assertTrue(taskInfo.getStartTimeInterval() > 0);
 
     //Not testing for killed attempts. So if there are no failures, it should succeed
     if (!hasFailedAttempts) {
-      assertTrue(taskInfo.getStatus().equals(TaskState.SUCCEEDED.toString()));
+      assertEquals(taskInfo.getStatus(), TaskState.SUCCEEDED.toString());
       assertTrue(taskInfo.getFinishTimeInterval() > 0 && taskInfo.getFinishTime() > taskInfo
           .getFinishTimeInterval());
       assertTrue(
           taskInfo.getStartTimeInterval() > 0 && taskInfo.getStartTime() > taskInfo.getStartTimeInterval());
-      assertTrue(taskInfo.getSuccessfulAttemptId() != null);
-      assertTrue(taskInfo.getSuccessfulTaskAttempt() != null);
+      assertNotNull(taskInfo.getSuccessfulAttemptId());
+      assertNotNull(taskInfo.getSuccessfulTaskAttempt());
       assertTrue(taskInfo.getFinishTime() > taskInfo.getStartTime());
     }
-    assertTrue(taskInfo.getTaskId() != null);
+    assertNotNull(taskInfo.getTaskId());
 
     for (TaskAttemptInfo attemptInfo : taskInfo.getTaskAttempts()) {
       verifyTaskAttemptInfo(attemptInfo);
@@ -827,12 +832,12 @@ public class TestHistoryParser {
       assertTrue(attemptInfo.getFinishTime() > attemptInfo.getStartTime());
       assertTrue(attemptInfo.getFinishTime() > attemptInfo.getFinishTimeInterval());
       assertTrue(attemptInfo.getStartTime() > attemptInfo.getStartTimeInterval());
-      assertTrue(attemptInfo.getNodeId() != null);
+      assertNotNull(attemptInfo.getNodeId());
       assertTrue(attemptInfo.getTimeTaken() != -1);
-      assertTrue(attemptInfo.getEvents() != null);
-      assertTrue(attemptInfo.getTezCounters() != null);
-      assertTrue(attemptInfo.getContainer() != null);
+      assertNotNull(attemptInfo.getEvents());
+      assertNotNull(attemptInfo.getTezCounters());
+      assertNotNull(attemptInfo.getContainer());
     }
-    assertTrue(attemptInfo.getTaskInfo() != null);
+    assertNotNull(attemptInfo.getTaskInfo());
   }
 }

--- a/tez-plugins/tez-protobuf-history-plugin/pom.xml
+++ b/tez-plugins/tez-protobuf-history-plugin/pom.xml
@@ -46,9 +46,8 @@
       <artifactId>protobuf-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/tez-plugins/tez-protobuf-history-plugin/src/test/java/org/apache/tez/dag/history/logging/proto/TestDagManifestFileScanner.java
+++ b/tez-plugins/tez-protobuf-history-plugin/src/test/java/org/apache/tez/dag/history/logging/proto/TestDagManifestFileScanner.java
@@ -18,7 +18,12 @@
  */
 package org.apache.tez.dag.history.logging.proto;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -29,22 +34,21 @@ import org.apache.hadoop.yarn.util.Clock;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.history.logging.proto.HistoryLoggerProtos.ManifestEntryProto;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.*;
 
 public class TestDagManifestFileScanner {
   private MockClock clock;
   private DatePartitionedLogger<ManifestEntryProto> manifestLogger;
 
-  @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  public java.nio.file.Path tempFolder;
 
-  @Before
+  @BeforeEach
   public void setupTest() throws Exception {
-    String basePath = tempFolder.newFolder().getAbsolutePath();
+    String basePath = String.valueOf(new Path(tempFolder.toAbsolutePath().toString()));
     clock = new MockClock();
     Configuration conf = new Configuration(false);
     conf.set(TezConfiguration.TEZ_HISTORY_LOGGING_PROTO_BASE_DIR, basePath);
@@ -55,7 +59,8 @@ public class TestDagManifestFileScanner {
     manifestLogger = loggers.getManifestEventsLogger();
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNormal() throws Exception {
     clock.setTime(0); // 0th day.
     createManifestEvents(0, 8);
@@ -66,7 +71,7 @@ public class TestDagManifestFileScanner {
     while (scanner.getNext() != null) {
       ++count;
     }
-    Assert.assertEquals(8, count);
+    assertEquals(8, count);
 
     // Save offset for later use.
     String offset = scanner.getOffset();
@@ -77,7 +82,7 @@ public class TestDagManifestFileScanner {
     while (scanner.getNext() != null) {
       ++count;
     }
-    Assert.assertEquals(5, count);
+    assertEquals(5, count);
 
     // Reset the offset
     scanner.setOffset(offset);
@@ -85,7 +90,7 @@ public class TestDagManifestFileScanner {
     while (scanner.getNext() != null) {
       ++count;
     }
-    Assert.assertEquals(5, count);
+    assertEquals(5, count);
 
     scanner.close();
 
@@ -93,7 +98,8 @@ public class TestDagManifestFileScanner {
   }
 
   private Path deleteFilePath = null;
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testError() throws Exception {
     clock.setTime(0); // 0th day.
     createManifestEvents(0, 4);
@@ -102,10 +108,10 @@ public class TestDagManifestFileScanner {
     createManifestEvents(24 * 3600, 1);
 
     DagManifesFileScanner scanner = new DagManifesFileScanner(manifestLogger);
-    Assert.assertNotNull(scanner.getNext());
+    assertNotNull(scanner.getNext());
     deleteFilePath.getFileSystem(manifestLogger.getConfig()).delete(deleteFilePath, false);
     // 4 files - 1 file deleted - 1 truncated - 1 corrupted => 1 remains.
-    Assert.assertNull(scanner.getNext());
+    assertNull(scanner.getNext());
 
     // Save offset for later use.
     String offset = scanner.getOffset();
@@ -113,13 +119,13 @@ public class TestDagManifestFileScanner {
     // Move time outside the window, it should skip files with error and give more data for
     // next day.
     clock.setTime((24 * 60 * 60 + 61) * 1000); // 1 day 61 sec.
-    Assert.assertNotNull(scanner.getNext());
-    Assert.assertNull(scanner.getNext());
+    assertNotNull(scanner.getNext());
+    assertNull(scanner.getNext());
 
     // Reset the offset
     scanner.setOffset(offset);
-    Assert.assertNotNull(scanner.getNext());
-    Assert.assertNull(scanner.getNext());
+    assertNotNull(scanner.getNext());
+    assertNull(scanner.getNext());
     scanner.close();
   }
 

--- a/tez-plugins/tez-protobuf-history-plugin/src/test/java/org/apache/tez/dag/history/logging/proto/TestDagManifestFileScanner.java
+++ b/tez-plugins/tez-protobuf-history-plugin/src/test/java/org/apache/tez/dag/history/logging/proto/TestDagManifestFileScanner.java
@@ -37,7 +37,7 @@ import org.apache.tez.dag.history.logging.proto.HistoryLoggerProtos.ManifestEntr
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.api.io.*;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestDagManifestFileScanner {
   private MockClock clock;

--- a/tez-plugins/tez-protobuf-history-plugin/src/test/java/org/apache/tez/dag/history/logging/proto/TestHistoryEventProtoConverter.java
+++ b/tez-plugins/tez-protobuf-history-plugin/src/test/java/org/apache/tez/dag/history/logging/proto/TestHistoryEventProtoConverter.java
@@ -18,10 +18,14 @@
  */
 package org.apache.tez.dag.history.logging.proto;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -84,9 +88,9 @@ import org.apache.tez.runtime.api.TaskFailureType;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestHistoryEventProtoConverter {
   private ApplicationAttemptId applicationAttemptId;
@@ -103,7 +107,7 @@ public class TestHistoryEventProtoConverter {
   private String containerLogs = "containerLogs";
   private HistoryEventProtoConverter converter = new HistoryEventProtoConverter();
 
-  @Before
+  @BeforeEach
   public void setup() {
     applicationId = ApplicationId.newInstance(9999l, 1);
     applicationAttemptId = ApplicationAttemptId.newInstance(applicationId, 1);
@@ -122,7 +126,8 @@ public class TestHistoryEventProtoConverter {
     nodeId = NodeId.newInstance("node", 13435);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testHandlerExists() {
     for (HistoryEventType eventType : HistoryEventType.values()) {
       HistoryEvent event = null;
@@ -211,7 +216,7 @@ public class TestHistoryEventProtoConverter {
           event = new DAGKillRequestEvent();
           break;
         default:
-          Assert.fail("Unhandled event type " + eventType);
+          fail("Unhandled event type " + eventType);
       }
       if (event == null || !event.isHistoryEvent()) {
         continue;
@@ -238,17 +243,17 @@ public class TestHistoryEventProtoConverter {
   private void assertEventData(HistoryEventProto proto, String key, String value) {
     String evtVal = findEventData(proto, key);
     if (evtVal == null) {
-      Assert.fail("Cannot find kv pair: " + key);
+      fail("Cannot find kv pair: " + key);
     }
     if (value != null) {
-      Assert.assertEquals(value, evtVal);
+      assertEquals(value, evtVal);
     }
   }
 
   private void assertNoEventData(HistoryEventProto proto, String key) {
     for (KVPair data : proto.getEventDataList()) {
       if (data.getKey().equals(key)) {
-        Assert.fail("Found find kv pair: " + key);
+        fail("Found find kv pair: " + key);
       }
     }
   }
@@ -259,32 +264,33 @@ public class TestHistoryEventProtoConverter {
 
   private void assertCommon(HistoryEventProto proto, HistoryEventType type, long eventTime,
       EntityTypes entityType, ApplicationAttemptId appAttemptId, String user, int numData) {
-    Assert.assertEquals(type.name(), proto.getEventType());
-    Assert.assertEquals(eventTime, proto.getEventTime());
-    // Assert.assertEquals(safeToString(appId), proto.getAppId());
-    Assert.assertEquals(safeToString(appAttemptId), proto.getAppAttemptId());
-    Assert.assertEquals(safeToString(user), proto.getUser());
+    assertEquals(type.name(), proto.getEventType());
+    assertEquals(eventTime, proto.getEventTime());
+    // assertEquals(safeToString(appId), proto.getAppId());
+    assertEquals(safeToString(appAttemptId), proto.getAppAttemptId());
+    assertEquals(safeToString(user), proto.getUser());
     if (entityType != null) {
       switch (entityType) { // Intentional fallthrough.
       case TEZ_TASK_ATTEMPT_ID:
-        Assert.assertEquals(tezTaskAttemptID.toString(), proto.getTaskAttemptId());
+        assertEquals(tezTaskAttemptID.toString(), proto.getTaskAttemptId());
       case TEZ_TASK_ID:
-        Assert.assertEquals(tezTaskID.toString(), proto.getTaskId());
+        assertEquals(tezTaskID.toString(), proto.getTaskId());
       case TEZ_VERTEX_ID:
-        Assert.assertEquals(tezVertexID.toString(), proto.getVertexId());
+        assertEquals(tezVertexID.toString(), proto.getVertexId());
       case TEZ_DAG_ID:
-        Assert.assertEquals(tezDAGID.toString(), proto.getDagId());
+        assertEquals(tezDAGID.toString(), proto.getDagId());
       case TEZ_APPLICATION:
-        Assert.assertEquals(applicationId.toString(), proto.getAppId());
+        assertEquals(applicationId.toString(), proto.getAppId());
         break;
       default:
-        Assert.fail("Invalid type: " + entityType.name());
+        fail("Invalid type: " + entityType.name());
       }
     }
-    Assert.assertEquals(numData, proto.getEventDataCount());
+    assertEquals(numData, proto.getEventDataCount());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertAppLaunchedEvent() {
     long launchTime = random.nextLong();
     long submitTime = random.nextLong();
@@ -304,7 +310,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.DAG_AM_WEB_SERVICE_VERSION, AMWebController.VERSION);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertAMLaunchedEvent() {
     long launchTime = random.nextLong();
     long submitTime = random.nextLong();
@@ -316,7 +323,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.APP_SUBMIT_TIME, String.valueOf(submitTime));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertAMStartedEvent() {
     long startTime = random.nextLong();
     AMStartedEvent event = new AMStartedEvent(applicationAttemptId, startTime, user);
@@ -325,7 +333,8 @@ public class TestHistoryEventProtoConverter {
         applicationAttemptId, user, 0);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertContainerLaunchedEvent() {
     long launchTime = random.nextLong();
     ContainerLaunchedEvent event = new ContainerLaunchedEvent(containerId, launchTime,
@@ -336,7 +345,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.CONTAINER_ID, containerId.toString());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertContainerStoppedEvent() {
     long stopTime = random.nextLong();
     int exitStatus = random.nextInt();
@@ -350,7 +360,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.FINISH_TIME, String.valueOf(stopTime));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertDAGStartedEvent() {
     long startTime = random.nextLong();
     String dagName = "testDagName";
@@ -362,7 +373,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.STATUS, DAGState.RUNNING.name());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertDAGSubmittedEvent() {
     long submitTime = random.nextLong();
 
@@ -386,7 +398,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.DAG_PLAN, null);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertTaskAttemptFinishedEvent() {
     String vertexName = "testVertex";
     long creationTime = random.nextLong();
@@ -439,7 +452,8 @@ public class TestHistoryEventProtoConverter {
     assertNoEventData(proto, ATSConstants.TASK_FAILURE_TYPE);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertDAGInitializedEvent() {
     long initTime = random.nextLong();
 
@@ -455,7 +469,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.VERTEX_NAME_ID_MAPPING, null);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertDAGFinishedEvent() {
     long finishTime = random.nextLong();
     long startTime = random.nextLong();
@@ -485,7 +500,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.COUNTERS, null);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertVertexInitializedEvent() {
     long initRequestedTime = random.nextLong();
     long initedTime = random.nextLong();
@@ -509,29 +525,30 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.SERVICE_PLUGIN, null);
 
     /*
-    Assert.assertNotNull(timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN));
-    Assert.assertEquals("abc",
+    assertNotNull(timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN));
+    assertEquals("abc",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.CONTAINER_LAUNCHER_NAME));
-    Assert.assertEquals("def",
+    assertEquals("def",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_SCHEDULER_NAME));
-    Assert.assertEquals("ghi",
+    assertEquals("ghi",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_COMMUNICATOR_NAME));
-    Assert.assertEquals("abc1",
+    assertEquals("abc1",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.CONTAINER_LAUNCHER_CLASS_NAME));
-    Assert.assertEquals("def1",
+    assertEquals("def1",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_SCHEDULER_CLASS_NAME));
-    Assert.assertEquals("ghi1",
+    assertEquals("ghi1",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_COMMUNICATOR_CLASS_NAME));
     */
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertVertexStartedEvent() {
     long startRequestedTime = random.nextLong();
     long startTime = random.nextLong();
@@ -544,7 +561,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.STATUS, VertexState.RUNNING.name());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertVertexFinishedEvent() {
     String vertexName = "v1";
     long initRequestedTime = random.nextLong();
@@ -581,28 +599,29 @@ public class TestHistoryEventProtoConverter {
 
     assertEventData(proto, ATSConstants.SERVICE_PLUGIN, null);
     /*
-    Assert.assertEquals("abc",
+    assertEquals("abc",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.CONTAINER_LAUNCHER_NAME));
-    Assert.assertEquals("def",
+    assertEquals("def",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_SCHEDULER_NAME));
-    Assert.assertEquals("ghi",
+    assertEquals("ghi",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_COMMUNICATOR_NAME));
-    Assert.assertEquals("abc1",
+    assertEquals("abc1",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.CONTAINER_LAUNCHER_CLASS_NAME));
-    Assert.assertEquals("def1",
+    assertEquals("def1",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_SCHEDULER_CLASS_NAME));
-    Assert.assertEquals("ghi1",
+    assertEquals("ghi1",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_COMMUNICATOR_CLASS_NAME));
     */
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertTaskStartedEvent() {
     long scheduleTime = random.nextLong();
     long startTime = random.nextLong();
@@ -615,7 +634,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.STATUS, TaskState.SCHEDULED.name());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertTaskAttemptStartedEvent() {
     long startTime = random.nextLong();
     TaskAttemptStartedEvent event = new TaskAttemptStartedEvent(tezTaskAttemptID, "v1",
@@ -632,7 +652,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.NODE_HTTP_ADDRESS, "nodeHttpAddress");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertTaskFinishedEvent() {
     String vertexName = "testVertexName";
     long startTime = random.nextLong();
@@ -655,7 +676,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.COUNTERS, null);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertVertexReconfigreDoneEvent() {
     TezVertexID vId = tezVertexID;
     Map<String, EdgeProperty> edgeMgrs =
@@ -675,18 +697,19 @@ public class TestHistoryEventProtoConverter {
     /*
     Map<String, Object> updatedEdgeMgrs = (Map<String, Object>)
         evt.getEventInfo().get(ATSConstants.UPDATED_EDGE_MANAGERS);
-    Assert.assertEquals(1, updatedEdgeMgrs.size());
-    Assert.assertTrue(updatedEdgeMgrs.containsKey("a"));
+    assertEquals(1, updatedEdgeMgrs.size());
+    assertTrue(updatedEdgeMgrs.containsKey("a"));
     Map<String, Object> updatedEdgeMgr = (Map<String, Object>) updatedEdgeMgrs.get("a");
 
-    Assert.assertEquals(DataMovementType.CUSTOM.name(),
+    assertEquals(DataMovementType.CUSTOM.name(),
         updatedEdgeMgr.get(DAGUtils.DATA_MOVEMENT_TYPE_KEY));
-    Assert.assertEquals("In", updatedEdgeMgr.get(DAGUtils.EDGE_DESTINATION_CLASS_KEY));
-    Assert.assertEquals("a.class", updatedEdgeMgr.get(DAGUtils.EDGE_MANAGER_CLASS_KEY));
+    assertEquals("In", updatedEdgeMgr.get(DAGUtils.EDGE_DESTINATION_CLASS_KEY));
+    assertEquals("a.class", updatedEdgeMgr.get(DAGUtils.EDGE_MANAGER_CLASS_KEY));
     */
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertDAGRecoveredEvent() {
     long recoverTime = random.nextLong();
     DAGRecoveredEvent event = new DAGRecoveredEvent(applicationAttemptId, tezDAGID,
@@ -699,7 +722,8 @@ public class TestHistoryEventProtoConverter {
     assertEventData(proto, ATSConstants.DAG_NAME, dagPlan.getName());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertDAGRecoveredEvent2() {
     long recoverTime = random.nextLong();
 

--- a/tez-plugins/tez-protobuf-history-plugin/src/test/java/org/apache/tez/dag/history/logging/proto/TestProtoHistoryLoggingService.java
+++ b/tez-plugins/tez-protobuf-history-plugin/src/test/java/org/apache/tez/dag/history/logging/proto/TestProtoHistoryLoggingService.java
@@ -73,7 +73,7 @@ import org.apache.tez.hadoop.shim.HadoopShim;
 import com.google.protobuf.CodedInputStream;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.*;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestProtoHistoryLoggingService {
   private static ApplicationId appId = ApplicationId.newInstance(1000l, 1);

--- a/tez-plugins/tez-protobuf-history-plugin/src/test/java/org/apache/tez/dag/history/logging/proto/TestProtoHistoryLoggingService.java
+++ b/tez-plugins/tez-protobuf-history-plugin/src/test/java/org/apache/tez/dag/history/logging/proto/TestProtoHistoryLoggingService.java
@@ -18,6 +18,12 @@
  */
 package org.apache.tez.dag.history.logging.proto;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -66,10 +72,8 @@ import org.apache.tez.hadoop.shim.HadoopShim;
 
 import com.google.protobuf.CodedInputStream;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.*;
 
 public class TestProtoHistoryLoggingService {
   private static ApplicationId appId = ApplicationId.newInstance(1000l, 1);
@@ -77,8 +81,8 @@ public class TestProtoHistoryLoggingService {
   private static String user = "TEST_USER";
   private Clock clock;
 
-  @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  public java.nio.file.Path tempFolder;
 
   @Test
   public void testService() throws Exception {
@@ -93,7 +97,7 @@ public class TestProtoHistoryLoggingService {
     service.stop();
 
     TezProtoLoggers loggers = new TezProtoLoggers();
-    Assert.assertTrue(loggers.setup(service.getConfig(), clock));
+    assertTrue(loggers.setup(service.getConfig(), clock));
 
     // Verify dag events are logged.
     DatePartitionedLogger<HistoryEventProto> dagLogger = loggers.getDagEventsLogger();
@@ -107,7 +111,7 @@ public class TestProtoHistoryLoggingService {
     Path appFilePath = appLogger.getPathForDate(LocalDate.ofEpochDay(0), attemptId.toString());
     ProtoMessageReader<HistoryEventProto> appReader = appLogger.getReader(appFilePath);
     long appOffset = appReader.getOffset();
-    Assert.assertEquals(protos.get(0), appReader.readEvent());
+    assertEquals(protos.get(0), appReader.readEvent());
     appReader.close();
 
     // Verify manifest events are logged.
@@ -116,29 +120,29 @@ public class TestProtoHistoryLoggingService {
         LocalDate.ofEpochDay(0), attemptId.toString());
     ProtoMessageReader<ManifestEntryProto> reader2 = manifestLogger.getReader(manifestFilePath);
     ManifestEntryProto manifest = reader2.readEvent();
-    Assert.assertEquals(appId.toString(), manifest.getAppId());
-    Assert.assertEquals(dagId.toString(), manifest.getDagId());
-    Assert.assertEquals(dagFilePath.toString(), manifest.getDagFilePath());
-    Assert.assertEquals(appFilePath.toString(), manifest.getAppFilePath());
-    Assert.assertEquals(appOffset, manifest.getAppLaunchedEventOffset());
+    assertEquals(appId.toString(), manifest.getAppId());
+    assertEquals(dagId.toString(), manifest.getDagId());
+    assertEquals(dagFilePath.toString(), manifest.getDagFilePath());
+    assertEquals(appFilePath.toString(), manifest.getAppFilePath());
+    assertEquals(appOffset, manifest.getAppLaunchedEventOffset());
 
     // Verify offsets in manifest logger.
     reader = dagLogger.getReader(new Path(manifest.getDagFilePath()));
     reader.setOffset(manifest.getDagSubmittedEventOffset());
     HistoryEventProto evt = reader.readEvent();
-    Assert.assertNotNull(evt);
-    Assert.assertEquals(HistoryEventType.DAG_SUBMITTED.name(), evt.getEventType());
+    assertNotNull(evt);
+    assertEquals(HistoryEventType.DAG_SUBMITTED.name(), evt.getEventType());
 
     reader.setOffset(manifest.getDagFinishedEventOffset());
     evt = reader.readEvent();
-    Assert.assertNotNull(evt);
-    Assert.assertEquals(HistoryEventType.DAG_FINISHED.name(), evt.getEventType());
+    assertNotNull(evt);
+    assertEquals(HistoryEventType.DAG_FINISHED.name(), evt.getEventType());
     reader.close();
 
     // Verify manifest file scanner.
     DagManifesFileScanner scanner = new DagManifesFileScanner(manifestLogger);
-    Assert.assertEquals(manifest, scanner.getNext());
-    Assert.assertNull(scanner.getNext());
+    assertEquals(manifest, scanner.getNext());
+    assertNull(scanner.getNext());
     scanner.close();
   }
 
@@ -156,7 +160,7 @@ public class TestProtoHistoryLoggingService {
     service.stop();
 
     TezProtoLoggers loggers = new TezProtoLoggers();
-    Assert.assertTrue(loggers.setup(service.getConfig(), clock));
+    assertTrue(loggers.setup(service.getConfig(), clock));
 
     // Verify dag events are logged.
     DatePartitionedLogger<HistoryEventProto> dagLogger = loggers.getDagEventsLogger();
@@ -167,7 +171,7 @@ public class TestProtoHistoryLoggingService {
       int totalBytesRead = getTotalBytesRead(reader);
       // cin.resetSizeCounter() in ProtoMessageWritable.java ensures that
       // totalBytesRead will always be 0. For reference read javadoc of CodedInputStream.
-      Assert.assertEquals(totalBytesRead, 0);
+      assertEquals(0, totalBytesRead);
     }
   }
 
@@ -200,7 +204,7 @@ public class TestProtoHistoryLoggingService {
     service.stop();
 
     TezProtoLoggers loggers = new TezProtoLoggers();
-    Assert.assertTrue(loggers.setup(service.getConfig(), clock));
+    assertTrue(loggers.setup(service.getConfig(), clock));
 
     // Verify dag events are logged.
     DatePartitionedLogger<HistoryEventProto> dagLogger = loggers.getDagEventsLogger();
@@ -221,7 +225,7 @@ public class TestProtoHistoryLoggingService {
     Path appFilePath = appLogger.getPathForDate(LocalDate.ofEpochDay(0), attemptId.toString());
     ProtoMessageReader<HistoryEventProto> appReader = appLogger.getReader(appFilePath);
     long appOffset = appReader.getOffset();
-    Assert.assertEquals(protos.get(0), appReader.readEvent());
+    assertEquals(protos.get(0), appReader.readEvent());
     appReader.close();
 
     // Verify manifest events are logged.
@@ -232,13 +236,13 @@ public class TestProtoHistoryLoggingService {
     ProtoMessageReader<ManifestEntryProto> manifestReader = manifestLogger.getReader(
         manifestFilePath);
     ManifestEntryProto manifest = manifestReader.readEvent();
-    Assert.assertEquals(manifest, scanner.getNext());
-    Assert.assertEquals(appId.toString(), manifest.getAppId());
-    Assert.assertEquals(dagId.toString(), manifest.getDagId());
-    Assert.assertEquals(dagFilePath1.toString(), manifest.getDagFilePath());
-    Assert.assertEquals(appFilePath.toString(), manifest.getAppFilePath());
-    Assert.assertEquals(appOffset, manifest.getAppLaunchedEventOffset());
-    Assert.assertEquals(-1, manifest.getDagFinishedEventOffset());
+    assertEquals(manifest, scanner.getNext());
+    assertEquals(appId.toString(), manifest.getAppId());
+    assertEquals(dagId.toString(), manifest.getDagId());
+    assertEquals(dagFilePath1.toString(), manifest.getDagFilePath());
+    assertEquals(appFilePath.toString(), manifest.getAppFilePath());
+    assertEquals(appOffset, manifest.getAppLaunchedEventOffset());
+    assertEquals(-1, manifest.getDagFinishedEventOffset());
 
     HistoryEventProto evt = null;
     // Verify offsets in manifest logger.
@@ -246,47 +250,47 @@ public class TestProtoHistoryLoggingService {
         new Path(manifest.getDagFilePath()))) {
       reader.setOffset(manifest.getDagSubmittedEventOffset());
       evt = reader.readEvent();
-      Assert.assertNotNull(evt);
-      Assert.assertEquals(HistoryEventType.DAG_SUBMITTED.name(), evt.getEventType());
+      assertNotNull(evt);
+      assertEquals(HistoryEventType.DAG_SUBMITTED.name(), evt.getEventType());
     }
 
     manifest = manifestReader.readEvent();
-    Assert.assertEquals(manifest, scanner.getNext());
-    Assert.assertEquals(appId.toString(), manifest.getAppId());
-    Assert.assertEquals(dagId.toString(), manifest.getDagId());
-    Assert.assertEquals(dagFilePath2.toString(), manifest.getDagFilePath());
-    Assert.assertEquals(appFilePath.toString(), manifest.getAppFilePath());
-    Assert.assertEquals(appOffset, manifest.getAppLaunchedEventOffset());
-    Assert.assertEquals(-1, manifest.getDagSubmittedEventOffset());
+    assertEquals(manifest, scanner.getNext());
+    assertEquals(appId.toString(), manifest.getAppId());
+    assertEquals(dagId.toString(), manifest.getDagId());
+    assertEquals(dagFilePath2.toString(), manifest.getDagFilePath());
+    assertEquals(appFilePath.toString(), manifest.getAppFilePath());
+    assertEquals(appOffset, manifest.getAppLaunchedEventOffset());
+    assertEquals(-1, manifest.getDagSubmittedEventOffset());
 
     try (ProtoMessageReader<HistoryEventProto> reader = dagLogger.getReader(
         new Path(manifest.getDagFilePath()))) {
       reader.setOffset(manifest.getDagFinishedEventOffset());
       evt = reader.readEvent();
-      Assert.assertNotNull(evt);
-      Assert.assertEquals(HistoryEventType.DAG_FINISHED.name(), evt.getEventType());
+      assertNotNull(evt);
+      assertEquals(HistoryEventType.DAG_FINISHED.name(), evt.getEventType());
     }
 
     // Verify manifest file scanner.
-    Assert.assertNull(scanner.getNext());
+    assertNull(scanner.getNext());
     scanner.close();
   }
 
   @Test
   public void testDirPermissions() throws IOException {
-    Path basePath = new Path(tempFolder.newFolder().getAbsolutePath());
+    Path basePath = new Path(tempFolder.toAbsolutePath().toString());
     Configuration conf = new Configuration();
     FileSystem fs = basePath.getFileSystem(conf);
     FsPermission expectedPermissions = FsPermission.createImmutable((short) 01777);
 
     // Check the directory already exists and doesn't have the expected permissions.
-    Assert.assertTrue(fs.exists(basePath));
-    Assert.assertNotEquals(expectedPermissions, fs.getFileStatus(basePath).getPermission());
+    assertTrue(fs.exists(basePath));
+    assertNotEquals(expectedPermissions, fs.getFileStatus(basePath).getPermission());
 
     new DatePartitionedLogger<>(HistoryEventProto.PARSER, basePath, conf, new FixedClock(Time.now()));
 
     // Check the permissions they should be same as the expected permissions
-    Assert.assertEquals(expectedPermissions, fs.getFileStatus(basePath).getPermission());
+    assertEquals(expectedPermissions, fs.getFileStatus(basePath).getPermission());
   }
 
   private List<DAGHistoryEvent> makeHistoryEvents(TezDAGID dagId,
@@ -345,7 +349,7 @@ public class TestProtoHistoryLoggingService {
     when(appContext.getClock()).thenReturn(clock);
     service.setAppContext(appContext);
     Configuration conf = new Configuration(false);
-    String basePath = tempFolder.newFolder().getAbsolutePath();
+    String basePath = tempFolder.toAbsolutePath().toString();
     conf.set("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
     conf.set(TezConfiguration.TEZ_HISTORY_LOGGING_PROTO_BASE_DIR, basePath);
     conf.setBoolean(TezConfiguration.TEZ_HISTORY_LOGGING_PROTO_SPLIT_DAG_START, splitEvents);
@@ -358,14 +362,14 @@ public class TestProtoHistoryLoggingService {
     for (int i = start; i < finish; ++i) {
       try {
         HistoryEventProto evt = reader.readEvent();
-        Assert.assertEquals(protos.get(i), evt);
+        assertEquals(protos.get(i), evt);
       } catch (EOFException e) {
-        Assert.fail("Unexpected eof");
+        fail("Unexpected eof");
       }
     }
     try {
       HistoryEventProto evt = reader.readEvent();
-      Assert.assertNull(evt);
+      assertNull(evt);
     } catch (EOFException e) {
       // Expected.
     }

--- a/tez-plugins/tez-yarn-timeline-cache-plugin/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-cache-plugin/pom.xml
@@ -38,9 +38,8 @@
       <artifactId>hadoop-yarn-server-timeline-pluginstorage</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
   </dependencies>
 

--- a/tez-plugins/tez-yarn-timeline-cache-plugin/src/test/java/org/apache/tez/dag/history/logging/ats/TestTimelineCachePluginImpl.java
+++ b/tez-plugins/tez-yarn-timeline-cache-plugin/src/test/java/org/apache/tez/dag/history/logging/ats/TestTimelineCachePluginImpl.java
@@ -18,6 +18,11 @@
  */
 package org.apache.tez.dag.history.logging.ats;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -43,9 +48,8 @@ import org.apache.tez.dag.records.TezVertexID;
 
 import com.google.common.collect.Sets;
 
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 
 public class TestTimelineCachePluginImpl {
@@ -81,7 +85,7 @@ public class TestTimelineCachePluginImpl {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     appId1 = ApplicationId.newInstance(1000l, 111);
     appId2 = ApplicationId.newInstance(1001l, 121);
@@ -120,19 +124,19 @@ public class TestTimelineCachePluginImpl {
     TimelineCachePluginImpl plugin = createPlugin(100, null);
     for (Entry<String, String> entry : typeIdMap1.entrySet()) {
       NameValuePair primaryFilter = new NameValuePair(entry.getKey(), entry.getValue());
-      Assert.assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_APPLICATION.name(),
+      assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_APPLICATION.name(),
           primaryFilter, null));
       Set<TimelineEntityGroupId> groupIds = plugin.getTimelineEntityGroupId(entry.getKey(), primaryFilter, null);
       if (entry.getKey().equals(EntityTypes.TEZ_DAG_ID.name())) {
-        Assert.assertNull(groupIds);
+        assertNull(groupIds);
         continue;
       }
-      Assert.assertEquals(2, groupIds.size());
+      assertEquals(2, groupIds.size());
       Iterator<TimelineEntityGroupId> iter = groupIds.iterator();
       while (iter.hasNext()) {
         TimelineEntityGroupId groupId = iter.next();
-        Assert.assertEquals(appId1, groupId.getApplicationId());
-        Assert.assertTrue(getGroupIds(dagID1, 100).contains(groupId.getTimelineEntityGroupId()));
+        assertEquals(appId1, groupId.getApplicationId());
+        assertTrue(getGroupIds(dagID1, 100).contains(groupId.getTimelineEntityGroupId()));
       }
     }
   }
@@ -143,15 +147,15 @@ public class TestTimelineCachePluginImpl {
     for (Entry<String, String> entry : typeIdMap1.entrySet()) {
       Set<TimelineEntityGroupId> groupIds = plugin.getTimelineEntityGroupId(entry.getValue(), entry.getKey());
       if (entry.getKey().equals(EntityTypes.TEZ_DAG_ID.name())) {
-        Assert.assertNull(groupIds);
+        assertNull(groupIds);
         continue;
       }
-      Assert.assertEquals(1, groupIds.size());
+      assertEquals(1, groupIds.size());
       Iterator<TimelineEntityGroupId> iter = groupIds.iterator();
       while (iter.hasNext()) {
         TimelineEntityGroupId groupId = iter.next();
-        Assert.assertEquals(appId1, groupId.getApplicationId());
-        Assert.assertTrue(getGroupIds(dagID1).contains(groupId.getTimelineEntityGroupId()));
+        assertEquals(appId1, groupId.getApplicationId());
+        assertTrue(getGroupIds(dagID1).contains(groupId.getTimelineEntityGroupId()));
       }
     }
   }
@@ -162,15 +166,15 @@ public class TestTimelineCachePluginImpl {
     for (Entry<String, String> entry : typeIdMap1.entrySet()) {
       Set<TimelineEntityGroupId> groupIds = plugin.getTimelineEntityGroupId(entry.getValue(), entry.getKey());
       if (entry.getKey().equals(EntityTypes.TEZ_DAG_ID.name())) {
-        Assert.assertNull(groupIds);
+        assertNull(groupIds);
         continue;
       }
-      Assert.assertEquals(1, groupIds.size());
+      assertEquals(1, groupIds.size());
       Iterator<TimelineEntityGroupId> iter = groupIds.iterator();
       while (iter.hasNext()) {
         TimelineEntityGroupId groupId = iter.next();
-        Assert.assertEquals(appId1, groupId.getApplicationId());
-        Assert.assertTrue(getGroupIds(dagID1).contains(groupId.getTimelineEntityGroupId()));
+        assertEquals(appId1, groupId.getApplicationId());
+        assertTrue(getGroupIds(dagID1).contains(groupId.getTimelineEntityGroupId()));
       }
     }
   }
@@ -181,15 +185,15 @@ public class TestTimelineCachePluginImpl {
     for (Entry<String, String> entry : typeIdMap1.entrySet()) {
       Set<TimelineEntityGroupId> groupIds = plugin.getTimelineEntityGroupId(entry.getValue(), entry.getKey());
       if (entry.getKey().equals(EntityTypes.TEZ_DAG_ID.name())) {
-        Assert.assertNull(groupIds);
+        assertNull(groupIds);
         continue;
       }
-      Assert.assertEquals(2, groupIds.size());
+      assertEquals(2, groupIds.size());
       Iterator<TimelineEntityGroupId> iter = groupIds.iterator();
       while (iter.hasNext()) {
         TimelineEntityGroupId groupId = iter.next();
-        Assert.assertEquals(appId1, groupId.getApplicationId());
-        Assert.assertTrue(getGroupIds(dagID1, 100).contains(groupId.getTimelineEntityGroupId()));
+        assertEquals(appId1, groupId.getApplicationId());
+        assertTrue(getGroupIds(dagID1, 100).contains(groupId.getTimelineEntityGroupId()));
       }
     }
   }
@@ -200,15 +204,15 @@ public class TestTimelineCachePluginImpl {
     for (Entry<String, String> entry : typeIdMap2.entrySet()) {
       Set<TimelineEntityGroupId> groupIds = plugin.getTimelineEntityGroupId(entry.getValue(), entry.getKey());
       if (entry.getKey().equals(EntityTypes.TEZ_DAG_ID.name())) {
-        Assert.assertNull(groupIds);
+        assertNull(groupIds);
         continue;
       }
-      Assert.assertEquals(3, groupIds.size());
+      assertEquals(3, groupIds.size());
       Iterator<TimelineEntityGroupId> iter = groupIds.iterator();
       while (iter.hasNext()) {
         TimelineEntityGroupId groupId = iter.next();
-        Assert.assertEquals(appId2, groupId.getApplicationId());
-        Assert.assertTrue(getGroupIds(dagID2, 100, 50).contains(groupId.getTimelineEntityGroupId()));
+        assertEquals(appId2, groupId.getApplicationId());
+        assertTrue(getGroupIds(dagID2, 100, 50).contains(groupId.getTimelineEntityGroupId()));
       }
     }
   }
@@ -219,15 +223,15 @@ public class TestTimelineCachePluginImpl {
     for (Entry<String, String> entry : typeIdMap2.entrySet()) {
       Set<TimelineEntityGroupId> groupIds = plugin.getTimelineEntityGroupId(entry.getValue(), entry.getKey());
       if (entry.getKey().equals(EntityTypes.TEZ_DAG_ID.name())) {
-        Assert.assertNull(groupIds);
+        assertNull(groupIds);
         continue;
       }
-      Assert.assertEquals(4, groupIds.size());
+      assertEquals(4, groupIds.size());
       Iterator<TimelineEntityGroupId> iter = groupIds.iterator();
       while (iter.hasNext()) {
         TimelineEntityGroupId groupId = iter.next();
-        Assert.assertEquals(appId2, groupId.getApplicationId());
-        Assert.assertTrue(
+        assertEquals(appId2, groupId.getApplicationId());
+        assertTrue(
             getGroupIds(dagID2, 100, 25, 50).contains(groupId.getTimelineEntityGroupId()));
       }
     }
@@ -239,15 +243,15 @@ public class TestTimelineCachePluginImpl {
     for (Entry<String, String> entry : typeIdMap2.entrySet()) {
       Set<TimelineEntityGroupId> groupIds = plugin.getTimelineEntityGroupId(entry.getValue(), entry.getKey());
       if (entry.getKey().equals(EntityTypes.TEZ_DAG_ID.name())) {
-        Assert.assertNull(groupIds);
+        assertNull(groupIds);
         continue;
       }
-      Assert.assertEquals(2, groupIds.size());
+      assertEquals(2, groupIds.size());
       Iterator<TimelineEntityGroupId> iter = groupIds.iterator();
       while (iter.hasNext()) {
         TimelineEntityGroupId groupId = iter.next();
-        Assert.assertEquals(appId2, groupId.getApplicationId());
-        Assert.assertTrue(getGroupIds(dagID2, 100).contains(groupId.getTimelineEntityGroupId()));
+        assertEquals(appId2, groupId.getApplicationId());
+        assertTrue(getGroupIds(dagID2, 100).contains(groupId.getTimelineEntityGroupId()));
       }
     }
   }
@@ -262,10 +266,10 @@ public class TestTimelineCachePluginImpl {
       Set<TimelineEntityGroupId> groupIds = plugin.getTimelineEntityGroupId(entry.getKey(),
           entityIds, null);
       if (entry.getKey().equals(EntityTypes.TEZ_DAG_ID.name())) {
-        Assert.assertNull(groupIds);
+        assertNull(groupIds);
         continue;
       }
-      Assert.assertEquals(4, groupIds.size());
+      assertEquals(4, groupIds.size());
       int found = 0;
       Iterator<TimelineEntityGroupId> iter = groupIds.iterator();
       while (iter.hasNext()) {
@@ -275,52 +279,52 @@ public class TestTimelineCachePluginImpl {
           if (getGroupIds(dagID1, 100).contains(entityGroupId)) {
             ++found;
           } else {
-            Assert.fail("Unexpected group id: " + entityGroupId);
+            fail("Unexpected group id: " + entityGroupId);
           }
         } else if (groupId.getApplicationId().equals(appId2)) {
           String entityGroupId = groupId.getTimelineEntityGroupId();
           if (getGroupIds(dagID2, 100).contains(entityGroupId)) {
             ++found;
           } else {
-            Assert.fail("Unexpected group id: " + entityGroupId);
+            fail("Unexpected group id: " + entityGroupId);
           }
         } else {
-          Assert.fail("Unexpected appId: " + groupId.getApplicationId());
+          fail("Unexpected appId: " + groupId.getApplicationId());
         }
       }
-      Assert.assertEquals("All groupIds not returned", 4, found);
+      assertEquals(4, found, "All groupIds not returned");
     }
   }
 
   @Test
   public void testInvalidIds() {
     TimelineCachePluginImpl plugin = createPlugin(-1, null);
-    Assert.assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_DAG_ID.name(),
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_DAG_ID.name(),
         vertexID1.toString()));
-    Assert.assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_VERTEX_ID.name(),
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_VERTEX_ID.name(),
         taskID1.toString()));
-    Assert.assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ID.name(),
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ID.name(),
         attemptID1.toString()));
-    Assert.assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ATTEMPT_ID.name(),
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ATTEMPT_ID.name(),
         dagID1.toString()));
-    Assert.assertNull(plugin.getTimelineEntityGroupId("", ""));
-    Assert.assertNull(plugin.getTimelineEntityGroupId(null, null));
-    Assert.assertNull(plugin.getTimelineEntityGroupId("adadasd", EntityTypes.TEZ_DAG_ID.name()));
+    assertNull(plugin.getTimelineEntityGroupId("", ""));
+    assertNull(plugin.getTimelineEntityGroupId(null, null));
+    assertNull(plugin.getTimelineEntityGroupId("adadasd", EntityTypes.TEZ_DAG_ID.name()));
   }
 
   @Test
   public void testInvalidTypeRequests() {
     TimelineCachePluginImpl plugin = createPlugin(-1, null);
-    Assert.assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_APPLICATION.name(),
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_APPLICATION.name(),
         appId1.toString()));
-    Assert.assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_APPLICATION_ATTEMPT.name(),
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_APPLICATION_ATTEMPT.name(),
         appAttemptId1.toString()));
-    Assert.assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_CONTAINER_ID.name(),
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_CONTAINER_ID.name(),
         appId1.toString()));
 
-    Assert.assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ID.name(), null,
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ID.name(), null,
         new HashSet<String>()));
-    Assert.assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ID.name(), null,
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ID.name(), null,
         new HashSet<NameValuePair>()));
 
   }
@@ -334,7 +338,7 @@ public class TestTimelineCachePluginImpl {
     entityIds.add("tez_" + cId2.toString());
     Set<TimelineEntityGroupId> groupIds = plugin.getTimelineEntityGroupId(entityType,
         entityIds, null);
-    Assert.assertEquals(2, groupIds.size());
+    assertEquals(2, groupIds.size());
     int found = 0;
     Iterator<TimelineEntityGroupId> iter = groupIds.iterator();
     while (iter.hasNext()) {
@@ -347,11 +351,11 @@ public class TestTimelineCachePluginImpl {
         ++found;
       }
     }
-    Assert.assertEquals("All groupIds not returned", 2, found);
+    assertEquals(2, found, "All groupIds not returned");
 
     groupIds.clear();
     groupIds = plugin.getTimelineEntityGroupId(cId1.toString(), entityType);
-    Assert.assertEquals(1, groupIds.size());
+    assertEquals(1, groupIds.size());
     found = 0;
     iter = groupIds.iterator();
     while (iter.hasNext()) {
@@ -361,11 +365,11 @@ public class TestTimelineCachePluginImpl {
         ++found;
       }
     }
-    Assert.assertEquals("All groupIds not returned", 1, found);
+    assertEquals(1, found, "All groupIds not returned");
 
     groupIds.clear();
     groupIds = plugin.getTimelineEntityGroupId("tez_" + cId2.toString(), entityType);
-    Assert.assertEquals(1, groupIds.size());
+    assertEquals(1, groupIds.size());
     found = 0;
     iter = groupIds.iterator();
     while (iter.hasNext()) {
@@ -375,7 +379,7 @@ public class TestTimelineCachePluginImpl {
         ++found;
       }
     }
-    Assert.assertEquals("All groupIds not returned", 1, found);
+    assertEquals(1, found, "All groupIds not returned");
   }
 
   private Set<String> getGroupIds(TezDAGID dagId, int ... allNumDagsPerGroup) {

--- a/tez-plugins/tez-yarn-timeline-cache-plugin/src/test/java/org/apache/tez/dag/history/logging/ats/TestTimelineCachePluginImpl.java
+++ b/tez-plugins/tez-yarn-timeline-cache-plugin/src/test/java/org/apache/tez/dag/history/logging/ats/TestTimelineCachePluginImpl.java
@@ -299,14 +299,10 @@ public class TestTimelineCachePluginImpl {
   @Test
   public void testInvalidIds() {
     TimelineCachePluginImpl plugin = createPlugin(-1, null);
-    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_DAG_ID.name(),
-        vertexID1.toString()));
-    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_VERTEX_ID.name(),
-        taskID1.toString()));
-    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ID.name(),
-        attemptID1.toString()));
-    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ATTEMPT_ID.name(),
-        dagID1.toString()));
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_DAG_ID.name(), vertexID1.toString()));
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_VERTEX_ID.name(), taskID1.toString()));
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ID.name(), attemptID1.toString()));
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ATTEMPT_ID.name(), dagID1.toString()));
     assertNull(plugin.getTimelineEntityGroupId("", ""));
     assertNull(plugin.getTimelineEntityGroupId(null, null));
     assertNull(plugin.getTimelineEntityGroupId("adadasd", EntityTypes.TEZ_DAG_ID.name()));
@@ -315,17 +311,12 @@ public class TestTimelineCachePluginImpl {
   @Test
   public void testInvalidTypeRequests() {
     TimelineCachePluginImpl plugin = createPlugin(-1, null);
-    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_APPLICATION.name(),
-        appId1.toString()));
-    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_APPLICATION_ATTEMPT.name(),
-        appAttemptId1.toString()));
-    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_CONTAINER_ID.name(),
-        appId1.toString()));
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_APPLICATION.name(), appId1.toString()));
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_APPLICATION_ATTEMPT.name(), appAttemptId1.toString()));
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_CONTAINER_ID.name(), appId1.toString()));
 
-    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ID.name(), null,
-        new HashSet<String>()));
-    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ID.name(), null,
-        new HashSet<NameValuePair>()));
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ID.name(), null, new HashSet<String>()));
+    assertNull(plugin.getTimelineEntityGroupId(EntityTypes.TEZ_TASK_ID.name(), null, new HashSet<NameValuePair>()));
 
   }
 

--- a/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-acls/pom.xml
@@ -135,9 +135,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
@@ -147,16 +146,6 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/tez-plugins/tez-yarn-timeline-history-with-acls/src/test/java/org/apache/tez/dag/history/ats/acls/TestATSHistoryWithACLs.java
+++ b/tez-plugins/tez-yarn-timeline-history-with-acls/src/test/java/org/apache/tez/dag/history/ats/acls/TestATSHistoryWithACLs.java
@@ -18,10 +18,11 @@
  */
 package org.apache.tez.dag.history.ats.acls;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
@@ -30,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -75,10 +77,10 @@ import com.google.common.collect.Sets;
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,7 +102,7 @@ public class TestATSHistoryWithACLs {
 
   private static String user;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     try {
       conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEST_ROOT_DIR);
@@ -134,7 +136,7 @@ public class TestATSHistoryWithACLs {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws InterruptedException {
     LOG.info("Shutdown invoked");
     Thread.sleep(10000);
@@ -254,7 +256,8 @@ public class TestATSHistoryWithACLs {
 
   }
 
-  @Test (timeout=50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleAMACls() throws Exception {
     TezClient tezSession = null;
     ApplicationId applicationId;
@@ -306,7 +309,8 @@ public class TestATSHistoryWithACLs {
     verifyEntityDomains(applicationId, true);
   }
 
-  @Test (timeout=50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testDAGACls() throws Exception {
     TezClient tezSession = null;
     ApplicationId applicationId;
@@ -373,7 +377,8 @@ public class TestATSHistoryWithACLs {
    * due to failure to create domain in session start
    * @throws Exception
    */
-  @Test (timeout=50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testDisableSessionLogging() throws Exception {
     TezClient tezSession = null;
     String viewAcls = "nobody nobody_group";
@@ -438,7 +443,8 @@ public class TestATSHistoryWithACLs {
    * in dagsubmittedevent is set off
    * @throws Exception
    */
-  @Test (timeout=50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testDagLoggingDisabled() throws Exception {
     ATSHistoryLoggingService historyLoggingService;
     historyLoggingService =
@@ -483,7 +489,8 @@ public class TestATSHistoryWithACLs {
    * the dag logging flag in dagsubmitted event is set on
    * @throws Exception
    */
-  @Test (timeout=50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testDagLoggingEnabled() throws Exception {
     ATSHistoryLoggingService historyLoggingService;
     historyLoggingService =
@@ -531,7 +538,8 @@ public class TestATSHistoryWithACLs {
 
   private static final String atsHistoryACLManagerClassName =
       "org.apache.tez.dag.history.ats.acls.ATSHistoryACLPolicyManager";
-  @Test (timeout=50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testTimelineServiceDisabled() throws Exception {
     TezConfiguration tezConf = new TezConfiguration(mrrTezCluster.getConfig());
     tezConf.set(TezConfiguration.TEZ_HISTORY_LOGGING_SERVICE_CLASS,
@@ -540,7 +548,7 @@ public class TestATSHistoryWithACLs {
     ATSHistoryACLPolicyManager historyACLPolicyManager = ReflectionUtils.createClazzInstance(
         atsHistoryACLManagerClassName);
     historyACLPolicyManager.setConf(tezConf);
-    Assert.assertNull(historyACLPolicyManager.timelineClient);
+    assertNull(historyACLPolicyManager.timelineClient);
   }
 
   private void verifyEntityDomains(ApplicationId applicationId, boolean sameDomain) {

--- a/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history-with-fs/pom.xml
@@ -143,18 +143,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tez-plugins/tez-yarn-timeline-history-with-fs/src/test/java/org/apache/tez/dag/history/ats/acls/TestATSHistoryV15.java
+++ b/tez-plugins/tez-yarn-timeline-history-with-fs/src/test/java/org/apache/tez/dag/history/ats/acls/TestATSHistoryV15.java
@@ -18,12 +18,14 @@
  */
 package org.apache.tez.dag.history.ats.acls;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -44,6 +46,7 @@ import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.Vertex;
 import org.apache.tez.dag.api.client.DAGClient;
 import org.apache.tez.dag.api.client.DAGStatus;
+import org.apache.tez.dag.api.client.DAGStatus.State;
 import org.apache.tez.dag.app.AppContext;
 import org.apache.tez.dag.history.DAGHistoryEvent;
 import org.apache.tez.dag.history.HistoryEvent;
@@ -58,10 +61,10 @@ import org.apache.tez.tests.MiniTezClusterWithTimeline;
 import com.google.protobuf.CodedInputStream;
 import com.google.protobuf.CodedOutputStream;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +84,7 @@ public class TestATSHistoryV15 {
       + TestATSHistoryV15.class.getName() + "-tmpDir";
   private static Path atsActivePath;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     try {
       conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEST_ROOT_DIR);
@@ -129,7 +132,7 @@ public class TestATSHistoryV15 {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws InterruptedException {
     LOG.info("Shutdown invoked");
     Thread.sleep(10000);
@@ -143,7 +146,8 @@ public class TestATSHistoryV15 {
     }
   }
 
-  @Test(timeout=50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleDAG() throws Exception {
     TezClient tezSession = null;
     ApplicationId applicationId;
@@ -184,11 +188,11 @@ public class TestATSHistoryV15 {
         Thread.sleep(500l);
         dagStatus = dagClient.getDAGStatus(null);
       }
-      assertEquals(DAGStatus.State.SUCCEEDED, dagStatus.getState());
+      assertEquals(State.SUCCEEDED, dagStatus.getState());
 
       // Verify HDFS data
       int count = verifyATSDataOnHDFS(atsActivePath, applicationId);
-      Assert.assertEquals("Count is: " + count, 2, count);
+      assertEquals(2, count, "Count is: " + count);
     } finally {
       if (tezSession != null) {
         tezSession.stop();
@@ -238,11 +242,11 @@ public class TestATSHistoryV15 {
         Thread.sleep(500l);
         dagStatus = dagClient.getDAGStatus(null);
       }
-      assertEquals(DAGStatus.State.SUCCEEDED, dagStatus.getState());
+      assertEquals(State.SUCCEEDED, dagStatus.getState());
 
       // Verify HDFS data
       int count = verifyATSDataOnHDFS(atsActivePath, applicationId);
-      Assert.assertEquals("Count is: " + count, 1, count);
+      assertEquals(1, count, "Count is: " + count);
     } finally {
       if (tezSession != null) {
         tezSession.stop();
@@ -307,18 +311,18 @@ public class TestATSHistoryV15 {
       service.setAppContext(appContext);
 
       TimelineEntityGroupId grpId = service.getGroupId(event);
-      Assert.assertNotNull(grpId);
-      Assert.assertEquals(appId, grpId.getApplicationId());
+      assertNotNull(grpId);
+      assertEquals(appId, grpId.getApplicationId());
       switch (eventType) {
         case AM_LAUNCHED:
         case APP_LAUNCHED:
         case AM_STARTED:
         case CONTAINER_LAUNCHED:
         case CONTAINER_STOPPED:
-          Assert.assertEquals(appId.toString(), grpId.getTimelineEntityGroupId());
+          assertEquals(appId.toString(), grpId.getTimelineEntityGroupId());
           break;
         default:
-          Assert.assertEquals(dagid.toString(), grpId.getTimelineEntityGroupId());
+          assertEquals(dagid.toString(), grpId.getTimelineEntityGroupId());
       }
       service.close();
     }

--- a/tez-plugins/tez-yarn-timeline-history-with-fs/src/test/java/org/apache/tez/dag/history/logging/ats/TestATSV15HistoryLoggingService.java
+++ b/tez-plugins/tez-yarn-timeline-history-with-fs/src/test/java/org/apache/tez/dag/history/logging/ats/TestATSV15HistoryLoggingService.java
@@ -18,11 +18,11 @@
  */
 package org.apache.tez.dag.history.logging.ats;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -65,7 +66,8 @@ import org.apache.tez.dag.records.TezTaskID;
 import org.apache.tez.dag.records.TezVertexID;
 import org.apache.tez.hadoop.shim.HadoopShim;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -81,7 +83,8 @@ public class TestATSV15HistoryLoggingService {
 
   private AppContext appContext;
 
-  @Test(timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testDAGGroupingDefault() throws Exception {
     ATSV15HistoryLoggingService service = createService(-1);
 
@@ -110,7 +113,8 @@ public class TestATSV15HistoryLoggingService {
     service.stop();
   }
 
-  @Test(timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testDAGGroupingDisabled() throws Exception {
     ATSV15HistoryLoggingService service = createService(1);
     service.start();
@@ -138,7 +142,8 @@ public class TestATSV15HistoryLoggingService {
     service.stop();
   }
 
-  @Test(timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testDAGGroupingGroupingEnabled() throws Exception {
     int numDagsPerGroup = 100;
     ATSV15HistoryLoggingService service = createService(numDagsPerGroup);

--- a/tez-plugins/tez-yarn-timeline-history/pom.xml
+++ b/tez-plugins/tez-yarn-timeline-history/pom.xml
@@ -129,18 +129,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
       <artifactId>jersey-media-json-jackson</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/tez-plugins/tez-yarn-timeline-history/src/test/java/org/apache/tez/dag/history/logging/ats/TestATSHistoryLoggingService.java
+++ b/tez-plugins/tez-yarn-timeline-history/src/test/java/org/apache/tez/dag/history/logging/ats/TestATSHistoryLoggingService.java
@@ -18,6 +18,9 @@
  */
 package org.apache.tez.dag.history.logging.ats;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -29,6 +32,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
@@ -54,10 +58,10 @@ import org.apache.tez.dag.records.TezTaskAttemptID;
 import org.apache.tez.dag.records.TezTaskID;
 import org.apache.tez.dag.records.TezVertexID;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -77,7 +81,7 @@ public class TestATSHistoryLoggingService {
   private static ApplicationId appId = ApplicationId.newInstance(1000l, 1);
   private static ApplicationAttemptId attemptId = ApplicationAttemptId.newInstance(appId, 1);
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     appContext = mock(AppContext.class);
     historyACLPolicyManager = mock(HistoryACLPolicyManager.class);
@@ -116,13 +120,14 @@ public class TestATSHistoryLoggingService {
     );
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     atsHistoryLoggingService.stop();
     atsHistoryLoggingService = null;
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testATSHistoryLoggingServiceShutdown() {
     atsHistoryLoggingService.start();
     TezDAGID tezDAGID = TezDAGID.getInstance(
@@ -144,12 +149,13 @@ public class TestATSHistoryLoggingService {
     LOG.info("ATS entitiesSent=" + atsEntitiesCounter
         + ", timelineInvocations=" + atsInvokeCounter);
 
-    Assert.assertTrue(atsEntitiesCounter >= 4);
-    Assert.assertTrue(atsEntitiesCounter < 20);
+    assertTrue(atsEntitiesCounter >= 4);
+    assertTrue(atsEntitiesCounter < 20);
 
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testATSEventBatching() {
     atsHistoryLoggingService.start();
     TezDAGID tezDAGID = TezDAGID.getInstance(
@@ -169,11 +175,12 @@ public class TestATSHistoryLoggingService {
     LOG.info("ATS entitiesSent=" + atsEntitiesCounter
         + ", timelineInvocations=" + atsInvokeCounter);
 
-    Assert.assertTrue(atsEntitiesCounter > atsInvokeCounter);
-    Assert.assertEquals(atsEntitiesCounter/2, atsInvokeCounter);
+    assertTrue(atsEntitiesCounter > atsInvokeCounter);
+    assertEquals(atsEntitiesCounter/2, atsInvokeCounter);
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testTimelineServiceDisable() throws Exception {
     atsHistoryLoggingService.start();
     ATSHistoryLoggingService atsHistoryLoggingService1;
@@ -215,13 +222,14 @@ public class TestATSHistoryLoggingService {
     }
     LOG.info("ATS entitiesSent=" + atsEntitiesCounter
          + ", timelineInvocations=" + atsInvokeCounter);
-    Assert.assertEquals(atsInvokeCounter, 0);
-    Assert.assertEquals(atsEntitiesCounter, 0);
-    Assert.assertNull(atsHistoryLoggingService1.timelineClient);
+    assertEquals(atsInvokeCounter, 0);
+    assertEquals(atsEntitiesCounter, 0);
+    assertNull(atsHistoryLoggingService1.timelineClient);
     atsHistoryLoggingService1.close();
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testNonSessionDomains() throws Exception {
     when(historyACLPolicyManager.setupSessionACLs(any(), any()))
         .thenReturn(
@@ -246,7 +254,8 @@ public class TestATSHistoryLoggingService {
     verify(historyACLPolicyManager, times(6)).updateTimelineEntityDomain(any(), eq("session-id"));
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testNonSessionDomainsFailed() throws Exception {
     when(historyACLPolicyManager.setupSessionACLs(any(), any()))
         .thenThrow(new IOException());
@@ -267,10 +276,11 @@ public class TestATSHistoryLoggingService {
 
     // All calls made with session domain id.
     verify(historyACLPolicyManager, times(0)).updateTimelineEntityDomain(any(), eq("session-id"));
-    Assert.assertEquals(0, atsEntitiesCounter);
+    assertEquals(0, atsEntitiesCounter);
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testNonSessionDomainsAclNull() throws Exception {
     when(historyACLPolicyManager.setupSessionACLs(any(), any()))
         .thenReturn(null);
@@ -292,10 +302,11 @@ public class TestATSHistoryLoggingService {
 
     // All calls made with session domain id.
     verify(historyACLPolicyManager, times(0)).updateTimelineEntityDomain(any(), eq("session-id"));
-    Assert.assertEquals(6, atsEntitiesCounter);
+    assertEquals(6, atsEntitiesCounter);
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSessionDomains() throws Exception {
     when(historyACLPolicyManager.setupSessionACLs(any(), any()))
         .thenReturn(Collections.singletonMap(TezConfiguration.YARN_ATS_ACL_SESSION_DOMAIN_ID, "test-domain"));
@@ -325,7 +336,8 @@ public class TestATSHistoryLoggingService {
     verify(historyACLPolicyManager, times(5)).updateTimelineEntityDomain(any(), eq("dag-domain"));
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSessionDomainsFailed() throws Exception {
     when(historyACLPolicyManager.setupSessionACLs(any(), any()))
         .thenThrow(new IOException());
@@ -351,10 +363,11 @@ public class TestATSHistoryLoggingService {
 
     // No calls were made for domains.
     verify(historyACLPolicyManager, times(0)).updateTimelineEntityDomain(any(), any());
-    Assert.assertEquals(0, atsEntitiesCounter);
+    assertEquals(0, atsEntitiesCounter);
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSessionDomainsDagFailed() throws Exception {
     when(historyACLPolicyManager.setupSessionACLs(any(), any()))
         .thenReturn(Collections.singletonMap(TezConfiguration.YARN_ATS_ACL_SESSION_DOMAIN_ID, "session-domain"));
@@ -384,10 +397,11 @@ public class TestATSHistoryLoggingService {
         .updateTimelineEntityDomain(any(), eq("session-domain"));
     verify(historyACLPolicyManager, times(1))
         .updateTimelineEntityDomain(any(), any());
-    Assert.assertEquals(1, atsEntitiesCounter);
+    assertEquals(1, atsEntitiesCounter);
   }
 
-  @Test(timeout=10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSessionDomainsAclNull() throws Exception {
     when(historyACLPolicyManager.setupSessionACLs(any(), any()))
         .thenReturn(null);
@@ -414,7 +428,7 @@ public class TestATSHistoryLoggingService {
 
     // All calls made with session domain id.
     verify(historyACLPolicyManager, times(0)).updateTimelineEntityDomain(any(), any());
-    Assert.assertEquals(6, atsEntitiesCounter);
+    assertEquals(6, atsEntitiesCounter);
   }
 
   private List<DAGHistoryEvent> makeHistoryEvents(TezDAGID dagId,

--- a/tez-plugins/tez-yarn-timeline-history/src/test/java/org/apache/tez/dag/history/logging/ats/TestATSHistoryWithMiniCluster.java
+++ b/tez-plugins/tez-yarn-timeline-history/src/test/java/org/apache/tez/dag/history/logging/ats/TestATSHistoryWithMiniCluster.java
@@ -18,8 +18,13 @@
  */
 package org.apache.tez.dag.history.logging.ats;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -44,10 +49,10 @@ import org.apache.tez.runtime.library.processor.SleepProcessor;
 import org.apache.tez.runtime.library.processor.SleepProcessor.SleepProcessorConfig;
 import org.apache.tez.tests.MiniTezClusterWithTimeline;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +71,7 @@ public class TestATSHistoryWithMiniCluster {
   private static String TEST_ROOT_DIR = "target" + Path.SEPARATOR
       + TestATSHistoryWithMiniCluster.class.getName() + "-tmpDir";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     try {
       conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEST_ROOT_DIR);
@@ -99,7 +104,7 @@ public class TestATSHistoryWithMiniCluster {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws InterruptedException {
     LOG.info("Shutdown invoked");
     Thread.sleep(10000);
@@ -120,17 +125,18 @@ public class TestATSHistoryWithMiniCluster {
 
     Response response = target.request(MediaType.APPLICATION_JSON)
         .get();
-    Assert.assertEquals(200, response.getStatus());
-    Assert.assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(response.getMediaType()));
+    assertEquals(200, response.getStatus());
+    assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(response.getMediaType()));
 
     K entity = response.readEntity(clazz);
-    Assert.assertNotNull(entity);
+    assertNotNull(entity);
     response.close();
     client.close();
     return entity;
   }
 
-  @Test (timeout=50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testDisabledACls() throws Exception {
     TezClient tezSession = null;
     try {
@@ -163,7 +169,7 @@ public class TestATSHistoryWithMiniCluster {
         Thread.sleep(500l);
         dagStatus = dagClient.getDAGStatus(null);
       }
-      Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagStatus.getState());
+      assertEquals(DAGStatus.State.SUCCEEDED, dagStatus.getState());
     } finally {
       if (tezSession != null) {
         tezSession.stop();

--- a/tez-plugins/tez-yarn-timeline-history/src/test/java/org/apache/tez/dag/history/logging/ats/TestHistoryEventTimelineConversion.java
+++ b/tez-plugins/tez-yarn-timeline-history/src/test/java/org/apache/tez/dag/history/logging/ats/TestHistoryEventTimelineConversion.java
@@ -18,11 +18,18 @@
  */
 package org.apache.tez.dag.history.logging.ats;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.conf.Configuration;
@@ -89,9 +96,9 @@ import org.apache.tez.runtime.api.TaskFailureType;
 import com.google.common.collect.Lists;
 
 import org.codehaus.jettison.json.JSONException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestHistoryEventTimelineConversion {
 
@@ -109,7 +116,7 @@ public class TestHistoryEventTimelineConversion {
   private String containerLogs = "containerLogs";
 
   @SuppressWarnings("deprecation")
-  @Before
+  @BeforeEach
   public void setup() {
     applicationId = ApplicationId.newInstance(9999l, 1);
     applicationAttemptId = ApplicationAttemptId.newInstance(applicationId, 1);
@@ -128,7 +135,8 @@ public class TestHistoryEventTimelineConversion {
     nodeId = NodeId.newInstance("node", 13435);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testHandlerExists() throws JSONException {
     for (HistoryEventType eventType : HistoryEventType.values()) {
       HistoryEvent event = null;
@@ -217,7 +225,7 @@ public class TestHistoryEventTimelineConversion {
           event = new DAGKillRequestEvent();
           break;
         default:
-          Assert.fail("Unhandled event type " + eventType);
+          fail("Unhandled event type " + eventType);
       }
       if (event == null || !event.isHistoryEvent()) {
         continue;
@@ -234,7 +242,8 @@ public class TestHistoryEventTimelineConversion {
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertAppLaunchedEventConcurrentModificationException()
       throws InterruptedException {
     long launchTime = random.nextLong();
@@ -268,7 +277,8 @@ public class TestHistoryEventTimelineConversion {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertAppLaunchedEvent() {
     long launchTime = random.nextLong();
     long submitTime = random.nextLong();
@@ -281,209 +291,215 @@ public class TestHistoryEventTimelineConversion {
         submitTime, user, conf, mockVersionInfo);
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(launchTime, timelineEntity.getStartTime().longValue());
+    assertEquals(launchTime, timelineEntity.getStartTime().longValue());
 
-    Assert.assertEquals(EntityTypes.TEZ_APPLICATION.name(), timelineEntity.getEntityType());
-    Assert.assertEquals("tez_" + applicationId.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_APPLICATION.name(), timelineEntity.getEntityType());
+    assertEquals("tez_" + applicationId.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(0, timelineEntity.getRelatedEntities().size());
+    assertEquals(0, timelineEntity.getRelatedEntities().size());
 
-    Assert.assertEquals(1, timelineEntity.getPrimaryFilters().size());
-    Assert.assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
+    assertEquals(1, timelineEntity.getPrimaryFilters().size());
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
 
-    Assert.assertEquals(5, timelineEntity.getOtherInfo().size());
-    Assert.assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.CONFIG));
-    Assert.assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.TEZ_VERSION));
-    Assert.assertEquals(user, timelineEntity.getOtherInfo().get(ATSConstants.USER));
-    Assert.assertEquals(applicationId.toString(),
+    assertEquals(5, timelineEntity.getOtherInfo().size());
+    assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.CONFIG));
+    assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.TEZ_VERSION));
+    assertEquals(user, timelineEntity.getOtherInfo().get(ATSConstants.USER));
+    assertEquals(applicationId.toString(),
         timelineEntity.getOtherInfo().get(ATSConstants.APPLICATION_ID));
-    Assert.assertEquals(AMWebController.VERSION,
+    assertEquals(AMWebController.VERSION,
         timelineEntity.getOtherInfo().get(ATSConstants.DAG_AM_WEB_SERVICE_VERSION));
 
     Map<String, String> config =
         (Map<String, String>) timelineEntity.getOtherInfo().get(ATSConstants.CONFIG);
-    Assert.assertEquals(conf.get("foo"), config.get("foo"));
-    Assert.assertEquals(conf.get("applicationId"), config.get("applicationId"));
+    assertEquals(conf.get("foo"), config.get("foo"));
+    assertEquals(conf.get("applicationId"), config.get("applicationId"));
 
     Map<String, String> versionInfo =
         (Map<String, String>) timelineEntity.getOtherInfo().get(ATSConstants.TEZ_VERSION);
-    Assert.assertEquals(mockVersionInfo.getVersion(),
+    assertEquals(mockVersionInfo.getVersion(),
         versionInfo.get(ATSConstants.VERSION));
-    Assert.assertEquals(mockVersionInfo.getRevision(),
+    assertEquals(mockVersionInfo.getRevision(),
         versionInfo.get(ATSConstants.REVISION));
-    Assert.assertEquals(mockVersionInfo.getBuildTime(),
+    assertEquals(mockVersionInfo.getBuildTime(),
         versionInfo.get(ATSConstants.BUILD_TIME));
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertAMLaunchedEvent() {
     long launchTime = random.nextLong();
     long submitTime = random.nextLong();
     AMLaunchedEvent event = new AMLaunchedEvent(applicationAttemptId, launchTime, submitTime, user);
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals("tez_" + applicationAttemptId.toString(), timelineEntity.getEntityId());
-    Assert.assertEquals(EntityTypes.TEZ_APPLICATION_ATTEMPT.name(), timelineEntity.getEntityType());
+    assertEquals("tez_" + applicationAttemptId.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_APPLICATION_ATTEMPT.name(), timelineEntity.getEntityType());
 
     final Map<String, Set<String>> relatedEntities = timelineEntity.getRelatedEntities();
-    Assert.assertEquals(0, relatedEntities.size());
+    assertEquals(0, relatedEntities.size());
 
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
-    Assert.assertEquals(2, primaryFilters.size());
-    Assert.assertTrue(primaryFilters.get(ATSConstants.USER).contains(user));
-    Assert.assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
+    assertEquals(2, primaryFilters.size());
+    assertTrue(primaryFilters.get(ATSConstants.USER).contains(user));
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
         .contains(applicationId.toString()));
 
-    Assert.assertEquals(launchTime, timelineEntity.getStartTime().longValue());
+    assertEquals(launchTime, timelineEntity.getStartTime().longValue());
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent evt = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.AM_LAUNCHED.name(), evt.getEventType());
-    Assert.assertEquals(launchTime, evt.getTimestamp());
+    assertEquals(HistoryEventType.AM_LAUNCHED.name(), evt.getEventType());
+    assertEquals(launchTime, evt.getTimestamp());
 
     final Map<String, Object> otherInfo = timelineEntity.getOtherInfo();
-    Assert.assertEquals(4, otherInfo.size());
-    Assert.assertEquals(submitTime, otherInfo.get(ATSConstants.APP_SUBMIT_TIME));
-    Assert.assertEquals(applicationId.toString(), otherInfo.get(ATSConstants.APPLICATION_ID));
-    Assert.assertEquals(applicationAttemptId.toString(), otherInfo.get(ATSConstants.APPLICATION_ATTEMPT_ID));
-    Assert.assertEquals(user, otherInfo.get(ATSConstants.USER));
+    assertEquals(4, otherInfo.size());
+    assertEquals(submitTime, otherInfo.get(ATSConstants.APP_SUBMIT_TIME));
+    assertEquals(applicationId.toString(), otherInfo.get(ATSConstants.APPLICATION_ID));
+    assertEquals(applicationAttemptId.toString(), otherInfo.get(ATSConstants.APPLICATION_ATTEMPT_ID));
+    assertEquals(user, otherInfo.get(ATSConstants.USER));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertAMStartedEvent() {
     long startTime = random.nextLong();
 
     AMStartedEvent event = new AMStartedEvent(applicationAttemptId, startTime, user);
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals("tez_" + applicationAttemptId.toString(), timelineEntity.getEntityId());
-    Assert.assertEquals(EntityTypes.TEZ_APPLICATION_ATTEMPT.name(), timelineEntity.getEntityType());
+    assertEquals("tez_" + applicationAttemptId.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_APPLICATION_ATTEMPT.name(), timelineEntity.getEntityType());
 
     final Map<String, Set<String>> relatedEntities = timelineEntity.getRelatedEntities();
-    Assert.assertEquals(0, relatedEntities.size());
+    assertEquals(0, relatedEntities.size());
 
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
-    Assert.assertEquals(2, primaryFilters.size());
-    Assert.assertTrue(primaryFilters.get(ATSConstants.USER).contains(user));
-    Assert.assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
+    assertEquals(2, primaryFilters.size());
+    assertTrue(primaryFilters.get(ATSConstants.USER).contains(user));
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
             .contains(applicationId.toString()));
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent evt = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.AM_STARTED.name(), evt.getEventType());
-    Assert.assertEquals(startTime, evt.getTimestamp());
+    assertEquals(HistoryEventType.AM_STARTED.name(), evt.getEventType());
+    assertEquals(startTime, evt.getTimestamp());
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertContainerLaunchedEvent() {
     long launchTime = random.nextLong();
     ContainerLaunchedEvent event = new ContainerLaunchedEvent(containerId, launchTime,
         applicationAttemptId);
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(EntityTypes.TEZ_CONTAINER_ID.name(), timelineEntity.getEntityType());
-    Assert.assertEquals("tez_" + containerId.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_CONTAINER_ID.name(), timelineEntity.getEntityType());
+    assertEquals("tez_" + containerId.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(1, timelineEntity.getRelatedEntities().size());
-    Assert.assertTrue(
+    assertEquals(1, timelineEntity.getRelatedEntities().size());
+    assertTrue(
         timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_APPLICATION_ATTEMPT.name()).contains(
             "tez_" + applicationAttemptId.toString()));
 
-    Assert.assertEquals(1, timelineEntity.getPrimaryFilters().size());
-    Assert.assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
+    assertEquals(1, timelineEntity.getPrimaryFilters().size());
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
         applicationAttemptId.getApplicationId().toString()));
 
-    Assert.assertEquals(containerId.toString(), timelineEntity.getOtherInfo().get(ATSConstants.CONTAINER_ID));
+    assertEquals(containerId.toString(), timelineEntity.getOtherInfo().get(ATSConstants.CONTAINER_ID));
 
-    Assert.assertEquals(launchTime, timelineEntity.getStartTime().longValue());
+    assertEquals(launchTime, timelineEntity.getStartTime().longValue());
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
-    Assert.assertEquals(HistoryEventType.CONTAINER_LAUNCHED.name(),
+    assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(HistoryEventType.CONTAINER_LAUNCHED.name(),
         timelineEntity.getEvents().get(0).getEventType());
-    Assert.assertEquals(launchTime,
+    assertEquals(launchTime,
         timelineEntity.getEvents().get(0).getTimestamp());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertContainerStoppedEvent() {
     long stopTime = random.nextLong();
     int exitStatus = random.nextInt();
     ContainerStoppedEvent event = new ContainerStoppedEvent(containerId, stopTime, exitStatus,
         applicationAttemptId);
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals("tez_" + containerId.toString(), timelineEntity.getEntityId());
-    Assert.assertEquals(EntityTypes.TEZ_CONTAINER_ID.name(), timelineEntity.getEntityType());
+    assertEquals("tez_" + containerId.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_CONTAINER_ID.name(), timelineEntity.getEntityType());
 
     final Map<String, Set<String>> relatedEntities = timelineEntity.getRelatedEntities();
-    Assert.assertEquals(1, relatedEntities.size());
-    Assert.assertTrue(relatedEntities.get(EntityTypes.TEZ_APPLICATION_ATTEMPT.name())
+    assertEquals(1, relatedEntities.size());
+    assertTrue(relatedEntities.get(EntityTypes.TEZ_APPLICATION_ATTEMPT.name())
         .contains("tez_" + applicationAttemptId.toString()));
 
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
-    Assert.assertEquals(2, primaryFilters.size());
-    Assert.assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
+    assertEquals(2, primaryFilters.size());
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
         .contains(applicationId.toString()));
-    Assert.assertTrue(primaryFilters.get(ATSConstants.EXIT_STATUS).contains(exitStatus));
+    assertTrue(primaryFilters.get(ATSConstants.EXIT_STATUS).contains(exitStatus));
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     final TimelineEvent evt = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.CONTAINER_STOPPED.name(), evt.getEventType());
-    Assert.assertEquals(stopTime, evt.getTimestamp());
+    assertEquals(HistoryEventType.CONTAINER_STOPPED.name(), evt.getEventType());
+    assertEquals(stopTime, evt.getTimestamp());
 
     final Map<String, Object> otherInfo = timelineEntity.getOtherInfo();
-    Assert.assertEquals(2, otherInfo.size());
-    Assert.assertEquals(exitStatus, otherInfo.get(ATSConstants.EXIT_STATUS));
-    Assert.assertEquals(stopTime, otherInfo.get(ATSConstants.FINISH_TIME));
+    assertEquals(2, otherInfo.size());
+    assertEquals(exitStatus, otherInfo.get(ATSConstants.EXIT_STATUS));
+    assertEquals(stopTime, otherInfo.get(ATSConstants.FINISH_TIME));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertDAGStartedEvent() {
     long startTime = random.nextLong();
     String dagName = "testDagName";
     DAGStartedEvent event = new DAGStartedEvent(tezDAGID, startTime, user, dagName);
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
 
-    Assert.assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
-    Assert.assertEquals(EntityTypes.TEZ_DAG_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_DAG_ID.name(), timelineEntity.getEntityType());
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent evt = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.DAG_STARTED.name(), evt.getEventType());
-    Assert.assertEquals(startTime, evt.getTimestamp());
+    assertEquals(HistoryEventType.DAG_STARTED.name(), evt.getEventType());
+    assertEquals(startTime, evt.getTimestamp());
 
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
-    Assert.assertEquals(3, primaryFilters.size());
-    Assert.assertTrue(primaryFilters.get(ATSConstants.USER).contains(user));
-    Assert.assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
+    assertEquals(3, primaryFilters.size());
+    assertTrue(primaryFilters.get(ATSConstants.USER).contains(user));
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
         .contains(applicationId.toString()));
-    Assert.assertTrue(primaryFilters.get(ATSConstants.DAG_NAME).contains(dagName));
+    assertTrue(primaryFilters.get(ATSConstants.DAG_NAME).contains(dagName));
 
     final Map<String, Object> otherInfo = timelineEntity.getOtherInfo();
-    Assert.assertEquals(2, otherInfo.size());
-    Assert.assertEquals(startTime, otherInfo.get(ATSConstants.START_TIME));
-    Assert.assertEquals(DAGState.RUNNING.name(), otherInfo.get(ATSConstants.STATUS));
+    assertEquals(2, otherInfo.size());
+    assertEquals(startTime, otherInfo.get(ATSConstants.START_TIME));
+    assertEquals(DAGState.RUNNING.name(), otherInfo.get(ATSConstants.STATUS));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertDAGSubmittedEvent() {
     long submitTime = random.nextLong();
 
@@ -492,7 +508,7 @@ public class TestHistoryEventTimelineConversion {
         applicationAttemptId, null, user, null, containerLogs, queueName);
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(2, entities.size());
+    assertEquals(2, entities.size());
 
 
     if (entities.get(0).getEntityType().equals(EntityTypes.TEZ_DAG_ID.name())) {
@@ -506,90 +522,91 @@ public class TestHistoryEventTimelineConversion {
 
   private void assertDagSubmittedEntity(long submitTime, DAGSubmittedEvent event,
       TimelineEntity timelineEntity) {
-    Assert.assertEquals(EntityTypes.TEZ_DAG_ID.name(), timelineEntity.getEntityType());
-    Assert.assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_DAG_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(2, timelineEntity.getRelatedEntities().size());
-    Assert.assertTrue(
+    assertEquals(2, timelineEntity.getRelatedEntities().size());
+    assertTrue(
         timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_APPLICATION.name()).contains(
             "tez_" + applicationId.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_APPLICATION_ATTEMPT.name()).contains(
             "tez_" + applicationAttemptId.toString()));
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.DAG_SUBMITTED.name(), timelineEvent.getEventType());
-    Assert.assertEquals(submitTime, timelineEvent.getTimestamp());
+    assertEquals(HistoryEventType.DAG_SUBMITTED.name(), timelineEvent.getEventType());
+    assertEquals(submitTime, timelineEvent.getTimestamp());
 
-    Assert.assertEquals(submitTime, timelineEntity.getStartTime().longValue());
+    assertEquals(submitTime, timelineEntity.getStartTime().longValue());
 
-    Assert.assertEquals(5, timelineEntity.getPrimaryFilters().size());
+    assertEquals(5, timelineEntity.getPrimaryFilters().size());
 
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains(
             dagPlan.getName()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.CALLER_CONTEXT_ID).contains(
             dagPlan.getCallerContext().getCallerId()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
             applicationAttemptId.getApplicationId().toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_QUEUE_NAME)
             .contains(event.getQueueName()));
 
-    Assert.assertEquals(9, timelineEntity.getOtherInfo().size());
-    Assert.assertEquals(applicationId.toString(),
+    assertEquals(9, timelineEntity.getOtherInfo().size());
+    assertEquals(applicationId.toString(),
         timelineEntity.getOtherInfo().get(ATSConstants.APPLICATION_ID));
-    Assert.assertEquals(applicationAttemptId.toString(),
+    assertEquals(applicationAttemptId.toString(),
         timelineEntity.getOtherInfo().get(ATSConstants.APPLICATION_ATTEMPT_ID));
-    Assert.assertEquals(applicationAttemptId.getApplicationId().toString(),
+    assertEquals(applicationAttemptId.getApplicationId().toString(),
         timelineEntity.getOtherInfo().get(ATSConstants.APPLICATION_ID));
-    Assert.assertEquals(AMWebController.VERSION,
+    assertEquals(AMWebController.VERSION,
         timelineEntity.getOtherInfo().get(ATSConstants.DAG_AM_WEB_SERVICE_VERSION));
-    Assert.assertEquals(user,
+    assertEquals(user,
         timelineEntity.getOtherInfo().get(ATSConstants.USER));
-    Assert.assertEquals(containerLogs,
+    assertEquals(containerLogs,
         timelineEntity.getOtherInfo().get(ATSConstants.IN_PROGRESS_LOGS_URL + "_"
             + applicationAttemptId.getAttemptId()));
-    Assert.assertEquals(
+    assertEquals(
         timelineEntity.getOtherInfo().get(ATSConstants.CALLER_CONTEXT_ID),
             dagPlan.getCallerContext().getCallerId());
-    Assert.assertEquals(
+    assertEquals(
         timelineEntity.getOtherInfo().get(ATSConstants.CALLER_CONTEXT_TYPE),
             dagPlan.getCallerContext().getCallerType());
-    Assert.assertEquals(dagPlan.getCallerContext().getContext(),
+    assertEquals(dagPlan.getCallerContext().getContext(),
         timelineEntity.getOtherInfo().get(ATSConstants.CALLER_CONTEXT));
-    Assert.assertEquals(
+    assertEquals(
         event.getQueueName(), timelineEntity.getOtherInfo().get(ATSConstants.DAG_QUEUE_NAME));
 
   }
 
   private void assertDagSubmittedExtraInfoEntity(long submitTime, DAGSubmittedEvent event,
       TimelineEntity timelineEntity) {
-    Assert.assertEquals(EntityTypes.TEZ_DAG_EXTRA_INFO.name(), timelineEntity.getEntityType());
-    Assert.assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_DAG_EXTRA_INFO.name(), timelineEntity.getEntityType());
+    assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(1, timelineEntity.getRelatedEntities().size());
-    Assert.assertTrue(timelineEntity.getRelatedEntities()
+    assertEquals(1, timelineEntity.getRelatedEntities().size());
+    assertTrue(timelineEntity.getRelatedEntities()
         .get(EntityTypes.TEZ_DAG_ID.name()).contains(tezDAGID.toString()));
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.DAG_SUBMITTED.name(), timelineEvent.getEventType());
-    Assert.assertEquals(submitTime, timelineEvent.getTimestamp());
+    assertEquals(HistoryEventType.DAG_SUBMITTED.name(), timelineEvent.getEventType());
+    assertEquals(submitTime, timelineEvent.getTimestamp());
 
-    Assert.assertEquals(submitTime, timelineEntity.getStartTime().longValue());
-    Assert.assertEquals(0, timelineEntity.getPrimaryFilters().size());
-    Assert.assertEquals(1, timelineEntity.getOtherInfo().size());
-    Assert.assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.DAG_PLAN));
+    assertEquals(submitTime, timelineEntity.getStartTime().longValue());
+    assertEquals(0, timelineEntity.getPrimaryFilters().size());
+    assertEquals(1, timelineEntity.getOtherInfo().size());
+    assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.DAG_PLAN));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertTaskAttemptFinishedEvent() {
     String vertexName = "testVertex";
     long creationTime = random.nextLong();
@@ -611,53 +628,53 @@ public class TestHistoryEventTimelineConversion {
         startTime, finishTime, state, TaskFailureType.FATAL, error, diagnostics, counters, events, null, creationTime,
         tezTaskAttemptID, allocationTime, containerId, nodeId, "inProgressURL", "logsURL", "nodeHttpAddress");
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(tezTaskAttemptID.toString(), timelineEntity.getEntityId());
-    Assert.assertEquals(EntityTypes.TEZ_TASK_ATTEMPT_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezTaskAttemptID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_TASK_ATTEMPT_ID.name(), timelineEntity.getEntityType());
 
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
-    Assert.assertEquals(5, primaryFilters.size());
-    Assert.assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
+    assertEquals(5, primaryFilters.size());
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
         .contains(applicationId.toString()));
-    Assert.assertTrue(primaryFilters.get(EntityTypes.TEZ_DAG_ID.name())
+    assertTrue(primaryFilters.get(EntityTypes.TEZ_DAG_ID.name())
         .contains(tezDAGID.toString()));
-    Assert.assertTrue(primaryFilters.get(EntityTypes.TEZ_VERTEX_ID.name())
+    assertTrue(primaryFilters.get(EntityTypes.TEZ_VERTEX_ID.name())
         .contains(tezVertexID.toString()));
-    Assert.assertTrue(primaryFilters.get(EntityTypes.TEZ_TASK_ID.name())
+    assertTrue(primaryFilters.get(EntityTypes.TEZ_TASK_ID.name())
         .contains(tezTaskID.toString()));
-    Assert.assertTrue(primaryFilters.get(ATSConstants.STATUS).contains(state.toString()));
+    assertTrue(primaryFilters.get(ATSConstants.STATUS).contains(state.toString()));
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent evt = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.TASK_ATTEMPT_FINISHED.name(), evt.getEventType());
-    Assert.assertEquals(finishTime, evt.getTimestamp());
+    assertEquals(HistoryEventType.TASK_ATTEMPT_FINISHED.name(), evt.getEventType());
+    assertEquals(finishTime, evt.getTimestamp());
 
     final Map<String, Object> otherInfo = timelineEntity.getOtherInfo();
-    Assert.assertEquals(17, otherInfo.size());
-    Assert.assertEquals(tezTaskAttemptID.toString(),
+    assertEquals(17, otherInfo.size());
+    assertEquals(tezTaskAttemptID.toString(),
         timelineEntity.getOtherInfo().get(ATSConstants.CREATION_CAUSAL_ATTEMPT));
-    Assert.assertEquals(creationTime, timelineEntity.getOtherInfo().get(ATSConstants.CREATION_TIME));
-    Assert.assertEquals(allocationTime, timelineEntity.getOtherInfo().get(ATSConstants.ALLOCATION_TIME));
-    Assert.assertEquals(startTime, timelineEntity.getOtherInfo().get(ATSConstants.START_TIME));
-    Assert.assertEquals(finishTime, otherInfo.get(ATSConstants.FINISH_TIME));
-    Assert.assertEquals(finishTime - startTime, otherInfo.get(ATSConstants.TIME_TAKEN));
-    Assert.assertEquals(state.name(), otherInfo.get(ATSConstants.STATUS));
-    Assert.assertEquals(TaskFailureType.FATAL.name(), otherInfo.get(ATSConstants.TASK_FAILURE_TYPE));
-    Assert.assertEquals(error.name(), otherInfo.get(ATSConstants.TASK_ATTEMPT_ERROR_ENUM));
-    Assert.assertEquals(diagnostics, otherInfo.get(ATSConstants.DIAGNOSTICS));
+    assertEquals(creationTime, timelineEntity.getOtherInfo().get(ATSConstants.CREATION_TIME));
+    assertEquals(allocationTime, timelineEntity.getOtherInfo().get(ATSConstants.ALLOCATION_TIME));
+    assertEquals(startTime, timelineEntity.getOtherInfo().get(ATSConstants.START_TIME));
+    assertEquals(finishTime, otherInfo.get(ATSConstants.FINISH_TIME));
+    assertEquals(finishTime - startTime, otherInfo.get(ATSConstants.TIME_TAKEN));
+    assertEquals(state.name(), otherInfo.get(ATSConstants.STATUS));
+    assertEquals(TaskFailureType.FATAL.name(), otherInfo.get(ATSConstants.TASK_FAILURE_TYPE));
+    assertEquals(error.name(), otherInfo.get(ATSConstants.TASK_ATTEMPT_ERROR_ENUM));
+    assertEquals(diagnostics, otherInfo.get(ATSConstants.DIAGNOSTICS));
     Map<String, Object> obj1 = (Map<String, Object>)otherInfo.get(ATSConstants.LAST_DATA_EVENTS);
     List<Object> obj2 = (List<Object>) obj1.get(ATSConstants.LAST_DATA_EVENTS);
-    Assert.assertEquals(2, obj2.size());
+    assertEquals(2, obj2.size());
     Map<String, Object> obj3 = (Map<String, Object>) obj2.get(0);
-    Assert.assertEquals(events.get(0).getTimestamp(), obj3.get(ATSConstants.TIMESTAMP));
-    Assert.assertTrue(otherInfo.containsKey(ATSConstants.COUNTERS));
-    Assert.assertEquals("inProgressURL", otherInfo.get(ATSConstants.IN_PROGRESS_LOGS_URL));
-    Assert.assertEquals("logsURL", otherInfo.get(ATSConstants.COMPLETED_LOGS_URL));
-    Assert.assertEquals(nodeId.toString(), otherInfo.get(ATSConstants.NODE_ID));
-    Assert.assertEquals(containerId.toString(), otherInfo.get(ATSConstants.CONTAINER_ID));
-    Assert.assertEquals("nodeHttpAddress", otherInfo.get(ATSConstants.NODE_HTTP_ADDRESS));
+    assertEquals(events.get(0).getTimestamp(), obj3.get(ATSConstants.TIMESTAMP));
+    assertTrue(otherInfo.containsKey(ATSConstants.COUNTERS));
+    assertEquals("inProgressURL", otherInfo.get(ATSConstants.IN_PROGRESS_LOGS_URL));
+    assertEquals("logsURL", otherInfo.get(ATSConstants.COMPLETED_LOGS_URL));
+    assertEquals(nodeId.toString(), otherInfo.get(ATSConstants.NODE_ID));
+    assertEquals(containerId.toString(), otherInfo.get(ATSConstants.CONTAINER_ID));
+    assertEquals("nodeHttpAddress", otherInfo.get(ATSConstants.NODE_HTTP_ADDRESS));
 
     TaskAttemptFinishedEvent eventWithNullFailureType =
         new TaskAttemptFinishedEvent(tezTaskAttemptID, vertexName,
@@ -667,15 +684,16 @@ public class TestHistoryEventTimelineConversion {
             "nodeHttpAddress");
     List<TimelineEntity> evtEntities = HistoryEventTimelineConversion.convertToTimelineEntities(
         eventWithNullFailureType);
-    Assert.assertEquals(1, evtEntities.size());
+    assertEquals(1, evtEntities.size());
     TimelineEntity timelineEntityWithNullFailureType = evtEntities.get(0);
 
-    Assert.assertNull(
+    assertNull(
         timelineEntityWithNullFailureType.getOtherInfo().get(ATSConstants.TASK_FAILURE_TYPE));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertDAGInitializedEvent() {
     long initTime = random.nextLong();
 
@@ -687,39 +705,40 @@ public class TestHistoryEventTimelineConversion {
 
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(EntityTypes.TEZ_DAG_ID.name(), timelineEntity.getEntityType());
-    Assert.assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_DAG_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(0, timelineEntity.getRelatedEntities().size());
+    assertEquals(0, timelineEntity.getRelatedEntities().size());
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.DAG_INITIALIZED.name(), timelineEvent.getEventType());
-    Assert.assertEquals(initTime, timelineEvent.getTimestamp());
+    assertEquals(HistoryEventType.DAG_INITIALIZED.name(), timelineEvent.getEventType());
+    assertEquals(initTime, timelineEvent.getTimestamp());
 
-    Assert.assertEquals(3, timelineEntity.getPrimaryFilters().size());
-    Assert.assertTrue(
+    assertEquals(3, timelineEntity.getPrimaryFilters().size());
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
             applicationId.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains("dagName"));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
 
-    Assert.assertTrue(timelineEntity.getOtherInfo().containsKey(
+    assertTrue(timelineEntity.getOtherInfo().containsKey(
         ATSConstants.VERTEX_NAME_ID_MAPPING));
     Map<String, String> vIdMap = (Map<String, String>) timelineEntity.getOtherInfo().get(
         ATSConstants.VERTEX_NAME_ID_MAPPING);
-    Assert.assertEquals(1, vIdMap.size());
-    Assert.assertNotNull(vIdMap.containsKey("foo"));
-    Assert.assertEquals(tezVertexID.toString(), vIdMap.get("foo"));
+    assertEquals(1, vIdMap.size());
+    assertNotNull(vIdMap.containsKey("foo"));
+    assertEquals(tezVertexID.toString(), vIdMap.get("foo"));
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertDAGFinishedEvent() {
     long finishTime = random.nextLong();
     long startTime = random.nextLong();
@@ -731,7 +750,7 @@ public class TestHistoryEventTimelineConversion {
         "diagnostics", null, user, dagPlan.getName(), taskStats, applicationAttemptId, dagPlan);
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(2, entities.size());
+    assertEquals(2, entities.size());
 
     if (entities.get(0).getEntityType().equals(EntityTypes.TEZ_DAG_ID.name())) {
       assertDagFinishedEntity(finishTime, startTime, event, entities.get(0));
@@ -744,69 +763,70 @@ public class TestHistoryEventTimelineConversion {
 
   private void assertDagFinishedEntity(long finishTime, long startTime, DAGFinishedEvent event,
       TimelineEntity timelineEntity) {
-    Assert.assertEquals(EntityTypes.TEZ_DAG_ID.name(), timelineEntity.getEntityType());
-    Assert.assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_DAG_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(0, timelineEntity.getRelatedEntities().size());
+    assertEquals(0, timelineEntity.getRelatedEntities().size());
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.DAG_FINISHED.name(), timelineEvent.getEventType());
-    Assert.assertEquals(finishTime, timelineEvent.getTimestamp());
+    assertEquals(HistoryEventType.DAG_FINISHED.name(), timelineEvent.getEventType());
+    assertEquals(finishTime, timelineEvent.getTimestamp());
 
-    Assert.assertEquals(5, timelineEntity.getPrimaryFilters().size());
-    Assert.assertTrue(
+    assertEquals(5, timelineEntity.getPrimaryFilters().size());
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
             applicationId.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains(dagPlan.getName()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.STATUS).contains(
             DAGState.ERROR.name()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.CALLER_CONTEXT_ID).contains(
             dagPlan.getCallerContext().getCallerId()));
 
-    Assert.assertEquals(startTime,
+    assertEquals(startTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.START_TIME)).longValue());
-    Assert.assertEquals(finishTime,
+    assertEquals(finishTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.FINISH_TIME)).longValue());
-    Assert.assertEquals(finishTime - startTime,
+    assertEquals(finishTime - startTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.TIME_TAKEN)).longValue());
-    Assert.assertEquals(DAGState.ERROR.name(),
+    assertEquals(DAGState.ERROR.name(),
         timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
-    Assert.assertEquals("diagnostics",
+    assertEquals("diagnostics",
         timelineEntity.getOtherInfo().get(ATSConstants.DIAGNOSTICS));
-    Assert.assertEquals(applicationAttemptId.toString(),
+    assertEquals(applicationAttemptId.toString(),
         timelineEntity.getOtherInfo().get(ATSConstants.COMPLETION_APPLICATION_ATTEMPT_ID));
 
-    Assert.assertEquals(100,
+    assertEquals(100,
         ((Integer) timelineEntity.getOtherInfo().get("FOO")).intValue());
-    Assert.assertEquals(200,
+    assertEquals(200,
         ((Integer) timelineEntity.getOtherInfo().get("BAR")).intValue());
   }
 
   private void assertDagFinishedExtraInfoEntity(long finishTime, TimelineEntity timelineEntity) {
-    Assert.assertEquals(EntityTypes.TEZ_DAG_EXTRA_INFO.name(), timelineEntity.getEntityType());
-    Assert.assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_DAG_EXTRA_INFO.name(), timelineEntity.getEntityType());
+    assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(1, timelineEntity.getRelatedEntities().size());
-    Assert.assertTrue(
+    assertEquals(1, timelineEntity.getRelatedEntities().size());
+    assertTrue(
         timelineEntity.getRelatedEntities().get(ATSConstants.TEZ_DAG_ID).contains(
             tezDAGID.toString()));
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.DAG_FINISHED.name(), timelineEvent.getEventType());
-    Assert.assertEquals(finishTime, timelineEvent.getTimestamp());
+    assertEquals(HistoryEventType.DAG_FINISHED.name(), timelineEvent.getEventType());
+    assertEquals(finishTime, timelineEvent.getTimestamp());
 
-    Assert.assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.COUNTERS));
+    assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.COUNTERS));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertVertexInitializedEvent() {
     long initRequestedTime = random.nextLong();
     long initedTime = random.nextLong();
@@ -821,65 +841,66 @@ public class TestHistoryEventTimelineConversion {
 
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(EntityTypes.TEZ_VERTEX_ID.name(), timelineEntity.getEntityType());
-    Assert.assertEquals(tezVertexID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_VERTEX_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezVertexID.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(initedTime, timelineEntity.getStartTime().longValue());
+    assertEquals(initedTime, timelineEntity.getStartTime().longValue());
 
-    Assert.assertEquals(1, timelineEntity.getRelatedEntities().size());
-    Assert.assertTrue(
+    assertEquals(1, timelineEntity.getRelatedEntities().size());
+    assertTrue(
         timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_DAG_ID.name()).contains(
             tezDAGID.toString()));
 
-    Assert.assertEquals(2, timelineEntity.getPrimaryFilters().size());
-    Assert.assertTrue(
+    assertEquals(2, timelineEntity.getPrimaryFilters().size());
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
             applicationId.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(
             tezDAGID.toString()));
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.VERTEX_INITIALIZED.name(), timelineEvent.getEventType());
-    Assert.assertEquals(initedTime, timelineEvent.getTimestamp());
+    assertEquals(HistoryEventType.VERTEX_INITIALIZED.name(), timelineEvent.getEventType());
+    assertEquals(initedTime, timelineEvent.getTimestamp());
 
-    Assert.assertEquals("v1", timelineEntity.getOtherInfo().get(ATSConstants.VERTEX_NAME));
-    Assert.assertEquals("proc", timelineEntity.getOtherInfo().get(ATSConstants.PROCESSOR_CLASS_NAME));
+    assertEquals("v1", timelineEntity.getOtherInfo().get(ATSConstants.VERTEX_NAME));
+    assertEquals("proc", timelineEntity.getOtherInfo().get(ATSConstants.PROCESSOR_CLASS_NAME));
 
-    Assert.assertEquals(initedTime,
+    assertEquals(initedTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.INIT_TIME)).longValue());
-    Assert.assertEquals(initRequestedTime,
+    assertEquals(initRequestedTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.INIT_REQUESTED_TIME)).longValue());
-    Assert.assertEquals(initedTime,
+    assertEquals(initedTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.INIT_TIME)).longValue());
-    Assert.assertEquals(numTasks,
+    assertEquals(numTasks,
         ((Integer) timelineEntity.getOtherInfo().get(ATSConstants.NUM_TASKS)).intValue());
-    Assert.assertNotNull(timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN));
-    Assert.assertEquals("abc",
+    assertNotNull(timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN));
+    assertEquals("abc",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.CONTAINER_LAUNCHER_NAME));
-    Assert.assertEquals("def",
+    assertEquals("def",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_SCHEDULER_NAME));
-    Assert.assertEquals("ghi",
+    assertEquals("ghi",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_COMMUNICATOR_NAME));
-    Assert.assertEquals("abc1",
+    assertEquals("abc1",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.CONTAINER_LAUNCHER_CLASS_NAME));
-    Assert.assertEquals("def1",
+    assertEquals("def1",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_SCHEDULER_CLASS_NAME));
-    Assert.assertEquals("ghi1",
+    assertEquals("ghi1",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_COMMUNICATOR_CLASS_NAME));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertVertexStartedEvent() {
     long startRequestedTime = random.nextLong();
     long startTime = random.nextLong();
@@ -887,37 +908,38 @@ public class TestHistoryEventTimelineConversion {
     VertexStartedEvent event = new VertexStartedEvent(tezVertexID, startRequestedTime, startTime);
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(EntityTypes.TEZ_VERTEX_ID.name(), timelineEntity.getEntityType());
-    Assert.assertEquals(tezVertexID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_VERTEX_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezVertexID.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(0, timelineEntity.getRelatedEntities().size());
+    assertEquals(0, timelineEntity.getRelatedEntities().size());
 
-    Assert.assertEquals(2, timelineEntity.getPrimaryFilters().size());
-    Assert.assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID)
+    assertEquals(2, timelineEntity.getPrimaryFilters().size());
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID)
             .contains(applicationId.toString()));
-    Assert.assertTrue(
+    assertTrue(
             timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(
                     tezDAGID.toString()));
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.VERTEX_STARTED.name(), timelineEvent.getEventType());
-    Assert.assertEquals(startTime, timelineEvent.getTimestamp());
+    assertEquals(HistoryEventType.VERTEX_STARTED.name(), timelineEvent.getEventType());
+    assertEquals(startTime, timelineEvent.getTimestamp());
 
-    Assert.assertEquals(3, timelineEntity.getOtherInfo().size());
-    Assert.assertEquals(startRequestedTime,
+    assertEquals(3, timelineEntity.getOtherInfo().size());
+    assertEquals(startRequestedTime,
             ((Long) timelineEntity.getOtherInfo().get(ATSConstants.START_REQUESTED_TIME)).longValue());
-    Assert.assertEquals(startTime,
+    assertEquals(startTime,
             ((Long) timelineEntity.getOtherInfo().get(ATSConstants.START_TIME)).longValue());
-    Assert.assertEquals(VertexState.RUNNING.name(),
+    assertEquals(VertexState.RUNNING.name(),
             timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertVertexFinishedEvent() {
     String vertexName = "v1";
     long initRequestedTime = random.nextLong();
@@ -940,169 +962,172 @@ public class TestHistoryEventTimelineConversion {
             .setTaskCommunicatorClassName("ghi1"));
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(EntityTypes.TEZ_VERTEX_ID.name(), timelineEntity.getEntityType());
-    Assert.assertEquals(tezVertexID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_VERTEX_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezVertexID.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(0, timelineEntity.getRelatedEntities().size());
+    assertEquals(0, timelineEntity.getRelatedEntities().size());
 
-    Assert.assertEquals(3, timelineEntity.getPrimaryFilters().size());
-    Assert.assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID)
+    assertEquals(3, timelineEntity.getPrimaryFilters().size());
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID)
         .contains(applicationId.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(
             tezDAGID.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.STATUS).contains(
             VertexState.ERROR.name()));
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.VERTEX_FINISHED.name(), timelineEvent.getEventType());
-    Assert.assertEquals(finishTime, timelineEvent.getTimestamp());
+    assertEquals(HistoryEventType.VERTEX_FINISHED.name(), timelineEvent.getEventType());
+    assertEquals(finishTime, timelineEvent.getTimestamp());
 
-    Assert.assertEquals(vertexName,
+    assertEquals(vertexName,
         timelineEntity.getOtherInfo().get(ATSConstants.VERTEX_NAME));
-    Assert.assertEquals(finishTime,
+    assertEquals(finishTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.FINISH_TIME)).longValue());
-    Assert.assertEquals(finishTime - startTime,
+    assertEquals(finishTime - startTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.TIME_TAKEN)).longValue());
-    Assert.assertEquals(VertexState.ERROR.name(),
+    assertEquals(VertexState.ERROR.name(),
         timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
-    Assert.assertEquals("diagnostics",
+    assertEquals("diagnostics",
         timelineEntity.getOtherInfo().get(ATSConstants.DIAGNOSTICS));
-    Assert.assertNotNull(timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN));
-    Assert.assertEquals("abc",
+    assertNotNull(timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN));
+    assertEquals("abc",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.CONTAINER_LAUNCHER_NAME));
-    Assert.assertEquals("def",
+    assertEquals("def",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_SCHEDULER_NAME));
-    Assert.assertEquals("ghi",
+    assertEquals("ghi",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_COMMUNICATOR_NAME));
-    Assert.assertEquals("abc1",
+    assertEquals("abc1",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.CONTAINER_LAUNCHER_CLASS_NAME));
-    Assert.assertEquals("def1",
+    assertEquals("def1",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_SCHEDULER_CLASS_NAME));
-    Assert.assertEquals("ghi1",
+    assertEquals("ghi1",
         ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
             ATSConstants.TASK_COMMUNICATOR_CLASS_NAME));
 
-    Assert.assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.STATS));
+    assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.STATS));
 
-    Assert.assertEquals(100,
+    assertEquals(100,
         ((Integer) timelineEntity.getOtherInfo().get("FOO")).intValue());
-    Assert.assertEquals(200,
+    assertEquals(200,
         ((Integer) timelineEntity.getOtherInfo().get("BAR")).intValue());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertTaskStartedEvent() {
     long scheduleTime = random.nextLong();
     long startTime = random.nextLong();
     TaskStartedEvent event = new TaskStartedEvent(tezTaskID, "v1", scheduleTime, startTime);
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(EntityTypes.TEZ_TASK_ID.name(), timelineEntity.getEntityType());
-    Assert.assertEquals(tezTaskID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_TASK_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezTaskID.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(startTime, timelineEntity.getStartTime().longValue());
+    assertEquals(startTime, timelineEntity.getStartTime().longValue());
 
-    Assert.assertEquals(1, timelineEntity.getRelatedEntities().size());
-    Assert.assertTrue(
+    assertEquals(1, timelineEntity.getRelatedEntities().size());
+    assertTrue(
         timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_VERTEX_ID.name()).contains(
             tezVertexID.toString()));
 
-    Assert.assertEquals(3, timelineEntity.getPrimaryFilters().size());
-    Assert.assertTrue(
+    assertEquals(3, timelineEntity.getPrimaryFilters().size());
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
             applicationId.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(
             tezDAGID.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_VERTEX_ID.name()).contains(
             tezVertexID.toString()));
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.TASK_STARTED.name(), timelineEvent.getEventType());
-    Assert.assertEquals(startTime, timelineEvent.getTimestamp());
+    assertEquals(HistoryEventType.TASK_STARTED.name(), timelineEvent.getEventType());
+    assertEquals(startTime, timelineEvent.getTimestamp());
 
-    Assert.assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.SCHEDULED_TIME));
-    Assert.assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.START_TIME));
+    assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.SCHEDULED_TIME));
+    assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.START_TIME));
 
-    Assert.assertEquals(scheduleTime,
+    assertEquals(scheduleTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.SCHEDULED_TIME)).longValue());
-    Assert.assertEquals(startTime,
+    assertEquals(startTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.START_TIME)).longValue());
-    Assert.assertTrue(TaskState.SCHEDULED.name()
-        .equals(timelineEntity.getOtherInfo().get(ATSConstants.STATUS)));
+    assertEquals(TaskState.SCHEDULED.name(),
+        timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertTaskAttemptStartedEvent() {
     long startTime = random.nextLong();
     TaskAttemptStartedEvent event = new TaskAttemptStartedEvent(tezTaskAttemptID, "v1",
         startTime, containerId, nodeId, "inProgressURL", "logsURL", "nodeHttpAddress");
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(EntityTypes.TEZ_TASK_ATTEMPT_ID.name(), timelineEntity.getEntityType());
-    Assert.assertEquals(tezTaskAttemptID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_TASK_ATTEMPT_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezTaskAttemptID.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(startTime, timelineEntity.getStartTime().longValue());
+    assertEquals(startTime, timelineEntity.getStartTime().longValue());
 
-    Assert.assertEquals(1, timelineEntity.getRelatedEntities().size());
-    Assert.assertTrue(
+    assertEquals(1, timelineEntity.getRelatedEntities().size());
+    assertTrue(
         timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_TASK_ID.name()).contains(
             tezTaskID.toString()));
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.TASK_ATTEMPT_STARTED.name(), timelineEvent.getEventType());
-    Assert.assertEquals(startTime, timelineEvent.getTimestamp());
+    assertEquals(HistoryEventType.TASK_ATTEMPT_STARTED.name(), timelineEvent.getEventType());
+    assertEquals(startTime, timelineEvent.getTimestamp());
 
-    Assert.assertEquals(4, timelineEntity.getPrimaryFilters().size());
-    Assert.assertTrue(
+    assertEquals(4, timelineEntity.getPrimaryFilters().size());
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
             applicationId.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(
             tezDAGID.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_VERTEX_ID.name()).contains(
             tezVertexID.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_TASK_ID.name()).contains(
             tezTaskID.toString()));
 
-    Assert.assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.START_TIME));
-    Assert.assertEquals("inProgressURL",
+    assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.START_TIME));
+    assertEquals("inProgressURL",
         timelineEntity.getOtherInfo().get(ATSConstants.IN_PROGRESS_LOGS_URL));
-    Assert.assertEquals("logsURL",
+    assertEquals("logsURL",
         timelineEntity.getOtherInfo().get(ATSConstants.COMPLETED_LOGS_URL));
-    Assert.assertEquals(nodeId.toString(),
+    assertEquals(nodeId.toString(),
         timelineEntity.getOtherInfo().get(ATSConstants.NODE_ID));
-    Assert.assertEquals(containerId.toString(),
+    assertEquals(containerId.toString(),
         timelineEntity.getOtherInfo().get(ATSConstants.CONTAINER_ID));
-    Assert.assertEquals("nodeHttpAddress",
+    assertEquals("nodeHttpAddress",
         timelineEntity.getOtherInfo().get(ATSConstants.NODE_HTTP_ADDRESS));
-    Assert.assertTrue(TaskAttemptState.RUNNING.name()
-        .equals(timelineEntity.getOtherInfo().get(ATSConstants.STATUS)));
+    assertEquals(TaskAttemptState.RUNNING.name(),
+        timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertTaskFinishedEvent() {
     String vertexName = "testVertexName";
     long startTime = random.nextLong();
@@ -1114,41 +1139,42 @@ public class TestHistoryEventTimelineConversion {
     TaskFinishedEvent event = new TaskFinishedEvent(tezTaskID, vertexName, startTime, finishTime,
         tezTaskAttemptID, state, diagnostics, counters, 3);
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(tezTaskID.toString(), timelineEntity.getEntityId());
-    Assert.assertEquals(EntityTypes.TEZ_TASK_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezTaskID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_TASK_ID.name(), timelineEntity.getEntityType());
 
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
-    Assert.assertEquals(4, primaryFilters.size());
-    Assert.assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
+    assertEquals(4, primaryFilters.size());
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
         .contains(applicationId.toString()));
-    Assert.assertTrue(primaryFilters.get(EntityTypes.TEZ_DAG_ID.name())
+    assertTrue(primaryFilters.get(EntityTypes.TEZ_DAG_ID.name())
         .contains(tezDAGID.toString()));
-    Assert.assertTrue(primaryFilters.get(EntityTypes.TEZ_VERTEX_ID.name())
+    assertTrue(primaryFilters.get(EntityTypes.TEZ_VERTEX_ID.name())
         .contains(tezVertexID.toString()));
-    Assert.assertTrue(primaryFilters.get(ATSConstants.STATUS).contains(state.name()));
+    assertTrue(primaryFilters.get(ATSConstants.STATUS).contains(state.name()));
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent evt = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.TASK_FINISHED.name(), evt.getEventType());
-    Assert.assertEquals(finishTime, evt.getTimestamp());
+    assertEquals(HistoryEventType.TASK_FINISHED.name(), evt.getEventType());
+    assertEquals(finishTime, evt.getTimestamp());
 
     final Map<String, Object> otherInfo = timelineEntity.getOtherInfo();
-    Assert.assertEquals(7, otherInfo.size());
-    Assert.assertEquals(finishTime, otherInfo.get(ATSConstants.FINISH_TIME));
-    Assert.assertEquals(finishTime - startTime, otherInfo.get(ATSConstants.TIME_TAKEN));
-    Assert.assertEquals(state.name(), otherInfo.get(ATSConstants.STATUS));
-    Assert.assertEquals(tezTaskAttemptID.toString(),
+    assertEquals(7, otherInfo.size());
+    assertEquals(finishTime, otherInfo.get(ATSConstants.FINISH_TIME));
+    assertEquals(finishTime - startTime, otherInfo.get(ATSConstants.TIME_TAKEN));
+    assertEquals(state.name(), otherInfo.get(ATSConstants.STATUS));
+    assertEquals(tezTaskAttemptID.toString(),
         otherInfo.get(ATSConstants.SUCCESSFUL_ATTEMPT_ID));
-    Assert.assertEquals(3, otherInfo.get(ATSConstants.NUM_FAILED_TASKS_ATTEMPTS));
-    Assert.assertEquals(diagnostics, otherInfo.get(ATSConstants.DIAGNOSTICS));
-    Assert.assertTrue(otherInfo.containsKey(ATSConstants.COUNTERS));
+    assertEquals(3, otherInfo.get(ATSConstants.NUM_FAILED_TASKS_ATTEMPTS));
+    assertEquals(diagnostics, otherInfo.get(ATSConstants.DIAGNOSTICS));
+    assertTrue(otherInfo.containsKey(ATSConstants.COUNTERS));
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertVertexReconfigreDoneEvent() {
     TezVertexID vId = tezVertexID;
     Map<String, EdgeProperty> edgeMgrs =
@@ -1161,40 +1187,41 @@ public class TestHistoryEventTimelineConversion {
         edgeMgrs, null, true);
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(ATSConstants.TEZ_VERTEX_ID, timelineEntity.getEntityType());
-    Assert.assertEquals(vId.toString(), timelineEntity.getEntityId());
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(ATSConstants.TEZ_VERTEX_ID, timelineEntity.getEntityType());
+    assertEquals(vId.toString(), timelineEntity.getEntityId());
+    assertEquals(1, timelineEntity.getEvents().size());
 
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
-    Assert.assertEquals(2, primaryFilters.size());
-    Assert.assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
+    assertEquals(2, primaryFilters.size());
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
         .contains(applicationId.toString()));
-    Assert.assertTrue(primaryFilters.get(EntityTypes.TEZ_DAG_ID.name())
+    assertTrue(primaryFilters.get(EntityTypes.TEZ_DAG_ID.name())
         .contains(tezDAGID.toString()));
 
     TimelineEvent evt = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.VERTEX_CONFIGURE_DONE.name(), evt.getEventType());
-    Assert.assertEquals(1, evt.getEventInfo().get(ATSConstants.NUM_TASKS));
-    Assert.assertNotNull(evt.getEventInfo().get(ATSConstants.UPDATED_EDGE_MANAGERS));
+    assertEquals(HistoryEventType.VERTEX_CONFIGURE_DONE.name(), evt.getEventType());
+    assertEquals(1, evt.getEventInfo().get(ATSConstants.NUM_TASKS));
+    assertNotNull(evt.getEventInfo().get(ATSConstants.UPDATED_EDGE_MANAGERS));
 
     Map<String, Object> updatedEdgeMgrs = (Map<String, Object>)
         evt.getEventInfo().get(ATSConstants.UPDATED_EDGE_MANAGERS);
-    Assert.assertEquals(1, updatedEdgeMgrs.size());
-    Assert.assertTrue(updatedEdgeMgrs.containsKey("a"));
+    assertEquals(1, updatedEdgeMgrs.size());
+    assertTrue(updatedEdgeMgrs.containsKey("a"));
     Map<String, Object> updatedEdgeMgr = (Map<String, Object>) updatedEdgeMgrs.get("a");
 
-    Assert.assertEquals(DataMovementType.CUSTOM.name(),
+    assertEquals(DataMovementType.CUSTOM.name(),
         updatedEdgeMgr.get(DAGUtils.DATA_MOVEMENT_TYPE_KEY));
-    Assert.assertEquals("In", updatedEdgeMgr.get(DAGUtils.EDGE_DESTINATION_CLASS_KEY));
-    Assert.assertEquals("a.class", updatedEdgeMgr.get(DAGUtils.EDGE_MANAGER_CLASS_KEY));
+    assertEquals("In", updatedEdgeMgr.get(DAGUtils.EDGE_DESTINATION_CLASS_KEY));
+    assertEquals("a.class", updatedEdgeMgr.get(DAGUtils.EDGE_MANAGER_CLASS_KEY));
 
-    Assert.assertEquals(1, timelineEntity.getOtherInfo().get(ATSConstants.NUM_TASKS));
+    assertEquals(1, timelineEntity.getOtherInfo().get(ATSConstants.NUM_TASKS));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertDAGRecoveredEvent() {
     long recoverTime = random.nextLong();
 
@@ -1202,37 +1229,38 @@ public class TestHistoryEventTimelineConversion {
         dagPlan.getName(), user, recoverTime, containerLogs);
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(EntityTypes.TEZ_DAG_ID.name(), timelineEntity.getEntityType());
-    Assert.assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_DAG_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(0, timelineEntity.getRelatedEntities().size());
+    assertEquals(0, timelineEntity.getRelatedEntities().size());
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.DAG_RECOVERED.name(), timelineEvent.getEventType());
-    Assert.assertEquals(recoverTime, timelineEvent.getTimestamp());
+    assertEquals(HistoryEventType.DAG_RECOVERED.name(), timelineEvent.getEventType());
+    assertEquals(recoverTime, timelineEvent.getTimestamp());
 
-    Assert.assertTrue(timelineEvent.getEventInfo().containsKey(ATSConstants.APPLICATION_ATTEMPT_ID));
-    Assert.assertEquals(applicationAttemptId.toString(),
+    assertTrue(timelineEvent.getEventInfo().containsKey(ATSConstants.APPLICATION_ATTEMPT_ID));
+    assertEquals(applicationAttemptId.toString(),
         timelineEvent.getEventInfo().get(ATSConstants.APPLICATION_ATTEMPT_ID));
 
-    Assert.assertEquals(3, timelineEntity.getPrimaryFilters().size());
-    Assert.assertTrue(
+    assertEquals(3, timelineEntity.getPrimaryFilters().size());
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
             applicationId.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains("DAGPlanMock"));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
-    Assert.assertEquals(containerLogs,
+    assertEquals(containerLogs,
         timelineEntity.getOtherInfo().get(ATSConstants.IN_PROGRESS_LOGS_URL + "_"
             + applicationAttemptId.getAttemptId()));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConvertDAGRecoveredEvent2() {
     long recoverTime = random.nextLong();
 
@@ -1241,36 +1269,36 @@ public class TestHistoryEventTimelineConversion {
 
 
     List<TimelineEntity> entities = HistoryEventTimelineConversion.convertToTimelineEntities(event);
-    Assert.assertEquals(1, entities.size());
+    assertEquals(1, entities.size());
     TimelineEntity timelineEntity = entities.get(0);
 
-    Assert.assertEquals(EntityTypes.TEZ_DAG_ID.name(), timelineEntity.getEntityType());
-    Assert.assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
+    assertEquals(EntityTypes.TEZ_DAG_ID.name(), timelineEntity.getEntityType());
+    assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
 
-    Assert.assertEquals(0, timelineEntity.getRelatedEntities().size());
+    assertEquals(0, timelineEntity.getRelatedEntities().size());
 
-    Assert.assertEquals(1, timelineEntity.getEvents().size());
+    assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
-    Assert.assertEquals(HistoryEventType.DAG_RECOVERED.name(), timelineEvent.getEventType());
-    Assert.assertEquals(recoverTime, timelineEvent.getTimestamp());
+    assertEquals(HistoryEventType.DAG_RECOVERED.name(), timelineEvent.getEventType());
+    assertEquals(recoverTime, timelineEvent.getTimestamp());
 
-    Assert.assertTrue(timelineEvent.getEventInfo().containsKey(ATSConstants.APPLICATION_ATTEMPT_ID));
-    Assert.assertEquals(applicationAttemptId.toString(),
+    assertTrue(timelineEvent.getEventInfo().containsKey(ATSConstants.APPLICATION_ATTEMPT_ID));
+    assertEquals(applicationAttemptId.toString(),
         timelineEvent.getEventInfo().get(ATSConstants.APPLICATION_ATTEMPT_ID));
-    Assert.assertEquals(DAGState.ERROR.name(),
+    assertEquals(DAGState.ERROR.name(),
         timelineEvent.getEventInfo().get(ATSConstants.DAG_STATE));
-    Assert.assertEquals("mock reason",
+    assertEquals("mock reason",
         timelineEvent.getEventInfo().get(ATSConstants.RECOVERY_FAILURE_REASON));
 
-    Assert.assertEquals(3, timelineEntity.getPrimaryFilters().size());
-    Assert.assertTrue(
+    assertEquals(3, timelineEntity.getPrimaryFilters().size());
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
             applicationId.toString()));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains("DAGPlanMock"));
-    Assert.assertTrue(
+    assertTrue(
         timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
-    Assert.assertEquals(containerLogs,
+    assertEquals(containerLogs,
         timelineEntity.getOtherInfo().get(ATSConstants.IN_PROGRESS_LOGS_URL + "_"
             + applicationAttemptId.getAttemptId()));
   }

--- a/tez-plugins/tez-yarn-timeline-history/src/test/java/org/apache/tez/dag/history/logging/ats/TestHistoryEventTimelineConversion.java
+++ b/tez-plugins/tez-yarn-timeline-history/src/test/java/org/apache/tez/dag/history/logging/ats/TestHistoryEventTimelineConversion.java
@@ -308,10 +308,8 @@ public class TestHistoryEventTimelineConversion {
     assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.CONFIG));
     assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.TEZ_VERSION));
     assertEquals(user, timelineEntity.getOtherInfo().get(ATSConstants.USER));
-    assertEquals(applicationId.toString(),
-        timelineEntity.getOtherInfo().get(ATSConstants.APPLICATION_ID));
-    assertEquals(AMWebController.VERSION,
-        timelineEntity.getOtherInfo().get(ATSConstants.DAG_AM_WEB_SERVICE_VERSION));
+    assertEquals(applicationId.toString(), timelineEntity.getOtherInfo().get(ATSConstants.APPLICATION_ID));
+    assertEquals(AMWebController.VERSION, timelineEntity.getOtherInfo().get(ATSConstants.DAG_AM_WEB_SERVICE_VERSION));
 
     Map<String, String> config =
         (Map<String, String>) timelineEntity.getOtherInfo().get(ATSConstants.CONFIG);
@@ -320,12 +318,9 @@ public class TestHistoryEventTimelineConversion {
 
     Map<String, String> versionInfo =
         (Map<String, String>) timelineEntity.getOtherInfo().get(ATSConstants.TEZ_VERSION);
-    assertEquals(mockVersionInfo.getVersion(),
-        versionInfo.get(ATSConstants.VERSION));
-    assertEquals(mockVersionInfo.getRevision(),
-        versionInfo.get(ATSConstants.REVISION));
-    assertEquals(mockVersionInfo.getBuildTime(),
-        versionInfo.get(ATSConstants.BUILD_TIME));
+    assertEquals(mockVersionInfo.getVersion(), versionInfo.get(ATSConstants.VERSION));
+    assertEquals(mockVersionInfo.getRevision(), versionInfo.get(ATSConstants.REVISION));
+    assertEquals(mockVersionInfo.getBuildTime(), versionInfo.get(ATSConstants.BUILD_TIME));
 
   }
 
@@ -349,8 +344,7 @@ public class TestHistoryEventTimelineConversion {
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
     assertEquals(2, primaryFilters.size());
     assertTrue(primaryFilters.get(ATSConstants.USER).contains(user));
-    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
-        .contains(applicationId.toString()));
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
 
     assertEquals(launchTime, timelineEntity.getStartTime().longValue());
 
@@ -387,8 +381,7 @@ public class TestHistoryEventTimelineConversion {
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
     assertEquals(2, primaryFilters.size());
     assertTrue(primaryFilters.get(ATSConstants.USER).contains(user));
-    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
-            .contains(applicationId.toString()));
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
 
     assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent evt = timelineEntity.getEvents().get(0);
@@ -411,23 +404,20 @@ public class TestHistoryEventTimelineConversion {
     assertEquals("tez_" + containerId.toString(), timelineEntity.getEntityId());
 
     assertEquals(1, timelineEntity.getRelatedEntities().size());
-    assertTrue(
-        timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_APPLICATION_ATTEMPT.name()).contains(
-            "tez_" + applicationAttemptId.toString()));
+    assertTrue(timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_APPLICATION_ATTEMPT.name())
+        .contains("tez_" + applicationAttemptId.toString()));
 
     assertEquals(1, timelineEntity.getPrimaryFilters().size());
-    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
-        applicationAttemptId.getApplicationId().toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID)
+        .contains(applicationAttemptId.getApplicationId().toString()));
 
     assertEquals(containerId.toString(), timelineEntity.getOtherInfo().get(ATSConstants.CONTAINER_ID));
 
     assertEquals(launchTime, timelineEntity.getStartTime().longValue());
 
     assertEquals(1, timelineEntity.getEvents().size());
-    assertEquals(HistoryEventType.CONTAINER_LAUNCHED.name(),
-        timelineEntity.getEvents().get(0).getEventType());
-    assertEquals(launchTime,
-        timelineEntity.getEvents().get(0).getTimestamp());
+    assertEquals(HistoryEventType.CONTAINER_LAUNCHED.name(), timelineEntity.getEvents().get(0).getEventType());
+    assertEquals(launchTime, timelineEntity.getEvents().get(0).getTimestamp());
   }
 
   @Test
@@ -451,8 +441,7 @@ public class TestHistoryEventTimelineConversion {
 
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
     assertEquals(2, primaryFilters.size());
-    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
-        .contains(applicationId.toString()));
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
     assertTrue(primaryFilters.get(ATSConstants.EXIT_STATUS).contains(exitStatus));
 
     assertEquals(1, timelineEntity.getEvents().size());
@@ -488,8 +477,7 @@ public class TestHistoryEventTimelineConversion {
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
     assertEquals(3, primaryFilters.size());
     assertTrue(primaryFilters.get(ATSConstants.USER).contains(user));
-    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
-        .contains(applicationId.toString()));
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
     assertTrue(primaryFilters.get(ATSConstants.DAG_NAME).contains(dagName));
 
     final Map<String, Object> otherInfo = timelineEntity.getOtherInfo();
@@ -526,12 +514,10 @@ public class TestHistoryEventTimelineConversion {
     assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
 
     assertEquals(2, timelineEntity.getRelatedEntities().size());
-    assertTrue(
-        timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_APPLICATION.name()).contains(
-            "tez_" + applicationId.toString()));
-    assertTrue(
-        timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_APPLICATION_ATTEMPT.name()).contains(
-            "tez_" + applicationAttemptId.toString()));
+    assertTrue(timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_APPLICATION.name())
+        .contains("tez_" + applicationId.toString()));
+    assertTrue(timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_APPLICATION_ATTEMPT.name())
+        .contains("tez_" + applicationAttemptId.toString()));
 
     assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
@@ -542,45 +528,31 @@ public class TestHistoryEventTimelineConversion {
 
     assertEquals(5, timelineEntity.getPrimaryFilters().size());
 
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains(
-            dagPlan.getName()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.CALLER_CONTEXT_ID).contains(
-            dagPlan.getCallerContext().getCallerId()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
-            applicationAttemptId.getApplicationId().toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_QUEUE_NAME)
-            .contains(event.getQueueName()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains(dagPlan.getName()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.CALLER_CONTEXT_ID)
+        .contains(dagPlan.getCallerContext().getCallerId()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID)
+        .contains(applicationAttemptId.getApplicationId().toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_QUEUE_NAME).contains(event.getQueueName()));
 
     assertEquals(9, timelineEntity.getOtherInfo().size());
-    assertEquals(applicationId.toString(),
-        timelineEntity.getOtherInfo().get(ATSConstants.APPLICATION_ID));
+    assertEquals(applicationId.toString(), timelineEntity.getOtherInfo().get(ATSConstants.APPLICATION_ID));
     assertEquals(applicationAttemptId.toString(),
         timelineEntity.getOtherInfo().get(ATSConstants.APPLICATION_ATTEMPT_ID));
     assertEquals(applicationAttemptId.getApplicationId().toString(),
         timelineEntity.getOtherInfo().get(ATSConstants.APPLICATION_ID));
-    assertEquals(AMWebController.VERSION,
-        timelineEntity.getOtherInfo().get(ATSConstants.DAG_AM_WEB_SERVICE_VERSION));
-    assertEquals(user,
-        timelineEntity.getOtherInfo().get(ATSConstants.USER));
-    assertEquals(containerLogs,
-        timelineEntity.getOtherInfo().get(ATSConstants.IN_PROGRESS_LOGS_URL + "_"
-            + applicationAttemptId.getAttemptId()));
-    assertEquals(
-        timelineEntity.getOtherInfo().get(ATSConstants.CALLER_CONTEXT_ID),
-            dagPlan.getCallerContext().getCallerId());
-    assertEquals(
-        timelineEntity.getOtherInfo().get(ATSConstants.CALLER_CONTEXT_TYPE),
-            dagPlan.getCallerContext().getCallerType());
+    assertEquals(AMWebController.VERSION, timelineEntity.getOtherInfo().get(ATSConstants.DAG_AM_WEB_SERVICE_VERSION));
+    assertEquals(user, timelineEntity.getOtherInfo().get(ATSConstants.USER));
+    assertEquals(containerLogs, timelineEntity.getOtherInfo()
+        .get(ATSConstants.IN_PROGRESS_LOGS_URL + "_" + applicationAttemptId.getAttemptId()));
+    assertEquals(timelineEntity.getOtherInfo().get(ATSConstants.CALLER_CONTEXT_ID),
+        dagPlan.getCallerContext().getCallerId());
+    assertEquals(timelineEntity.getOtherInfo().get(ATSConstants.CALLER_CONTEXT_TYPE),
+        dagPlan.getCallerContext().getCallerType());
     assertEquals(dagPlan.getCallerContext().getContext(),
         timelineEntity.getOtherInfo().get(ATSConstants.CALLER_CONTEXT));
-    assertEquals(
-        event.getQueueName(), timelineEntity.getOtherInfo().get(ATSConstants.DAG_QUEUE_NAME));
+    assertEquals(event.getQueueName(), timelineEntity.getOtherInfo().get(ATSConstants.DAG_QUEUE_NAME));
 
   }
 
@@ -590,8 +562,7 @@ public class TestHistoryEventTimelineConversion {
     assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
 
     assertEquals(1, timelineEntity.getRelatedEntities().size());
-    assertTrue(timelineEntity.getRelatedEntities()
-        .get(EntityTypes.TEZ_DAG_ID.name()).contains(tezDAGID.toString()));
+    assertTrue(timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_DAG_ID.name()).contains(tezDAGID.toString()));
 
     assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
@@ -636,14 +607,10 @@ public class TestHistoryEventTimelineConversion {
 
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
     assertEquals(5, primaryFilters.size());
-    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
-        .contains(applicationId.toString()));
-    assertTrue(primaryFilters.get(EntityTypes.TEZ_DAG_ID.name())
-        .contains(tezDAGID.toString()));
-    assertTrue(primaryFilters.get(EntityTypes.TEZ_VERTEX_ID.name())
-        .contains(tezVertexID.toString()));
-    assertTrue(primaryFilters.get(EntityTypes.TEZ_TASK_ID.name())
-        .contains(tezTaskID.toString()));
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
+    assertTrue(primaryFilters.get(EntityTypes.TEZ_DAG_ID.name()).contains(tezDAGID.toString()));
+    assertTrue(primaryFilters.get(EntityTypes.TEZ_VERTEX_ID.name()).contains(tezVertexID.toString()));
+    assertTrue(primaryFilters.get(EntityTypes.TEZ_TASK_ID.name()).contains(tezTaskID.toString()));
     assertTrue(primaryFilters.get(ATSConstants.STATUS).contains(state.toString()));
 
     assertEquals(1, timelineEntity.getEvents().size());
@@ -653,8 +620,7 @@ public class TestHistoryEventTimelineConversion {
 
     final Map<String, Object> otherInfo = timelineEntity.getOtherInfo();
     assertEquals(17, otherInfo.size());
-    assertEquals(tezTaskAttemptID.toString(),
-        timelineEntity.getOtherInfo().get(ATSConstants.CREATION_CAUSAL_ATTEMPT));
+    assertEquals(tezTaskAttemptID.toString(), timelineEntity.getOtherInfo().get(ATSConstants.CREATION_CAUSAL_ATTEMPT));
     assertEquals(creationTime, timelineEntity.getOtherInfo().get(ATSConstants.CREATION_TIME));
     assertEquals(allocationTime, timelineEntity.getOtherInfo().get(ATSConstants.ALLOCATION_TIME));
     assertEquals(startTime, timelineEntity.getOtherInfo().get(ATSConstants.START_TIME));
@@ -719,18 +685,13 @@ public class TestHistoryEventTimelineConversion {
     assertEquals(initTime, timelineEvent.getTimestamp());
 
     assertEquals(3, timelineEntity.getPrimaryFilters().size());
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
-            applicationId.toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains("dagName"));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains("dagName"));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
 
-    assertTrue(timelineEntity.getOtherInfo().containsKey(
-        ATSConstants.VERTEX_NAME_ID_MAPPING));
-    Map<String, String> vIdMap = (Map<String, String>) timelineEntity.getOtherInfo().get(
-        ATSConstants.VERTEX_NAME_ID_MAPPING);
+    assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.VERTEX_NAME_ID_MAPPING));
+    Map<String, String> vIdMap =
+        (Map<String, String>) timelineEntity.getOtherInfo().get(ATSConstants.VERTEX_NAME_ID_MAPPING);
     assertEquals(1, vIdMap.size());
     assertNotNull(vIdMap.containsKey("foo"));
     assertEquals(tezVertexID.toString(), vIdMap.get("foo"));
@@ -774,37 +735,24 @@ public class TestHistoryEventTimelineConversion {
     assertEquals(finishTime, timelineEvent.getTimestamp());
 
     assertEquals(5, timelineEntity.getPrimaryFilters().size());
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
-            applicationId.toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains(dagPlan.getName()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.STATUS).contains(
-            DAGState.ERROR.name()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.CALLER_CONTEXT_ID).contains(
-            dagPlan.getCallerContext().getCallerId()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains(dagPlan.getName()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.STATUS).contains(DAGState.ERROR.name()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.CALLER_CONTEXT_ID)
+        .contains(dagPlan.getCallerContext().getCallerId()));
 
-    assertEquals(startTime,
-        ((Long) timelineEntity.getOtherInfo().get(ATSConstants.START_TIME)).longValue());
-    assertEquals(finishTime,
-        ((Long) timelineEntity.getOtherInfo().get(ATSConstants.FINISH_TIME)).longValue());
+    assertEquals(startTime, ((Long) timelineEntity.getOtherInfo().get(ATSConstants.START_TIME)).longValue());
+    assertEquals(finishTime, ((Long) timelineEntity.getOtherInfo().get(ATSConstants.FINISH_TIME)).longValue());
     assertEquals(finishTime - startTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.TIME_TAKEN)).longValue());
-    assertEquals(DAGState.ERROR.name(),
-        timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
-    assertEquals("diagnostics",
-        timelineEntity.getOtherInfo().get(ATSConstants.DIAGNOSTICS));
+    assertEquals(DAGState.ERROR.name(), timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
+    assertEquals("diagnostics", timelineEntity.getOtherInfo().get(ATSConstants.DIAGNOSTICS));
     assertEquals(applicationAttemptId.toString(),
         timelineEntity.getOtherInfo().get(ATSConstants.COMPLETION_APPLICATION_ATTEMPT_ID));
 
-    assertEquals(100,
-        ((Integer) timelineEntity.getOtherInfo().get("FOO")).intValue());
-    assertEquals(200,
-        ((Integer) timelineEntity.getOtherInfo().get("BAR")).intValue());
+    assertEquals(100, ((Integer) timelineEntity.getOtherInfo().get("FOO")).intValue());
+    assertEquals(200, ((Integer) timelineEntity.getOtherInfo().get("BAR")).intValue());
   }
 
   private void assertDagFinishedExtraInfoEntity(long finishTime, TimelineEntity timelineEntity) {
@@ -812,9 +760,7 @@ public class TestHistoryEventTimelineConversion {
     assertEquals(tezDAGID.toString(), timelineEntity.getEntityId());
 
     assertEquals(1, timelineEntity.getRelatedEntities().size());
-    assertTrue(
-        timelineEntity.getRelatedEntities().get(ATSConstants.TEZ_DAG_ID).contains(
-            tezDAGID.toString()));
+    assertTrue(timelineEntity.getRelatedEntities().get(ATSConstants.TEZ_DAG_ID).contains(tezDAGID.toString()));
 
     assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
@@ -850,17 +796,11 @@ public class TestHistoryEventTimelineConversion {
     assertEquals(initedTime, timelineEntity.getStartTime().longValue());
 
     assertEquals(1, timelineEntity.getRelatedEntities().size());
-    assertTrue(
-        timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_DAG_ID.name()).contains(
-            tezDAGID.toString()));
+    assertTrue(timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_DAG_ID.name()).contains(tezDAGID.toString()));
 
     assertEquals(2, timelineEntity.getPrimaryFilters().size());
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
-            applicationId.toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(
-            tezDAGID.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(tezDAGID.toString()));
 
     assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
@@ -870,33 +810,24 @@ public class TestHistoryEventTimelineConversion {
     assertEquals("v1", timelineEntity.getOtherInfo().get(ATSConstants.VERTEX_NAME));
     assertEquals("proc", timelineEntity.getOtherInfo().get(ATSConstants.PROCESSOR_CLASS_NAME));
 
-    assertEquals(initedTime,
-        ((Long) timelineEntity.getOtherInfo().get(ATSConstants.INIT_TIME)).longValue());
+    assertEquals(initedTime, ((Long) timelineEntity.getOtherInfo().get(ATSConstants.INIT_TIME)).longValue());
     assertEquals(initRequestedTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.INIT_REQUESTED_TIME)).longValue());
-    assertEquals(initedTime,
-        ((Long) timelineEntity.getOtherInfo().get(ATSConstants.INIT_TIME)).longValue());
-    assertEquals(numTasks,
-        ((Integer) timelineEntity.getOtherInfo().get(ATSConstants.NUM_TASKS)).intValue());
+    assertEquals(initedTime, ((Long) timelineEntity.getOtherInfo().get(ATSConstants.INIT_TIME)).longValue());
+    assertEquals(numTasks, ((Integer) timelineEntity.getOtherInfo().get(ATSConstants.NUM_TASKS)).intValue());
     assertNotNull(timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN));
-    assertEquals("abc",
-        ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
-            ATSConstants.CONTAINER_LAUNCHER_NAME));
-    assertEquals("def",
-        ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
-            ATSConstants.TASK_SCHEDULER_NAME));
-    assertEquals("ghi",
-        ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
-            ATSConstants.TASK_COMMUNICATOR_NAME));
-    assertEquals("abc1",
-        ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
-            ATSConstants.CONTAINER_LAUNCHER_CLASS_NAME));
-    assertEquals("def1",
-        ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
-            ATSConstants.TASK_SCHEDULER_CLASS_NAME));
-    assertEquals("ghi1",
-        ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
-            ATSConstants.TASK_COMMUNICATOR_CLASS_NAME));
+    assertEquals("abc", ((Map<String, Object>) timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
+        ATSConstants.CONTAINER_LAUNCHER_NAME));
+    assertEquals("def", ((Map<String, Object>) timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
+        ATSConstants.TASK_SCHEDULER_NAME));
+    assertEquals("ghi", ((Map<String, Object>) timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
+        ATSConstants.TASK_COMMUNICATOR_NAME));
+    assertEquals("abc1", ((Map<String, Object>) timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
+        ATSConstants.CONTAINER_LAUNCHER_CLASS_NAME));
+    assertEquals("def1", ((Map<String, Object>) timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
+        ATSConstants.TASK_SCHEDULER_CLASS_NAME));
+    assertEquals("ghi1", ((Map<String, Object>) timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
+        ATSConstants.TASK_COMMUNICATOR_CLASS_NAME));
   }
 
   @Test
@@ -917,11 +848,8 @@ public class TestHistoryEventTimelineConversion {
     assertEquals(0, timelineEntity.getRelatedEntities().size());
 
     assertEquals(2, timelineEntity.getPrimaryFilters().size());
-    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID)
-            .contains(applicationId.toString()));
-    assertTrue(
-            timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(
-                    tezDAGID.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(tezDAGID.toString()));
 
     assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
@@ -930,11 +858,9 @@ public class TestHistoryEventTimelineConversion {
 
     assertEquals(3, timelineEntity.getOtherInfo().size());
     assertEquals(startRequestedTime,
-            ((Long) timelineEntity.getOtherInfo().get(ATSConstants.START_REQUESTED_TIME)).longValue());
-    assertEquals(startTime,
-            ((Long) timelineEntity.getOtherInfo().get(ATSConstants.START_TIME)).longValue());
-    assertEquals(VertexState.RUNNING.name(),
-            timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
+        ((Long) timelineEntity.getOtherInfo().get(ATSConstants.START_REQUESTED_TIME)).longValue());
+    assertEquals(startTime, ((Long) timelineEntity.getOtherInfo().get(ATSConstants.START_TIME)).longValue());
+    assertEquals(VertexState.RUNNING.name(), timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
   }
 
   @SuppressWarnings("unchecked")
@@ -971,56 +897,39 @@ public class TestHistoryEventTimelineConversion {
     assertEquals(0, timelineEntity.getRelatedEntities().size());
 
     assertEquals(3, timelineEntity.getPrimaryFilters().size());
-    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID)
-        .contains(applicationId.toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(
-            tezDAGID.toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.STATUS).contains(
-            VertexState.ERROR.name()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(tezDAGID.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.STATUS).contains(VertexState.ERROR.name()));
 
     assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
     assertEquals(HistoryEventType.VERTEX_FINISHED.name(), timelineEvent.getEventType());
     assertEquals(finishTime, timelineEvent.getTimestamp());
 
-    assertEquals(vertexName,
-        timelineEntity.getOtherInfo().get(ATSConstants.VERTEX_NAME));
-    assertEquals(finishTime,
-        ((Long) timelineEntity.getOtherInfo().get(ATSConstants.FINISH_TIME)).longValue());
+    assertEquals(vertexName, timelineEntity.getOtherInfo().get(ATSConstants.VERTEX_NAME));
+    assertEquals(finishTime, ((Long) timelineEntity.getOtherInfo().get(ATSConstants.FINISH_TIME)).longValue());
     assertEquals(finishTime - startTime,
         ((Long) timelineEntity.getOtherInfo().get(ATSConstants.TIME_TAKEN)).longValue());
-    assertEquals(VertexState.ERROR.name(),
-        timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
-    assertEquals("diagnostics",
-        timelineEntity.getOtherInfo().get(ATSConstants.DIAGNOSTICS));
+    assertEquals(VertexState.ERROR.name(), timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
+    assertEquals("diagnostics", timelineEntity.getOtherInfo().get(ATSConstants.DIAGNOSTICS));
     assertNotNull(timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN));
-    assertEquals("abc",
-        ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
-            ATSConstants.CONTAINER_LAUNCHER_NAME));
-    assertEquals("def",
-        ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
-            ATSConstants.TASK_SCHEDULER_NAME));
-    assertEquals("ghi",
-        ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
-            ATSConstants.TASK_COMMUNICATOR_NAME));
-    assertEquals("abc1",
-        ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
-            ATSConstants.CONTAINER_LAUNCHER_CLASS_NAME));
-    assertEquals("def1",
-        ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
-            ATSConstants.TASK_SCHEDULER_CLASS_NAME));
-    assertEquals("ghi1",
-        ((Map<String, Object>)timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
-            ATSConstants.TASK_COMMUNICATOR_CLASS_NAME));
+    assertEquals("abc", ((Map<String, Object>) timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
+        ATSConstants.CONTAINER_LAUNCHER_NAME));
+    assertEquals("def", ((Map<String, Object>) timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
+        ATSConstants.TASK_SCHEDULER_NAME));
+    assertEquals("ghi", ((Map<String, Object>) timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
+        ATSConstants.TASK_COMMUNICATOR_NAME));
+    assertEquals("abc1", ((Map<String, Object>) timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
+        ATSConstants.CONTAINER_LAUNCHER_CLASS_NAME));
+    assertEquals("def1", ((Map<String, Object>) timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
+        ATSConstants.TASK_SCHEDULER_CLASS_NAME));
+    assertEquals("ghi1", ((Map<String, Object>) timelineEntity.getOtherInfo().get(ATSConstants.SERVICE_PLUGIN)).get(
+        ATSConstants.TASK_COMMUNICATOR_CLASS_NAME));
 
     assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.STATS));
 
-    assertEquals(100,
-        ((Integer) timelineEntity.getOtherInfo().get("FOO")).intValue());
-    assertEquals(200,
-        ((Integer) timelineEntity.getOtherInfo().get("BAR")).intValue());
+    assertEquals(100, ((Integer) timelineEntity.getOtherInfo().get("FOO")).intValue());
+    assertEquals(200, ((Integer) timelineEntity.getOtherInfo().get("BAR")).intValue());
   }
 
   @Test
@@ -1041,19 +950,13 @@ public class TestHistoryEventTimelineConversion {
 
     assertEquals(1, timelineEntity.getRelatedEntities().size());
     assertTrue(
-        timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_VERTEX_ID.name()).contains(
-            tezVertexID.toString()));
+        timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_VERTEX_ID.name()).contains(tezVertexID.toString()));
 
     assertEquals(3, timelineEntity.getPrimaryFilters().size());
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(tezDAGID.toString()));
     assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
-            applicationId.toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(
-            tezDAGID.toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_VERTEX_ID.name()).contains(
-            tezVertexID.toString()));
+        timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_VERTEX_ID.name()).contains(tezVertexID.toString()));
 
     assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
@@ -1063,12 +966,9 @@ public class TestHistoryEventTimelineConversion {
     assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.SCHEDULED_TIME));
     assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.START_TIME));
 
-    assertEquals(scheduleTime,
-        ((Long) timelineEntity.getOtherInfo().get(ATSConstants.SCHEDULED_TIME)).longValue());
-    assertEquals(startTime,
-        ((Long) timelineEntity.getOtherInfo().get(ATSConstants.START_TIME)).longValue());
-    assertEquals(TaskState.SCHEDULED.name(),
-        timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
+    assertEquals(scheduleTime, ((Long) timelineEntity.getOtherInfo().get(ATSConstants.SCHEDULED_TIME)).longValue());
+    assertEquals(startTime, ((Long) timelineEntity.getOtherInfo().get(ATSConstants.START_TIME)).longValue());
+    assertEquals(TaskState.SCHEDULED.name(), timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
   }
 
   @Test
@@ -1088,9 +988,7 @@ public class TestHistoryEventTimelineConversion {
     assertEquals(startTime, timelineEntity.getStartTime().longValue());
 
     assertEquals(1, timelineEntity.getRelatedEntities().size());
-    assertTrue(
-        timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_TASK_ID.name()).contains(
-            tezTaskID.toString()));
+    assertTrue(timelineEntity.getRelatedEntities().get(EntityTypes.TEZ_TASK_ID.name()).contains(tezTaskID.toString()));
 
     assertEquals(1, timelineEntity.getEvents().size());
     TimelineEvent timelineEvent = timelineEntity.getEvents().get(0);
@@ -1098,32 +996,19 @@ public class TestHistoryEventTimelineConversion {
     assertEquals(startTime, timelineEvent.getTimestamp());
 
     assertEquals(4, timelineEntity.getPrimaryFilters().size());
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(tezDAGID.toString()));
     assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
-            applicationId.toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_DAG_ID.name()).contains(
-            tezDAGID.toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_VERTEX_ID.name()).contains(
-            tezVertexID.toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_TASK_ID.name()).contains(
-            tezTaskID.toString()));
+        timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_VERTEX_ID.name()).contains(tezVertexID.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(EntityTypes.TEZ_TASK_ID.name()).contains(tezTaskID.toString()));
 
     assertTrue(timelineEntity.getOtherInfo().containsKey(ATSConstants.START_TIME));
-    assertEquals("inProgressURL",
-        timelineEntity.getOtherInfo().get(ATSConstants.IN_PROGRESS_LOGS_URL));
-    assertEquals("logsURL",
-        timelineEntity.getOtherInfo().get(ATSConstants.COMPLETED_LOGS_URL));
-    assertEquals(nodeId.toString(),
-        timelineEntity.getOtherInfo().get(ATSConstants.NODE_ID));
-    assertEquals(containerId.toString(),
-        timelineEntity.getOtherInfo().get(ATSConstants.CONTAINER_ID));
-    assertEquals("nodeHttpAddress",
-        timelineEntity.getOtherInfo().get(ATSConstants.NODE_HTTP_ADDRESS));
-    assertEquals(TaskAttemptState.RUNNING.name(),
-        timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
+    assertEquals("inProgressURL", timelineEntity.getOtherInfo().get(ATSConstants.IN_PROGRESS_LOGS_URL));
+    assertEquals("logsURL", timelineEntity.getOtherInfo().get(ATSConstants.COMPLETED_LOGS_URL));
+    assertEquals(nodeId.toString(), timelineEntity.getOtherInfo().get(ATSConstants.NODE_ID));
+    assertEquals(containerId.toString(), timelineEntity.getOtherInfo().get(ATSConstants.CONTAINER_ID));
+    assertEquals("nodeHttpAddress", timelineEntity.getOtherInfo().get(ATSConstants.NODE_HTTP_ADDRESS));
+    assertEquals(TaskAttemptState.RUNNING.name(), timelineEntity.getOtherInfo().get(ATSConstants.STATUS));
   }
 
   @Test
@@ -1147,12 +1032,9 @@ public class TestHistoryEventTimelineConversion {
 
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
     assertEquals(4, primaryFilters.size());
-    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
-        .contains(applicationId.toString()));
-    assertTrue(primaryFilters.get(EntityTypes.TEZ_DAG_ID.name())
-        .contains(tezDAGID.toString()));
-    assertTrue(primaryFilters.get(EntityTypes.TEZ_VERTEX_ID.name())
-        .contains(tezVertexID.toString()));
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
+    assertTrue(primaryFilters.get(EntityTypes.TEZ_DAG_ID.name()).contains(tezDAGID.toString()));
+    assertTrue(primaryFilters.get(EntityTypes.TEZ_VERTEX_ID.name()).contains(tezVertexID.toString()));
     assertTrue(primaryFilters.get(ATSConstants.STATUS).contains(state.name()));
 
     assertEquals(1, timelineEntity.getEvents().size());
@@ -1165,8 +1047,7 @@ public class TestHistoryEventTimelineConversion {
     assertEquals(finishTime, otherInfo.get(ATSConstants.FINISH_TIME));
     assertEquals(finishTime - startTime, otherInfo.get(ATSConstants.TIME_TAKEN));
     assertEquals(state.name(), otherInfo.get(ATSConstants.STATUS));
-    assertEquals(tezTaskAttemptID.toString(),
-        otherInfo.get(ATSConstants.SUCCESSFUL_ATTEMPT_ID));
+    assertEquals(tezTaskAttemptID.toString(), otherInfo.get(ATSConstants.SUCCESSFUL_ATTEMPT_ID));
     assertEquals(3, otherInfo.get(ATSConstants.NUM_FAILED_TASKS_ATTEMPTS));
     assertEquals(diagnostics, otherInfo.get(ATSConstants.DIAGNOSTICS));
     assertTrue(otherInfo.containsKey(ATSConstants.COUNTERS));
@@ -1196,10 +1077,8 @@ public class TestHistoryEventTimelineConversion {
 
     final Map<String, Set<Object>> primaryFilters = timelineEntity.getPrimaryFilters();
     assertEquals(2, primaryFilters.size());
-    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID)
-        .contains(applicationId.toString()));
-    assertTrue(primaryFilters.get(EntityTypes.TEZ_DAG_ID.name())
-        .contains(tezDAGID.toString()));
+    assertTrue(primaryFilters.get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
+    assertTrue(primaryFilters.get(EntityTypes.TEZ_DAG_ID.name()).contains(tezDAGID.toString()));
 
     TimelineEvent evt = timelineEntity.getEvents().get(0);
     assertEquals(HistoryEventType.VERTEX_CONFIGURE_DONE.name(), evt.getEventType());
@@ -1212,8 +1091,7 @@ public class TestHistoryEventTimelineConversion {
     assertTrue(updatedEdgeMgrs.containsKey("a"));
     Map<String, Object> updatedEdgeMgr = (Map<String, Object>) updatedEdgeMgrs.get("a");
 
-    assertEquals(DataMovementType.CUSTOM.name(),
-        updatedEdgeMgr.get(DAGUtils.DATA_MOVEMENT_TYPE_KEY));
+    assertEquals(DataMovementType.CUSTOM.name(), updatedEdgeMgr.get(DAGUtils.DATA_MOVEMENT_TYPE_KEY));
     assertEquals("In", updatedEdgeMgr.get(DAGUtils.EDGE_DESTINATION_CLASS_KEY));
     assertEquals("a.class", updatedEdgeMgr.get(DAGUtils.EDGE_MANAGER_CLASS_KEY));
 
@@ -1247,16 +1125,11 @@ public class TestHistoryEventTimelineConversion {
         timelineEvent.getEventInfo().get(ATSConstants.APPLICATION_ATTEMPT_ID));
 
     assertEquals(3, timelineEntity.getPrimaryFilters().size());
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
-            applicationId.toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains("DAGPlanMock"));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
-    assertEquals(containerLogs,
-        timelineEntity.getOtherInfo().get(ATSConstants.IN_PROGRESS_LOGS_URL + "_"
-            + applicationAttemptId.getAttemptId()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains("DAGPlanMock"));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
+    assertEquals(containerLogs, timelineEntity.getOtherInfo()
+        .get(ATSConstants.IN_PROGRESS_LOGS_URL + "_" + applicationAttemptId.getAttemptId()));
   }
 
   @Test
@@ -1285,23 +1158,14 @@ public class TestHistoryEventTimelineConversion {
     assertTrue(timelineEvent.getEventInfo().containsKey(ATSConstants.APPLICATION_ATTEMPT_ID));
     assertEquals(applicationAttemptId.toString(),
         timelineEvent.getEventInfo().get(ATSConstants.APPLICATION_ATTEMPT_ID));
-    assertEquals(DAGState.ERROR.name(),
-        timelineEvent.getEventInfo().get(ATSConstants.DAG_STATE));
-    assertEquals("mock reason",
-        timelineEvent.getEventInfo().get(ATSConstants.RECOVERY_FAILURE_REASON));
+    assertEquals(DAGState.ERROR.name(), timelineEvent.getEventInfo().get(ATSConstants.DAG_STATE));
+    assertEquals("mock reason", timelineEvent.getEventInfo().get(ATSConstants.RECOVERY_FAILURE_REASON));
 
     assertEquals(3, timelineEntity.getPrimaryFilters().size());
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(
-            applicationId.toString()));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains("DAGPlanMock"));
-    assertTrue(
-        timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
-    assertEquals(containerLogs,
-        timelineEntity.getOtherInfo().get(ATSConstants.IN_PROGRESS_LOGS_URL + "_"
-            + applicationAttemptId.getAttemptId()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.APPLICATION_ID).contains(applicationId.toString()));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.DAG_NAME).contains("DAGPlanMock"));
+    assertTrue(timelineEntity.getPrimaryFilters().get(ATSConstants.USER).contains(user));
+    assertEquals(containerLogs, timelineEntity.getOtherInfo()
+        .get(ATSConstants.IN_PROGRESS_LOGS_URL + "_" + applicationAttemptId.getAttemptId()));
   }
-
-
 }

--- a/tez-runtime-internals/pom.xml
+++ b/tez-runtime-internals/pom.xml
@@ -86,9 +86,9 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/TestInputReadyTracker.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/TestInputReadyTracker.java
@@ -18,16 +18,17 @@
  */
 package org.apache.tez.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.runtime.api.AbstractLogicalInput;
 import org.apache.tez.runtime.api.Event;
@@ -40,14 +41,16 @@ import org.apache.tez.runtime.api.impl.TezMergedInputContextImpl;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 
 public class TestInputReadyTracker {
 
   private static final long SLEEP_TIME = 200l;
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testWithoutGrouping1() throws InterruptedException {
     InputReadyTracker inputReadyTracker = new InputReadyTracker();
 
@@ -78,7 +81,8 @@ public class TestInputReadyTracker {
     assertTrue(input1.isReady);
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testWithoutGrouping2() throws InterruptedException {
     InputReadyTracker inputReadyTracker = new InputReadyTracker();
 
@@ -140,7 +144,8 @@ public class TestInputReadyTracker {
     assertTrue(input2.isReady);
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testGrouped() throws InterruptedException {
     InputReadyTracker inputReadyTracker = new InputReadyTracker();
 

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/TestLogicalIOProcessorRuntimeTask.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/TestLogicalIOProcessorRuntimeTask.java
@@ -18,10 +18,11 @@
  */
 package org.apache.tez.runtime;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -36,6 +37,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -78,12 +80,14 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 
 public class TestLogicalIOProcessorRuntimeTask {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAutoStart() throws Exception {
     TezDAGID dagId = createTezDagId();
     TezVertexID vertexId = createTezVertexId(dagId);
@@ -120,8 +124,8 @@ public class TestLogicalIOProcessorRuntimeTask {
       assertEquals(1, TestInput.startCount);
       assertEquals(0, TestOutput.startCount);
       // test that invocations of progress are counted correctly
-      assertEquals(true, lio1.getAndClearProgressNotification());
-      assertEquals(false, lio1.getAndClearProgressNotification()); // cleared after getting
+      assertTrue(lio1.getAndClearProgressNotification());
+      assertFalse(lio1.getAndClearProgressNotification()); // cleared after getting
       assertEquals(30, TestInput.vertexParallelism);
       assertEquals(0, TestOutput.vertexParallelism);
       assertEquals(30, lio1.getProcessorContext().getVertexParallelism());
@@ -251,17 +255,17 @@ public class TestLogicalIOProcessorRuntimeTask {
 
     lio.cleanup();
 
-    assertTrue(procContext.getUserPayload() == null);
-    assertTrue(procContext.getObjectRegistry() == null);
+    assertNull(procContext.getUserPayload());
+    assertNull(procContext.getObjectRegistry());
 
     for (InputContext inputContext : inputContexts) {
-      assertTrue(inputContext.getUserPayload() == null);
-      assertTrue(inputContext.getObjectRegistry() == null);
+      assertNull(inputContext.getUserPayload());
+      assertNull(inputContext.getObjectRegistry());
     }
 
     for (OutputContext outputContext : outputContexts) {
-      assertTrue(outputContext.getUserPayload() == null);
-      assertTrue(outputContext.getObjectRegistry() == null);
+      assertNull(outputContext.getUserPayload());
+      assertNull(outputContext.getObjectRegistry());
     }
     boolean localMode = lio.tezConf.getBoolean(TezConfiguration.TEZ_LOCAL_MODE,
         TezConfiguration.TEZ_LOCAL_MODE_DEFAULT);

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/api/impl/TestProcessorContext.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/api/impl/TestProcessorContext.java
@@ -18,15 +18,15 @@
  */
 package org.apache.tez.runtime.api.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -46,11 +46,13 @@ import org.apache.tez.runtime.common.resources.MemoryDistributor;
 
 import com.google.common.collect.Maps;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestProcessorContext {
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDagNumber() throws IOException {
     String[] localDirs = new String[] {"dummyLocalDir"};
     int appAttemptNumber = 1;
@@ -111,7 +113,7 @@ public class TestProcessorContext {
     assertEquals(dagName, procContext.getDAGName());
     assertEquals(vertexName, procContext.getTaskVertexName());
     assertEquals(vertexId.getId(), procContext.getTaskVertexIndex());
-    assertTrue(Arrays.equals(localDirs, procContext.getWorkDirs()));
+    assertArrayEquals(localDirs, procContext.getWorkDirs());
 
      // test auto call of notifyProgress
      procContext.setProgress(0.1f);

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/api/impl/TestTaskSpec.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/api/impl/TestTaskSpec.java
@@ -86,10 +86,10 @@ public class TestTaskSpec {
     assertEquals(taskSpec.getInputs().size(), deSerTaskSpec.getInputs().size());
     assertEquals(taskSpec.getOutputs().size(), deSerTaskSpec.getOutputs().size());
     assertNull(deSerTaskSpec.getGroupInputs());
-    assertEquals(taskSpec.getInputs().get(0).getSourceVertexName(),
-        deSerTaskSpec.getInputs().get(0).getSourceVertexName());
-    assertEquals(taskSpec.getOutputs().get(0).getDestinationVertexName(),
-        deSerTaskSpec.getOutputs().get(0).getDestinationVertexName());
+    assertEquals(taskSpec.getInputs().getFirst().getSourceVertexName(),
+        deSerTaskSpec.getInputs().getFirst().getSourceVertexName());
+    assertEquals(taskSpec.getOutputs().getFirst().getDestinationVertexName(),
+        deSerTaskSpec.getOutputs().getFirst().getDestinationVertexName());
 
     assertEquals(taskConf.get("foo"), deSerTaskSpec.getTaskConf().get("foo"));
   }

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/api/impl/TestTaskSpec.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/api/impl/TestTaskSpec.java
@@ -18,6 +18,9 @@
  */
 package org.apache.tez.runtime.api.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
@@ -28,6 +31,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.dag.api.InputDescriptor;
@@ -39,12 +43,13 @@ import org.apache.tez.dag.records.TezTaskAttemptID;
 import org.apache.tez.dag.records.TezTaskID;
 import org.apache.tez.dag.records.TezVertexID;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestTaskSpec {
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSerDe() throws IOException {
     ByteBuffer payload = null;
     ProcessorDescriptor procDesc = ProcessorDescriptor.create("proc").setUserPayload(
@@ -75,18 +80,18 @@ public class TestTaskSpec {
     DataInput in = new DataInputStream(bis);
     deSerTaskSpec.readFields(in);
 
-    Assert.assertEquals(taskSpec.getDAGName(), deSerTaskSpec.getDAGName());
-    Assert.assertEquals(taskSpec.getVertexName(), deSerTaskSpec.getVertexName());
-    Assert.assertEquals(taskSpec.getVertexParallelism(), deSerTaskSpec.getVertexParallelism());
-    Assert.assertEquals(taskSpec.getInputs().size(), deSerTaskSpec.getInputs().size());
-    Assert.assertEquals(taskSpec.getOutputs().size(), deSerTaskSpec.getOutputs().size());
-    Assert.assertNull(deSerTaskSpec.getGroupInputs());
-    Assert.assertEquals(taskSpec.getInputs().get(0).getSourceVertexName(),
+    assertEquals(taskSpec.getDAGName(), deSerTaskSpec.getDAGName());
+    assertEquals(taskSpec.getVertexName(), deSerTaskSpec.getVertexName());
+    assertEquals(taskSpec.getVertexParallelism(), deSerTaskSpec.getVertexParallelism());
+    assertEquals(taskSpec.getInputs().size(), deSerTaskSpec.getInputs().size());
+    assertEquals(taskSpec.getOutputs().size(), deSerTaskSpec.getOutputs().size());
+    assertNull(deSerTaskSpec.getGroupInputs());
+    assertEquals(taskSpec.getInputs().get(0).getSourceVertexName(),
         deSerTaskSpec.getInputs().get(0).getSourceVertexName());
-    Assert.assertEquals(taskSpec.getOutputs().get(0).getDestinationVertexName(),
+    assertEquals(taskSpec.getOutputs().get(0).getDestinationVertexName(),
         deSerTaskSpec.getOutputs().get(0).getDestinationVertexName());
 
-    Assert.assertEquals(taskConf.get("foo"), deSerTaskSpec.getTaskConf().get("foo"));
+    assertEquals(taskConf.get("foo"), deSerTaskSpec.getTaskConf().get("foo"));
   }
 
 }

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/api/impl/TestTezEvent.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/api/impl/TestTezEvent.java
@@ -18,6 +18,9 @@
  */
 package org.apache.tez.runtime.api.impl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
 import java.io.ByteArrayInputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
@@ -41,8 +44,8 @@ import org.apache.tez.runtime.api.impl.EventMetaData.EventProducerConsumerType;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 public class TestTezEvent {
 
@@ -122,31 +125,31 @@ public class TestTezEvent {
   }
 
   private void assertEventEquals(ArrayList<TezEvent> expectedList, ArrayList<TezEvent> actualList) {
-    Assert.assertEquals(expectedList.size(), actualList.size());
+    assertEquals(expectedList.size(), actualList.size());
     for (int i = 0; i < expectedList.size(); i++) {
       TezEvent expected = expectedList.get(i);
       TezEvent actual = actualList.get(i);
-      Assert.assertEquals(expected.getEventReceivedTime(), actual.getEventReceivedTime());
-      Assert.assertEquals(expected.getSourceInfo(), actual.getSourceInfo());
-      Assert.assertEquals(expected.getDestinationInfo(), actual.getDestinationInfo());
-      Assert.assertEquals(expected.getEventType(), actual.getEventType());
+      assertEquals(expected.getEventReceivedTime(), actual.getEventReceivedTime());
+      assertEquals(expected.getSourceInfo(), actual.getSourceInfo());
+      assertEquals(expected.getDestinationInfo(), actual.getDestinationInfo());
+      assertEquals(expected.getEventType(), actual.getEventType());
       // Doing this instead of implementing equals methods for events
       if (i == 0) {
-        Assert.assertTrue(actual.getEvent() instanceof TaskAttemptCompletedEvent);
+        assertInstanceOf(TaskAttemptCompletedEvent.class, actual.getEvent());
       } else if (i == 1) {
         DataMovementEvent dmeExpected = (DataMovementEvent) expected.getEvent();
         DataMovementEvent dmeActual = (DataMovementEvent) actual.getEvent();
-        Assert.assertEquals(dmeExpected.getSourceIndex(), dmeActual.getSourceIndex());
-        Assert.assertEquals(dmeExpected.getTargetIndex(), dmeActual.getTargetIndex());
-        Assert.assertEquals(dmeExpected.getVersion(), dmeActual.getVersion());
-        Assert.assertEquals(dmeExpected.getUserPayload(), dmeActual.getUserPayload());
+        assertEquals(dmeExpected.getSourceIndex(), dmeActual.getSourceIndex());
+        assertEquals(dmeExpected.getTargetIndex(), dmeActual.getTargetIndex());
+        assertEquals(dmeExpected.getVersion(), dmeActual.getVersion());
+        assertEquals(dmeExpected.getUserPayload(), dmeActual.getUserPayload());
       } else {
         TaskStatusUpdateEvent tsuExpected = (TaskStatusUpdateEvent) expected.getEvent();
         TaskStatusUpdateEvent tsuActual = (TaskStatusUpdateEvent) actual.getEvent();
-        Assert.assertEquals(tsuExpected.getCounters(), tsuActual.getCounters());
-        Assert.assertEquals(tsuExpected.getProgress(), tsuActual.getProgress(), 0);
-        Assert.assertEquals(tsuExpected.getProgressNotified(), tsuActual.getProgressNotified());
-        Assert.assertEquals(tsuExpected.getStatistics(), tsuActual.getStatistics());
+        assertEquals(tsuExpected.getCounters(), tsuActual.getCounters());
+        assertEquals(tsuExpected.getProgress(), tsuActual.getProgress(), 0);
+        assertEquals(tsuExpected.getProgressNotified(), tsuActual.getProgressNotified());
+        assertEquals(tsuExpected.getStatistics(), tsuActual.getStatistics());
       }
     }
   }

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/common/objectregistry/TestObjectRegistry.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/common/objectregistry/TestObjectRegistry.java
@@ -18,39 +18,50 @@
  */
 package org.apache.tez.runtime.common.objectregistry;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
+
 import org.apache.tez.runtime.api.ObjectRegistry;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestObjectRegistry {
 
   private void testCRUD(ObjectRegistry objectRegistry) {
-    Assert.assertNotNull(objectRegistry);
+    assertNotNull(objectRegistry);
 
-    Assert.assertNull(objectRegistry.get("foo"));
-    Assert.assertFalse(objectRegistry.delete("foo"));
+    assertNull(objectRegistry.get("foo"));
+    assertFalse(objectRegistry.delete("foo"));
     Integer one = new Integer(1);
     Integer two_1 = new Integer(2);
     Integer two_2 = new Integer(3);
-    Assert.assertNull(objectRegistry.cacheForDAG("one", one));
-    Assert.assertEquals(one, objectRegistry.get("one"));
-    Assert.assertNull(objectRegistry.cacheForDAG("two", two_1));
-    Assert.assertNotNull(objectRegistry.cacheForSession("two", two_2));
-    Assert.assertNotEquals(two_1, objectRegistry.get("two"));
-    Assert.assertEquals(two_2, objectRegistry.get("two"));
-    Assert.assertTrue(objectRegistry.delete("one"));
-    Assert.assertFalse(objectRegistry.delete("one"));
+    assertNull(objectRegistry.cacheForDAG("one", one));
+    assertEquals(one, objectRegistry.get("one"));
+    assertNull(objectRegistry.cacheForDAG("two", two_1));
+    assertNotNull(objectRegistry.cacheForSession("two", two_2));
+    assertNotEquals(two_1, objectRegistry.get("two"));
+    assertEquals(two_2, objectRegistry.get("two"));
+    assertTrue(objectRegistry.delete("one"));
+    assertFalse(objectRegistry.delete("one"));
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasicCRUD() {
     ObjectRegistry objectRegistry = new ObjectRegistryImpl();
     testCRUD(objectRegistry);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testClearCache() {
     ObjectRegistry objectRegistry = new ObjectRegistryImpl();
     testCRUD(objectRegistry);
@@ -61,12 +72,12 @@ public class TestObjectRegistry {
     objectRegistry.cacheForDAG(two, two);
 
     ((ObjectRegistryImpl)objectRegistry).clearCache(ObjectRegistryImpl.ObjectLifeCycle.VERTEX);
-    Assert.assertNull(objectRegistry.get(one));
-    Assert.assertNotNull(objectRegistry.get(two));
+    assertNull(objectRegistry.get(one));
+    assertNotNull(objectRegistry.get(two));
 
     objectRegistry.cacheForVertex(one, one);
     ((ObjectRegistryImpl)objectRegistry).clearCache(ObjectRegistryImpl.ObjectLifeCycle.DAG);
-    Assert.assertNotNull(objectRegistry.get(one));
-    Assert.assertNull(objectRegistry.get(two));
+    assertNotNull(objectRegistry.get(one));
+    assertNull(objectRegistry.get(two));
   }
 }

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/common/resources/TestMemoryDistributor.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/common/resources/TestMemoryDistributor.java
@@ -18,10 +18,12 @@
  */
 package org.apache.tez.runtime.common.resources;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.dag.api.InputDescriptor;
@@ -34,21 +36,23 @@ import org.apache.tez.runtime.api.MemoryUpdateCallback;
 import org.apache.tez.runtime.api.OutputContext;
 import org.apache.tez.runtime.api.ProcessorContext;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestMemoryDistributor {
 
   protected Configuration conf = new Configuration();
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf.setBoolean(TezConfiguration.TEZ_TASK_SCALE_MEMORY_ENABLED, true);
     conf.set(TezConfiguration.TEZ_TASK_SCALE_MEMORY_ALLOCATOR_CLASS,
         ScalingAllocator.class.getName());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testScalingNoProcessor() throws TezException {
     MemoryDistributor dist = new MemoryDistributor(2, 1, conf);
 
@@ -82,7 +86,8 @@ public class TestMemoryDistributor {
     assertEquals(1400, e3Callback.assigned);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testScalingNoProcessor2() throws TezException {
     // Real world values
     MemoryDistributor dist = new MemoryDistributor(2, 0, conf);
@@ -107,7 +112,8 @@ public class TestMemoryDistributor {
     assertEquals(88080384l, e2Callback.assigned);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testScalingProcessor() throws TezException {
     MemoryDistributor dist = new MemoryDistributor(2, 1, conf);
 
@@ -149,7 +155,8 @@ public class TestMemoryDistributor {
     assertTrue(e4Callback.assigned >= 1166 && e4Callback.assigned <= 1167);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testScalingDisabled() throws TezException {
     // Real world values
     Configuration conf = new Configuration(this.conf);
@@ -176,7 +183,8 @@ public class TestMemoryDistributor {
     assertEquals(144965632l, e2Callback.assigned);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testReserveFractionConfigured() throws TezException {
     Configuration conf = new Configuration(this.conf);
     conf.setDouble(TezConfiguration.TEZ_TASK_SCALE_MEMORY_RESERVE_FRACTION, 0.5d);

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/metrics/TestFileSystemStatisticUpdater.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/metrics/TestFileSystemStatisticUpdater.java
@@ -18,6 +18,9 @@
  */
 package org.apache.tez.runtime.metrics;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
@@ -29,11 +32,10 @@ import org.apache.tez.common.counters.FileSystemCounter;
 import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.common.counters.TezCounters;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,12 +52,12 @@ public class TestFileSystemStatisticUpdater {
   private static final String TEST_ROOT_DIR = "target" + Path.SEPARATOR +
       TestFileSystemStatisticUpdater.class.getName() + "-tmpDir";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     CONF.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEST_ROOT_DIR);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (dfsCluster != null) {
       dfsCluster.shutdown();
@@ -63,7 +65,7 @@ public class TestFileSystemStatisticUpdater {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     FileSystem.clearStatistics();
     try {
@@ -113,7 +115,7 @@ public class TestFileSystemStatisticUpdater {
 
   private void assertCounter(TezCounters counters, FileSystemCounter fsCounter, int value) {
     TezCounter counter = counters.findCounter(remoteFs.getScheme(), fsCounter);
-    Assert.assertNotNull(counter);
-    Assert.assertEquals(value, counter.getValue());
+    assertNotNull(counter);
+    assertEquals(value, counter.getValue());
   }
 }

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/metrics/TestTaskCounterUpdater.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/metrics/TestTaskCounterUpdater.java
@@ -18,13 +18,15 @@
  */
 package org.apache.tez.runtime.metrics;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.common.counters.TaskCounter;
 import org.apache.tez.common.counters.TezCounter;
 import org.apache.tez.common.counters.TezCounters;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,17 +46,18 @@ public class TestTaskCounterUpdater {
     TezCounter cpuCounter = assertCounter(counters, TaskCounter.CPU_MILLISECONDS);
 
     long oldVal = cpuCounter.getValue();
-    Assert.assertTrue(cpuCounter.getValue() > 0);
+    assertTrue(cpuCounter.getValue() > 0);
 
     updater.updateCounters();
     LOG.info("Counters (after second update): {}", counters);
-    Assert.assertTrue("Counter not updated, old=" + oldVal
-        + ", new=" + cpuCounter.getValue(), cpuCounter.getValue() > oldVal);
+    assertTrue(
+        cpuCounter.getValue() > oldVal,
+        "Counter not updated, old=" + oldVal + ", new=" + cpuCounter.getValue());
   }
 
   private TezCounter assertCounter(TezCounters counters, TaskCounter taskCounter) {
     TezCounter counter = counters.findCounter(taskCounter);
-    Assert.assertNotNull(counter);
+    assertNotNull(counter);
     return counter;
   }
 }

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/metrics/TestTaskCounterUpdater.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/metrics/TestTaskCounterUpdater.java
@@ -50,9 +50,7 @@ public class TestTaskCounterUpdater {
 
     updater.updateCounters();
     LOG.info("Counters (after second update): {}", counters);
-    assertTrue(
-        cpuCounter.getValue() > oldVal,
-        "Counter not updated, old=" + oldVal + ", new=" + cpuCounter.getValue());
+    assertTrue(cpuCounter.getValue() > oldVal, "Counter not updated, old=" + oldVal + ", new=" + cpuCounter.getValue());
   }
 
   private TezCounter assertCounter(TezCounters counters, TaskCounter taskCounter) {

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TaskExecutionTestHelpers.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TaskExecutionTestHelpers.java
@@ -18,8 +18,9 @@
  */
 package org.apache.tez.runtime.task;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.LinkedList;
@@ -52,7 +53,6 @@ import org.apache.tez.runtime.api.impl.TezEvent;
 import org.apache.tez.runtime.api.impl.TezHeartbeatRequest;
 import org.apache.tez.runtime.api.impl.TezHeartbeatResponse;
 
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -531,7 +531,7 @@ public final class TaskExecutionTestHelpers {
     if (diagnostics != null && diagnostics.startsWith("Node:")) {
       diagnosticsWithoutIP = diagnostics.substring(diagnostics.indexOf(" : ") + 3);
       String nodeIp = diagnostics.substring(5, diagnostics.indexOf(" : "));
-      Assert.assertFalse(nodeIp.isEmpty());
+      assertFalse(nodeIp.isEmpty());
     }
 
     return diagnosticsWithoutIP;

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestContainerExecution.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestContainerExecution.java
@@ -18,11 +18,12 @@
  */
 package org.apache.tez.runtime.task;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
@@ -34,11 +35,13 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestContainerExecution {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGetTaskShouldDie() throws InterruptedException, ExecutionException {
     ListeningExecutorService executor = null;
     try {

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestTaskExecution2.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestTaskExecution2.java
@@ -19,11 +19,11 @@
 package org.apache.tez.runtime.task;
 
 import static org.apache.tez.runtime.task.TaskExecutionTestHelpers.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Condition;
@@ -84,9 +85,10 @@ import com.google.common.collect.Multimap;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,17 +119,18 @@ public class TestTaskExecution2 {
     }
   }
 
-  @Before
+  @BeforeEach
   public void reset() {
     TestProcessor.reset();
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     taskExecutor.shutdownNow();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSingleSuccessfulTask() throws IOException, InterruptedException, TezException,
       ExecutionException {
     ListeningExecutorService executor = null;
@@ -156,7 +159,8 @@ public class TestTaskExecution2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleSuccessfulTasks() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -209,7 +213,8 @@ public class TestTaskExecution2 {
 
 
   // test task failed due to exception in Processor
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFailedTaskTezException() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -247,7 +252,8 @@ public class TestTaskExecution2 {
 
 
   // Test task failed due to Processor class not found
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFailedTask2() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -283,7 +289,8 @@ public class TestTaskExecution2 {
   }
 
   // test task failed due to exception in Processor
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFailedTaskIOException() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -321,7 +328,8 @@ public class TestTaskExecution2 {
   }
 
   // test that makes sure errors aren't reported when the container is already failing
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testIgnoreErrorsDuringFailure() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -357,7 +365,8 @@ public class TestTaskExecution2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testHeartbeatException() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -397,7 +406,8 @@ public class TestTaskExecution2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testHeartbeatShouldDie() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -438,7 +448,8 @@ public class TestTaskExecution2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSignalDeprecatedFatalErrorAndLoop() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -479,7 +490,8 @@ public class TestTaskExecution2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSignalFatalAndThrow() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -515,7 +527,8 @@ public class TestTaskExecution2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSignalNonFatalAndThrow() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -551,7 +564,8 @@ public class TestTaskExecution2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskSelfKill() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -588,7 +602,8 @@ public class TestTaskExecution2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskKilled() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -624,7 +639,8 @@ public class TestTaskExecution2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testKilledAfterComplete() throws IOException, InterruptedException, TezException,
       ExecutionException {
 
@@ -714,8 +730,8 @@ public class TestTaskExecution2 {
 
     // If Target <=0, assert counter count is exactly 0
     if (minTaskCounterCount <= 0) {
-      assertEquals(tezCounters.toString(), 0, numTaskCounters);
-      assertEquals(tezCounters.toString(), 0, numFsCounters);
+      assertEquals(0, numTaskCounters, tezCounters.toString());
+      assertEquals(0, numFsCounters, tezCounters.toString());
     } else {
       assertTrue(numTaskCounters >= minTaskCounterCount);
       assertTrue(numFsCounters >= minFsCounterCount);

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestTaskReporter.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestTaskReporter.java
@@ -19,6 +19,11 @@
 package org.apache.tez.runtime.task;
 
 import static org.apache.tez.dag.api.TezConfiguration.TEZ_TASK_LOCAL_FS_WRITE_LIMIT_BYTES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -36,6 +41,7 @@ import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -61,8 +67,8 @@ import org.apache.tez.runtime.api.impl.TezHeartbeatResponse;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -73,7 +79,8 @@ public class TestTaskReporter {
   private static final File TEST_DIR =
       new File(System.getProperty("test.build.data"), TestTaskReporter.class.getName()).getAbsoluteFile();
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testContinuousHeartbeatsOnMaxEvents() throws Exception {
 
     final Object lock = new Object();
@@ -133,7 +140,8 @@ public class TestTaskReporter {
 
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testEventThrottling() throws Exception {
     TezTaskAttemptID mockTaskAttemptId = mock(TezTaskAttemptID.class);
     LogicalIOProcessorRuntimeTask mockTask = mock(LogicalIOProcessorRuntimeTask.class);
@@ -158,7 +166,7 @@ public class TestTaskReporter {
     ExecutorService executor = Executors.newSingleThreadExecutor();
     try {
       Future<Boolean> result = executor.submit(heartbeatCallable);
-      Assert.assertFalse(result.get());
+      assertFalse(result.get());
     } finally {
       executor.shutdownNow();
     }
@@ -166,11 +174,12 @@ public class TestTaskReporter {
     ArgumentCaptor<TezHeartbeatRequest> captor = ArgumentCaptor.forClass(TezHeartbeatRequest.class);
     verify(mockUmbilical, times(2)).heartbeat(captor.capture());
     TezHeartbeatRequest req = captor.getValue();
-    Assert.assertEquals(2, req.getRequestId());
-    Assert.assertEquals(1, req.getMaxEvents());
+    assertEquals(2, req.getRequestId());
+    assertEquals(1, req.getMaxEvents());
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testStatusUpdateAfterInitializationAndCounterFlag() {
     TezTaskAttemptID mockTaskAttemptId = mock(TezTaskAttemptID.class);
     LogicalIOProcessorRuntimeTask mockTask = mock(LogicalIOProcessorRuntimeTask.class);
@@ -201,10 +210,10 @@ public class TestTaskReporter {
     verify(mockTask, times(0)).getAndClearProgressNotification();
     verify(mockTask, times(0)).getTaskStatistics();
     verify(mockTask, times(0)).getCounters();
-    Assert.assertEquals(0, event.getProgress(), 0);
-    Assert.assertEquals(false, event.getProgressNotified());
-    Assert.assertNull(event.getCounters());
-    Assert.assertNull(event.getStatistics());
+    assertEquals(0, event.getProgress(), 0);
+    assertFalse(event.getProgressNotified());
+    assertNull(event.getCounters());
+    assertNull(event.getStatistics());
 
     // task is initialized - progress obtained but not counters since flag is false
     doReturn(true).when(mockTask).hasInitialized();
@@ -214,10 +223,10 @@ public class TestTaskReporter {
     verify(mockTask, times(1)).getAndClearProgressNotification();
     verify(mockTask, times(0)).getTaskStatistics();
     verify(mockTask, times(0)).getCounters();
-    Assert.assertEquals(progress, event.getProgress(), 0);
-    Assert.assertEquals(progressNotified, event.getProgressNotified());
-    Assert.assertNull(event.getCounters());
-    Assert.assertNull(event.getStatistics());
+    assertEquals(progress, event.getProgress(), 0);
+    assertEquals(progressNotified, event.getProgressNotified());
+    assertNull(event.getCounters());
+    assertNull(event.getStatistics());
 
     // task is initialized - progress obtained and also counters since flag is true
     progressNotified = true;
@@ -229,10 +238,10 @@ public class TestTaskReporter {
     verify(mockTask, times(2)).getAndClearProgressNotification();
     verify(mockTask, times(1)).getTaskStatistics();
     verify(mockTask, times(1)).getCounters();
-    Assert.assertEquals(progress, event.getProgress(), 0);
-    Assert.assertEquals(progressNotified, event.getProgressNotified());
-    Assert.assertEquals(counters, event.getCounters());
-    Assert.assertEquals(stats, event.getStatistics());
+    assertEquals(progress, event.getProgress(), 0);
+    assertEquals(progressNotified, event.getProgressNotified());
+    assertEquals(counters, event.getCounters());
+    assertEquals(stats, event.getStatistics());
 
   }
 
@@ -262,9 +271,9 @@ public class TestTaskReporter {
 
     try {
       lio1.checkTaskLimits();
-      Assert.fail("Expected to throw LocalWriteLimitException");
+      fail("Expected to throw LocalWriteLimitException");
     } catch (LocalWriteLimitException localWriteLimitException) {
-      Assert.assertTrue(localWriteLimitException.getMessage().contains("Too much write to local file system"));
+      assertTrue(localWriteLimitException.getMessage().contains("Too much write to local file system"));
     }
   }
 

--- a/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestTezTaskRunner2.java
+++ b/tez-runtime-internals/src/test/java/org/apache/tez/runtime/task/TestTezTaskRunner2.java
@@ -18,10 +18,12 @@
  */
 package org.apache.tez.runtime.task;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -38,13 +40,14 @@ import org.apache.tez.runtime.api.impl.InputSpec;
 import org.apache.tez.runtime.api.impl.OutputSpec;
 import org.apache.tez.runtime.api.impl.TaskSpec;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 
 public class TestTezTaskRunner2 {
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTaskConfUsage() throws Exception {
     Configuration conf = new Configuration(false);
     conf.set("global", "global1");
@@ -68,9 +71,9 @@ public class TestTezTaskRunner2 {
         localDirs, taskSpec, 1, null, null, null, mock(TaskReporter.class), null, null, "pid",
         null, 1000, false, new DefaultHadoopShim(), sharedExecutor);
 
-    Assert.assertEquals("global1", taskRunner2.task.getTaskConf().get("global"));
-    Assert.assertEquals("task1", taskRunner2.task.getTaskConf().get("global_override"));
-    Assert.assertEquals("task1", taskRunner2.task.getTaskConf().get("task"));
+    assertEquals("global1", taskRunner2.task.getTaskConf().get("global"));
+    assertEquals("task1", taskRunner2.task.getTaskConf().get("global_override"));
+    assertEquals("task1", taskRunner2.task.getTaskConf().get("task"));
     sharedExecutor.shutdownNow();
   }
 

--- a/tez-runtime-library/pom.xml
+++ b/tez-runtime-library/pom.xml
@@ -58,8 +58,8 @@
      <artifactId>protobuf-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestFairShuffleVertexManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestFairShuffleVertexManager.java
@@ -85,8 +85,8 @@ public class TestFairShuffleVertexManager
     verify(mockContext, times(1)).vertexReconfigurationPlanned(); // Tez not notified of reconfig
 
     assertFalse(manager.config.isAutoParallelismEnabled());
-    assertEquals(manager.config.getDesiredTaskInputDataSize(),
-        FairShuffleVertexManager.TEZ_FAIR_SHUFFLE_VERTEX_MANAGER_DESIRED_TASK_INPUT_SIZE_DEFAULT);
+    assertEquals(FairShuffleVertexManager.TEZ_FAIR_SHUFFLE_VERTEX_MANAGER_DESIRED_TASK_INPUT_SIZE_DEFAULT,
+        manager.config.getDesiredTaskInputDataSize());
     assertEquals(FairShuffleVertexManager.TEZ_FAIR_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION_DEFAULT,
         manager.config.getMinFraction());
     assertEquals(FairShuffleVertexManager.TEZ_FAIR_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION_DEFAULT,

--- a/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestFairShuffleVertexManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestFairShuffleVertexManager.java
@@ -18,6 +18,11 @@
  */
 package org.apache.tez.dag.library.vertexmanager;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;
@@ -31,6 +36,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.dag.api.EdgeManagerPlugin;
@@ -49,15 +55,16 @@ import org.apache.tez.runtime.api.events.VertexManagerEvent;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class TestFairShuffleVertexManager
     extends TestShuffleVertexManagerUtils {
   List<TaskAttemptIdentifier> emptyCompletions = null;
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAutoParallelismConfig() throws Exception {
     FairShuffleVertexManager manager;
 
@@ -69,24 +76,25 @@ public class TestFairShuffleVertexManager
 
     manager = createManager(null, mockContext, null, 0.5f);
     verify(mockContext, times(1)).vertexReconfigurationPlanned(); // Tez notified of reconfig
-    Assert.assertTrue(manager.config.isAutoParallelismEnabled());
-    Assert.assertTrue(manager.config.getDesiredTaskInputDataSize() == 1000l * MB);
-    Assert.assertTrue(manager.config.getMinFraction() == 0.25f);
-    Assert.assertTrue(manager.config.getMaxFraction() == 0.5f);
+    assertTrue(manager.config.isAutoParallelismEnabled());
+    assertEquals(manager.config.getDesiredTaskInputDataSize(), 1000l * MB);
+    assertEquals(0.25f, manager.config.getMinFraction());
+    assertEquals(0.5f, manager.config.getMaxFraction());
 
     manager = createManager(null, mockContext, null, null, null, null);
     verify(mockContext, times(1)).vertexReconfigurationPlanned(); // Tez not notified of reconfig
 
-    Assert.assertTrue(!manager.config.isAutoParallelismEnabled());
-    Assert.assertTrue(manager.config.getDesiredTaskInputDataSize() ==
+    assertFalse(manager.config.isAutoParallelismEnabled());
+    assertEquals(manager.config.getDesiredTaskInputDataSize(),
         FairShuffleVertexManager.TEZ_FAIR_SHUFFLE_VERTEX_MANAGER_DESIRED_TASK_INPUT_SIZE_DEFAULT);
-    Assert.assertTrue(manager.config.getMinFraction() ==
-        FairShuffleVertexManager.TEZ_FAIR_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION_DEFAULT);
-    Assert.assertTrue(manager.config.getMaxFraction() ==
-        FairShuffleVertexManager.TEZ_FAIR_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION_DEFAULT);
+    assertEquals(FairShuffleVertexManager.TEZ_FAIR_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION_DEFAULT,
+        manager.config.getMinFraction());
+    assertEquals(FairShuffleVertexManager.TEZ_FAIR_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION_DEFAULT,
+        manager.config.getMaxFraction());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidSetup() {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
@@ -102,15 +110,16 @@ public class TestFairShuffleVertexManager
       manager = createFairShuffleVertexManager(conf, mockContext,
           FairRoutingType.FAIR_PARALLELISM, 1000 * MB, 0.001f, 0.001f);
       manager.onVertexStarted(emptyCompletions);
-      Assert.assertFalse(true);
+      fail();
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "Having more than one destination task process same partition(s) " +
               "only works with one bipartite source."));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testReduceSchedulingWithPartitionStats() throws Exception {
     final int numScatherAndGatherSourceTasks = 300;
     final Map<String, EdgeManagerPlugin> newEdgeManagers =
@@ -124,7 +133,7 @@ public class TestFairShuffleVertexManager
 
     // The first destination task fetches two partitions from all source tasks.
     // Thus the # of inputs == # of source tasks * 2 merged partitions
-    Assert.assertEquals(numScatherAndGatherSourceTasks * 2,
+    assertEquals(numScatherAndGatherSourceTasks * 2,
         edgeManager.getNumDestinationTaskPhysicalInputs(0));
     for (int sourceTaskIndex = 0;
         sourceTaskIndex < numScatherAndGatherSourceTasks; sourceTaskIndex++) {
@@ -132,14 +141,14 @@ public class TestFairShuffleVertexManager
         if (j == 0) {
           EdgeManagerPluginOnDemand.CompositeEventRouteMetadata routeMetadata =
               edgeManager.routeCompositeDataMovementEventToDestination(sourceTaskIndex, 0);
-          Assert.assertEquals(2, routeMetadata.getCount());
-          Assert.assertEquals(0, routeMetadata.getSource());
-          Assert.assertEquals(sourceTaskIndex*2, routeMetadata.getTarget());
+          assertEquals(2, routeMetadata.getCount());
+          assertEquals(0, routeMetadata.getSource());
+          assertEquals(sourceTaskIndex*2, routeMetadata.getTarget());
         } else {
           EdgeManagerPluginOnDemand.EventRouteMetadata routeMetadata =
               edgeManager.routeInputSourceTaskFailedEventToDestination(sourceTaskIndex, 0);
-          Assert.assertEquals(2, routeMetadata.getNumEvents());
-          Assert.assertArrayEquals(
+          assertEquals(2, routeMetadata.getNumEvents());
+          assertArrayEquals(
               new int[]{0 + sourceTaskIndex * 2, 1 + sourceTaskIndex * 2},
               routeMetadata.getTargetIndices());
         }
@@ -147,7 +156,8 @@ public class TestFairShuffleVertexManager
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFairSchedulingWithPartitionStats() throws Exception {
     final int numScatherAndGatherSourceTasks = 300;
     final Map<String, EdgeManagerPlugin> newEdgeManagers =
@@ -165,7 +175,7 @@ public class TestFairShuffleVertexManager
 
     // The first destination task fetches two partitions from all source tasks.
     // Thus the # of inputs == # of source tasks * 2 merged partitions
-    Assert.assertEquals(numScatherAndGatherSourceTasks * 2,
+    assertEquals(numScatherAndGatherSourceTasks * 2,
         edgeManager.getNumDestinationTaskPhysicalInputs(0));
     for (int sourceTaskIndex = 0; sourceTaskIndex < numScatherAndGatherSourceTasks;
         sourceTaskIndex++) {
@@ -173,14 +183,14 @@ public class TestFairShuffleVertexManager
         if (j == 0) {
           EdgeManagerPluginOnDemand.CompositeEventRouteMetadata routeMetadata =
               edgeManager.routeCompositeDataMovementEventToDestination(sourceTaskIndex, 0);
-          Assert.assertEquals(2, routeMetadata.getCount());
-          Assert.assertEquals(0, routeMetadata.getSource());
-          Assert.assertEquals(sourceTaskIndex*2, routeMetadata.getTarget());
+          assertEquals(2, routeMetadata.getCount());
+          assertEquals(0, routeMetadata.getSource());
+          assertEquals(sourceTaskIndex*2, routeMetadata.getTarget());
         } else {
           EdgeManagerPluginOnDemand.EventRouteMetadata routeMetadata =
               edgeManager.routeInputSourceTaskFailedEventToDestination(sourceTaskIndex, 0);
-          Assert.assertEquals(2, routeMetadata.getNumEvents());
-          Assert.assertArrayEquals(
+          assertEquals(2, routeMetadata.getNumEvents());
+          assertArrayEquals(
               new int[]{0 + sourceTaskIndex * 2, 1 + sourceTaskIndex * 2},
               routeMetadata.getTargetIndices());
         }
@@ -189,26 +199,26 @@ public class TestFairShuffleVertexManager
 
     // The 2nd destination task fetches one partition from the first half of
     // source tasks.
-    Assert.assertEquals(numScatherAndGatherSourceTasks / 2,
+    assertEquals(numScatherAndGatherSourceTasks / 2,
         edgeManager.getNumDestinationTaskPhysicalInputs(1));
     for (int j = 0; j < 2; j++) {
       if (j == 0) {
         EdgeManagerPluginOnDemand.CompositeEventRouteMetadata routeMetadata =
             edgeManager.routeCompositeDataMovementEventToDestination(0, 1);
-        Assert.assertEquals(1, routeMetadata.getCount());
-        Assert.assertEquals(2, routeMetadata.getSource());
-        Assert.assertEquals(0, routeMetadata.getTarget());
+        assertEquals(1, routeMetadata.getCount());
+        assertEquals(2, routeMetadata.getSource());
+        assertEquals(0, routeMetadata.getTarget());
       } else {
         EdgeManagerPluginOnDemand.EventRouteMetadata routeMetadata =
             edgeManager.routeInputSourceTaskFailedEventToDestination(0, 1);
-        Assert.assertEquals(1, routeMetadata.getNumEvents());
-        Assert.assertEquals(0, routeMetadata.getTargetIndices()[0]);
+        assertEquals(1, routeMetadata.getNumEvents());
+        assertEquals(0, routeMetadata.getTargetIndices()[0]);
       }
     }
 
     // The 3rd destination task fetches one partition from 2nd half of
     // source tasks.
-    Assert.assertEquals(numScatherAndGatherSourceTasks / 2,
+    assertEquals(numScatherAndGatherSourceTasks / 2,
         edgeManager.getNumDestinationTaskPhysicalInputs(2));
     for (int sourceTaskIndex = numScatherAndGatherSourceTasks / 2;
         sourceTaskIndex < numScatherAndGatherSourceTasks; sourceTaskIndex++) {
@@ -216,23 +226,24 @@ public class TestFairShuffleVertexManager
         if (j == 0) {
           EdgeManagerPluginOnDemand.CompositeEventRouteMetadata routeMetadata =
               edgeManager.routeCompositeDataMovementEventToDestination(sourceTaskIndex, 2);
-          Assert.assertEquals(1, routeMetadata.getCount());
-          Assert.assertEquals(2, routeMetadata.getSource());
-          Assert.assertEquals(
+          assertEquals(1, routeMetadata.getCount());
+          assertEquals(2, routeMetadata.getSource());
+          assertEquals(
               sourceTaskIndex - numScatherAndGatherSourceTasks / 2,
               routeMetadata.getTarget());
         } else {
           EdgeManagerPluginOnDemand.EventRouteMetadata routeMetadata =
               edgeManager.routeInputSourceTaskFailedEventToDestination(sourceTaskIndex, 2);
-          Assert.assertEquals(1, routeMetadata.getNumEvents());
-          Assert.assertEquals(sourceTaskIndex - numScatherAndGatherSourceTasks / 2,
+          assertEquals(1, routeMetadata.getNumEvents());
+          assertEquals(sourceTaskIndex - numScatherAndGatherSourceTasks / 2,
               routeMetadata.getTargetIndices()[0]);
         }
       }
     }
   }
 
-  @Test(timeout = 500000)
+  @Test
+  @Timeout(value = 500000, unit = TimeUnit.MILLISECONDS)
   public void testOverflow() throws Exception {
     final int numScatherAndGatherSourceTasks = 30000;
     final Map<String, EdgeManagerPlugin> newEdgeManagers =
@@ -317,21 +328,21 @@ public class TestFairShuffleVertexManager
     manager = createFairShuffleVertexManager(conf, mockContext,
         fairRoutingType, 1000 * MB, 0.001f, 0.001f);
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertTrue(manager.bipartiteSources == 1);
+    assertEquals(1, manager.bipartiteSources);
 
     manager.onVertexStateUpdated(new VertexStateUpdate(r1,
         VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(m2,
         VertexState.CONFIGURED));
 
-    Assert.assertEquals(numOfTasksInDestination,
+    assertEquals(numOfTasksInDestination,
         manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(numOfTasksInr1,
+    assertEquals(numOfTasksInr1,
         manager.totalNumBipartiteSourceTasks);
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
 
-    Assert.assertTrue(manager.pendingTasks.size() == numOfTasksInDestination); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == numOfTasksInr1);
+    assertEquals(numOfTasksInDestination, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(manager.totalNumBipartiteSourceTasks, numOfTasksInr1);
 
 
     for (int i = 0; i < numCompletedEvents; i++) {
@@ -343,28 +354,28 @@ public class TestFairShuffleVertexManager
 
     //Send an event for m2.
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(m2, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == numOfTasksInDestination); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == numOfTasksInr1);
+    assertEquals(numOfTasksInDestination, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(manager.totalNumBipartiteSourceTasks, numOfTasksInr1);
 
     //Send an event for m3.
     manager.onVertexStateUpdated(new VertexStateUpdate(m3, VertexState.CONFIGURED));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(m3, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 0); // all tasks scheduled
-    Assert.assertTrue(scheduledTasks.size() == expectedScheduledTasks);
+    assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
+    assertEquals(scheduledTasks.size(), expectedScheduledTasks);
 
-    Assert.assertEquals(1, newEdgeManagers.size());
+    assertEquals(1, newEdgeManagers.size());
     EdgeManagerPluginOnDemand edgeManager =
         (EdgeManagerPluginOnDemand)newEdgeManagers.values().iterator().next();
     // For each source task, there are 3 outputs,
     // the same as original number of partitions.
     for (int i = 0; i < numOfTasksInr1; i++) {
-      Assert.assertEquals(numOfTasksInDestination,
+      assertEquals(numOfTasksInDestination,
           edgeManager.getNumSourceTaskPhysicalOutputs(0));
     }
 
     for (int sourceTaskIndex = 0; sourceTaskIndex < numOfTasksInr1;
         sourceTaskIndex++) {
-      Assert.assertEquals(expectedNumDestinationConsumerTasks,
+      assertEquals(expectedNumDestinationConsumerTasks,
           edgeManager.getNumDestinationConsumerTasks(sourceTaskIndex));
     }
   }

--- a/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestInputReadyVertexManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestInputReadyVertexManager.java
@@ -18,11 +18,14 @@
  */
 package org.apache.tez.dag.library.vertexmanager;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerId;
@@ -39,9 +42,9 @@ import org.apache.tez.runtime.api.TaskAttemptIdentifier;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
@@ -52,12 +55,13 @@ public class TestInputReadyVertexManager {
   @Captor
   ArgumentCaptor<List<ScheduleTaskRequest>> requestCaptor;
 
-  @Before
+  @BeforeEach
   public void init() {
     MockitoAnnotations.initMocks(this);
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasicScatterGather() throws Exception {
     HashMap<String, EdgeProperty> mockInputVertices =
         new HashMap<String, EdgeProperty>();
@@ -94,10 +98,11 @@ public class TestInputReadyVertexManager {
     manager.onSourceTaskCompleted(
         TestShuffleVertexManager.createTaskAttemptIdentifier(mockSrcVertexId1, 2));
     verify(mockContext, times(1)).scheduleTasks(requestCaptor.capture());
-    Assert.assertEquals(2, requestCaptor.getValue().size());
+    assertEquals(2, requestCaptor.getValue().size());
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasicOneToOne() throws Exception {
     HashMap<String, EdgeProperty> mockInputVertices =
         new HashMap<String, EdgeProperty>();
@@ -128,33 +133,34 @@ public class TestInputReadyVertexManager {
     manager.onVertexStarted(Collections.singletonList(
         TestShuffleVertexManager.createTaskAttemptIdentifier(mockSrcVertexId1, 0)));
     verify(mockContext, times(1)).scheduleTasks(requestCaptor.capture());
-    Assert.assertEquals(1, requestCaptor.getValue().size());
-    Assert.assertEquals(0, requestCaptor.getValue().get(0).getTaskIndex());
-    Assert.assertEquals(mockSrcVertexId1, requestCaptor.getValue().get(0)
+    assertEquals(1, requestCaptor.getValue().size());
+    assertEquals(0, requestCaptor.getValue().get(0).getTaskIndex());
+    assertEquals(mockSrcVertexId1, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getVertexName());
-    Assert.assertEquals(0, requestCaptor.getValue().get(0)
+    assertEquals(0, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getTaskIndex());
     manager.onSourceTaskCompleted(
         TestShuffleVertexManager.createTaskAttemptIdentifier(mockSrcVertexId1, 1));
     verify(mockContext, times(2)).scheduleTasks(requestCaptor.capture());
-    Assert.assertEquals(1, requestCaptor.getValue().size());
-    Assert.assertEquals(1, requestCaptor.getValue().get(0).getTaskIndex());
-    Assert.assertEquals(mockSrcVertexId1, requestCaptor.getValue().get(0)
+    assertEquals(1, requestCaptor.getValue().size());
+    assertEquals(1, requestCaptor.getValue().get(0).getTaskIndex());
+    assertEquals(mockSrcVertexId1, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getVertexName());
-    Assert.assertEquals(1, requestCaptor.getValue().get(0)
+    assertEquals(1, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getTaskIndex());
     manager.onSourceTaskCompleted(
         TestShuffleVertexManager.createTaskAttemptIdentifier(mockSrcVertexId1, 2));
     verify(mockContext, times(3)).scheduleTasks(requestCaptor.capture());
-    Assert.assertEquals(1, requestCaptor.getValue().size());
-    Assert.assertEquals(2, requestCaptor.getValue().get(0).getTaskIndex());
-    Assert.assertEquals(mockSrcVertexId1, requestCaptor.getValue().get(0)
+    assertEquals(1, requestCaptor.getValue().size());
+    assertEquals(2, requestCaptor.getValue().get(0).getTaskIndex());
+    assertEquals(mockSrcVertexId1, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getVertexName());
-    Assert.assertEquals(2, requestCaptor.getValue().get(0)
+    assertEquals(2, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getTaskIndex());
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDelayedConfigureOneToOne() throws Exception {
     HashMap<String, EdgeProperty> mockInputVertices =
         new HashMap<String, EdgeProperty>();
@@ -195,15 +201,16 @@ public class TestInputReadyVertexManager {
     manager.onSourceTaskCompleted(
         TestShuffleVertexManager.createTaskAttemptIdentifier(mockSrcVertexId1, 2));
     verify(mockContext, times(3)).scheduleTasks(requestCaptor.capture());
-    Assert.assertEquals(1, requestCaptor.getValue().size());
-    Assert.assertEquals(2, requestCaptor.getValue().get(0).getTaskIndex());
-    Assert.assertEquals(mockSrcVertexId1, requestCaptor.getValue().get(0)
+    assertEquals(1, requestCaptor.getValue().size());
+    assertEquals(2, requestCaptor.getValue().get(0).getTaskIndex());
+    assertEquals(mockSrcVertexId1, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getVertexName());
-    Assert.assertEquals(2, requestCaptor.getValue().get(0)
+    assertEquals(2, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getTaskIndex());
   }
 
-  @Test (timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testComplex() throws Exception {
     HashMap<String, EdgeProperty> mockInputVertices =
         new HashMap<String, EdgeProperty>();
@@ -271,7 +278,7 @@ public class TestInputReadyVertexManager {
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     try {
       manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-      Assert.assertTrue("Should have exception", false);
+      fail("Should have exception");
     } catch (TezUncheckedException e) {
       e.getMessage().contains("1-1 source vertices must have identical concurrency");
     }
@@ -303,21 +310,21 @@ public class TestInputReadyVertexManager {
     manager.onSourceTaskCompleted(
         TestShuffleVertexManager.createTaskAttemptIdentifier(mockSrcVertexId1, 2)); // v1 done
     verify(mockContext, times(1)).scheduleTasks(requestCaptor.capture());
-    Assert.assertEquals(1, requestCaptor.getValue().size());
-    Assert.assertEquals(0, requestCaptor.getValue().get(0).getTaskIndex());
-    Assert.assertEquals(mockSrcVertexId3, requestCaptor.getValue().get(0)
+    assertEquals(1, requestCaptor.getValue().size());
+    assertEquals(0, requestCaptor.getValue().get(0).getTaskIndex());
+    assertEquals(mockSrcVertexId3, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getVertexName());
-    Assert.assertEquals(0, requestCaptor.getValue().get(0)
+    assertEquals(0, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getTaskIndex()); // affinity to last completion
     // 1-1 completion triggers since other 1-1 is done
     manager.onSourceTaskCompleted(
         TestShuffleVertexManager.createTaskAttemptIdentifier(mockSrcVertexId3, 1));
     verify(mockContext, times(2)).scheduleTasks(requestCaptor.capture());
-    Assert.assertEquals(1, requestCaptor.getValue().size());
-    Assert.assertEquals(1, requestCaptor.getValue().get(0).getTaskIndex());
-    Assert.assertEquals(mockSrcVertexId3, requestCaptor.getValue().get(0)
+    assertEquals(1, requestCaptor.getValue().size());
+    assertEquals(1, requestCaptor.getValue().get(0).getTaskIndex());
+    assertEquals(mockSrcVertexId3, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getVertexName());
-    Assert.assertEquals(1, requestCaptor.getValue().get(0)
+    assertEquals(1, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getTaskIndex()); // affinity to last completion
     // 1-1 completion does not trigger since other 1-1 is not done
     manager.onSourceTaskCompleted(
@@ -327,11 +334,11 @@ public class TestInputReadyVertexManager {
     manager.onSourceTaskCompleted(
         TestShuffleVertexManager.createTaskAttemptIdentifier(mockSrcVertexId2, 2));
     verify(mockContext, times(3)).scheduleTasks(requestCaptor.capture());
-    Assert.assertEquals(1, requestCaptor.getValue().size());
-    Assert.assertEquals(2, requestCaptor.getValue().get(0).getTaskIndex());
-    Assert.assertEquals(mockSrcVertexId2, requestCaptor.getValue().get(0)
+    assertEquals(1, requestCaptor.getValue().size());
+    assertEquals(2, requestCaptor.getValue().get(0).getTaskIndex());
+    assertEquals(mockSrcVertexId2, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getVertexName());
-    Assert.assertEquals(2, requestCaptor.getValue().get(0)
+    assertEquals(2, requestCaptor.getValue().get(0)
         .getTaskLocationHint().getAffinitizedTask().getTaskIndex()); // affinity to last completion
 
     // no more starts

--- a/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestShuffleVertexManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestShuffleVertexManager.java
@@ -18,6 +18,9 @@
  */
 package org.apache.tez.dag.library.vertexmanager;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;
@@ -33,6 +36,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.common.ReflectionUtils;
@@ -45,15 +49,16 @@ import org.apache.tez.runtime.api.events.VertexManagerEvent;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class TestShuffleVertexManager extends TestShuffleVertexManagerUtils {
 
   List<TaskAttemptIdentifier> emptyCompletions = null;
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLargeDataSize() throws IOException {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
@@ -75,7 +80,7 @@ public class TestShuffleVertexManager extends TestShuffleVertexManagerUtils {
     manager = createManager(conf, mockContext, 0.1f, 0.1f);
     verify(mockContext, times(1)).vertexReconfigurationPlanned(); // Tez notified of reconfig
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertTrue(manager.pendingTasks.size() == 4); // no tasks scheduled
+    assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
     manager.onVertexManagerEventReceived(vmEvent);
 
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
@@ -87,15 +92,15 @@ public class TestShuffleVertexManager extends TestShuffleVertexManagerUtils {
     verify(mockContext, times(0)).doneReconfiguringVertex();
     // trigger scheduling
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 4);
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
     verify(mockContext, times(0)).reconfigureVertex(anyInt(), any
         (VertexLocationHint.class), anyMap());
     verify(mockContext, times(1)).doneReconfiguringVertex(); // reconfig done
-    Assert.assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
-    Assert.assertEquals(4, scheduledTasks.size());
+    assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
+    assertEquals(4, scheduledTasks.size());
     // TODO TEZ-1714 locking verify(mockContext, times(2)).vertexManagerDone(); // notified after scheduling all tasks
-    Assert.assertEquals(2, manager.numBipartiteSourceTasksCompleted);
-    Assert.assertEquals(5000L, manager.completedSourceTasksOutputSize);
+    assertEquals(2, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(5000L, manager.completedSourceTasksOutputSize);
     scheduledTasks.clear();
 
     // Ensure long overflow doesn't reduce mistakenly
@@ -106,38 +111,38 @@ public class TestShuffleVertexManager extends TestShuffleVertexManagerUtils {
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(4, manager.totalNumBipartiteSourceTasks);
+    assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
     // task completion from non-bipartite stage does nothing
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId3, 0));
-    Assert.assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(4, manager.totalNumBipartiteSourceTasks);
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
     // First source 1 task completes
     vmEvent = getVertexManagerEvent(null, 0L, mockSrcVertexId1);
     manager.onVertexManagerEventReceived(vmEvent);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 0));
-    Assert.assertEquals(4, manager.pendingTasks.size());
-    Assert.assertEquals(0, scheduledTasks.size()); // no tasks scheduled
-    Assert.assertEquals(1, manager.numBipartiteSourceTasksCompleted);
-    Assert.assertEquals(1, manager.numVertexManagerEventsReceived);
-    Assert.assertEquals(0L, manager.completedSourceTasksOutputSize);
+    assertEquals(4, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size()); // no tasks scheduled
+    assertEquals(1, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(1, manager.numVertexManagerEventsReceived);
+    assertEquals(0L, manager.completedSourceTasksOutputSize);
     // Second source 1 task completes
     vmEvent = getVertexManagerEvent(null, 0L, mockSrcVertexId1);
     manager.onVertexManagerEventReceived(vmEvent);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 1));
-    Assert.assertEquals(4, manager.pendingTasks.size());
-    Assert.assertEquals(0, scheduledTasks.size()); // no tasks scheduled
-    Assert.assertEquals(2, manager.numBipartiteSourceTasksCompleted);
-    Assert.assertEquals(0L, manager.completedSourceTasksOutputSize);
+    assertEquals(4, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size()); // no tasks scheduled
+    assertEquals(2, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(0L, manager.completedSourceTasksOutputSize);
     // First source 2 task completes
     vmEvent = getVertexManagerEvent(null, Long.MAX_VALUE >> 1 , mockSrcVertexId2);
     manager.onVertexManagerEventReceived(vmEvent);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 0));
-    Assert.assertEquals(4, manager.pendingTasks.size());
-    Assert.assertEquals(0, scheduledTasks.size()); // no tasks scheduled
-    Assert.assertEquals(3, manager.numBipartiteSourceTasksCompleted);
-    Assert.assertEquals(Long.MAX_VALUE >> 1, manager.completedSourceTasksOutputSize);
+    assertEquals(4, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size()); // no tasks scheduled
+    assertEquals(3, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(Long.MAX_VALUE >> 1, manager.completedSourceTasksOutputSize);
     // Second source 2 task completes
     vmEvent = getVertexManagerEvent(null, Long.MAX_VALUE >> 1 , mockSrcVertexId2);
     manager.onVertexManagerEventReceived(vmEvent);
@@ -145,14 +150,14 @@ public class TestShuffleVertexManager extends TestShuffleVertexManagerUtils {
     // Auto-reduce is triggered
     verify(mockContext, times(1)).reconfigureVertex(anyInt(), any(), anyMap());
     verify(mockContext, times(1)).reconfigureVertex(eq(2), any(), anyMap());
-    Assert.assertEquals(2, newEdgeManagers.size());
-    Assert.assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
-    Assert.assertEquals(2, scheduledTasks.size());
-    Assert.assertTrue(scheduledTasks.contains(new Integer(0)));
-    Assert.assertTrue(scheduledTasks.contains(new Integer(1)));
-    Assert.assertEquals(4, manager.numBipartiteSourceTasksCompleted);
-    Assert.assertEquals(4, manager.numVertexManagerEventsReceived);
-    Assert.assertEquals(Long.MAX_VALUE >> 1 << 1, manager.completedSourceTasksOutputSize);
+    assertEquals(2, newEdgeManagers.size());
+    assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
+    assertEquals(2, scheduledTasks.size());
+    assertTrue(scheduledTasks.contains(new Integer(0)));
+    assertTrue(scheduledTasks.contains(new Integer(1)));
+    assertEquals(4, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(4, manager.numVertexManagerEventsReceived);
+    assertEquals(Long.MAX_VALUE >> 1 << 1, manager.completedSourceTasksOutputSize);
 
     //reset context for next test
     when(mockContext.getVertexNumTasks(mockSrcVertexId1)).thenReturn(2);
@@ -163,7 +168,8 @@ public class TestShuffleVertexManager extends TestShuffleVertexManagerUtils {
     scheduledTasks.clear();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAutoParallelismConfig() throws Exception {
     ShuffleVertexManager manager;
 
@@ -187,11 +193,11 @@ public class TestShuffleVertexManager extends TestShuffleVertexManagerUtils {
     manager.initialize();
     verify(mockContext, times(1)).vertexReconfigurationPlanned(); // Tez notified of reconfig
 
-    Assert.assertTrue(manager.config.isAutoParallelismEnabled());
-    Assert.assertTrue(manager.config.getDesiredTaskInputDataSize() == 1000l);
-    Assert.assertTrue(manager.mgrConfig.getMinTaskParallelism() == 10);
-    Assert.assertTrue(manager.config.getMinFraction() == 0.25f);
-    Assert.assertTrue(manager.config.getMaxFraction() == 0.5f);
+    assertTrue(manager.config.isAutoParallelismEnabled());
+    assertEquals(1000l, manager.config.getDesiredTaskInputDataSize());
+    assertEquals(10, manager.mgrConfig.getMinTaskParallelism());
+    assertEquals(0.25f, manager.config.getMinFraction());
+    assertEquals(0.5f, manager.config.getMaxFraction());
 
     configurer = ShuffleVertexManager.createConfigBuilder(null);
     pluginDesc = configurer.setAutoReduceParallelism(false).build();
@@ -202,17 +208,18 @@ public class TestShuffleVertexManager extends TestShuffleVertexManagerUtils {
     manager.initialize();
     verify(mockContext, times(1)).vertexReconfigurationPlanned(); // Tez not notified of reconfig
 
-    Assert.assertTrue(!manager.config.isAutoParallelismEnabled());
-    Assert.assertTrue(manager.config.getDesiredTaskInputDataSize() ==
+    assertFalse(manager.config.isAutoParallelismEnabled());
+    assertEquals(manager.config.getDesiredTaskInputDataSize(),
         ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_DESIRED_TASK_INPUT_SIZE_DEFAULT);
-    Assert.assertTrue(manager.mgrConfig.getMinTaskParallelism() == 1);
-    Assert.assertTrue(manager.config.getMinFraction() ==
-        ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION_DEFAULT);
-    Assert.assertTrue(manager.config.getMaxFraction() ==
-        ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION_DEFAULT);
+    assertEquals(1, manager.mgrConfig.getMinTaskParallelism());
+    assertEquals(ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION_DEFAULT,
+        manager.config.getMinFraction());
+    assertEquals(ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION_DEFAULT,
+        manager.config.getMaxFraction());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSchedulingWithPartitionStats() throws IOException {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
@@ -261,19 +268,19 @@ public class TestShuffleVertexManager extends TestShuffleVertexManagerUtils {
     // check initialization
     manager = createManager(conf, mockContext, 0.001f, 0.001f);
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertTrue(manager.bipartiteSources == 1);
+    assertEquals(1, manager.bipartiteSources);
 
     manager.onVertexStateUpdated(new VertexStateUpdate(r1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(m2, VertexState.CONFIGURED));
 
-    Assert.assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(3, manager.totalNumBipartiteSourceTasks);
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(3, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
 
     //Send an event for r1.
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(r1, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 3);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(3, manager.totalNumBipartiteSourceTasks);
 
     //Tasks should be scheduled in task 2, 0, 1 order
     long[] sizes = new long[]{(100 * 1000l * 1000l), (0l), (5000 * 1000l * 1000l)};
@@ -287,19 +294,19 @@ public class TestShuffleVertexManager extends TestShuffleVertexManagerUtils {
 
     //Send an event for m2.
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(m2, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 3);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(3, manager.totalNumBipartiteSourceTasks);
 
     //Send an event for m3.
     manager.onVertexStateUpdated(new VertexStateUpdate(m3, VertexState.CONFIGURED));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(m3, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 0); // all tasks scheduled
-    Assert.assertTrue(scheduledTasks.size() == 3);
+    assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
+    assertEquals(3, scheduledTasks.size());
 
     //Order of scheduling should be 2,0,1 based on the available partition statistics
-    Assert.assertTrue(scheduledTasks.get(0) == 2);
-    Assert.assertTrue(scheduledTasks.get(1) == 0);
-    Assert.assertTrue(scheduledTasks.get(2) == 1);
+    assertEquals(2, (int) scheduledTasks.get(0));
+    assertEquals(0, (int) scheduledTasks.get(1));
+    assertEquals(1, (int) scheduledTasks.get(2));
   }
 
 

--- a/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestShuffleVertexManagerBase.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestShuffleVertexManagerBase.java
@@ -18,6 +18,10 @@
  */
 package org.apache.tez.dag.library.vertexmanager;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;
@@ -30,12 +34,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.dag.api.EdgeManagerPlugin;
@@ -56,36 +60,29 @@ import org.apache.tez.runtime.api.events.VertexManagerEvent;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
-@RunWith(Parameterized.class)
 public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils {
 
   List<TaskAttemptIdentifier> emptyCompletions = null;
-  Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass;
 
   @SuppressWarnings("deprecation")
-  @Parameterized.Parameters(name = "test[{0}]")
-  public static Collection<Object[]> data() {
-    Object[][] data = new Object[][]{
-        {ShuffleVertexManager.class},
-        {FairShuffleVertexManager.class}};
-    return Arrays.asList(data);
-  }
-
-  public TestShuffleVertexManagerBase(
-      Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) {
-    this.shuffleVertexManagerClass = shuffleVertexManagerClass;
+  public static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(ShuffleVertexManager.class),
+        Arguments.of(FairShuffleVertexManager.class)
+    );
   }
 
   // Test zero source tasks and onVertexStarted is called
   // before onVertexStateUpdated.
-  @Test(timeout = 5000)
-  public void testZeroSourceTasksWithVertexStartedFirst() {
+  @ParameterizedTest(name = "test[{0}]")
+  @MethodSource("data")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testZeroSourceTasksWithVertexStartedFirst(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
 
@@ -100,32 +97,34 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
         mockSrcVertexId1, 0, mockSrcVertexId2, 0, mockSrcVertexId3, 1,
         mockManagedVertexId, 4, scheduledTasks, null);
     // check initialization
-    manager = createManager(conf, mockContext, 0.1f, 0.1f); // Tez notified of reconfig
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.1f, 0.1f); // Tez notified of reconfig
 
     manager.onVertexStarted(emptyCompletions);
     verify(mockContext, times(1)).vertexReconfigurationPlanned();
     // The edge between destination and source vertex mockSrcVertexId3 is
     // broadcast type. Thus mockSrcVertexId3 isn't counted as bipartiteSource.
-    Assert.assertTrue(manager.bipartiteSources == 2);
+    assertEquals(2, manager.bipartiteSources);
 
     // check waiting for notification before scheduling
-    Assert.assertFalse(manager.pendingTasks.isEmpty());
+    assertFalse(manager.pendingTasks.isEmpty());
     // source vertices have 0 tasks. triggers scheduling
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertTrue(manager.pendingTasks.isEmpty());
+    assertTrue(manager.pendingTasks.isEmpty());
     verify(mockContext, times(1)).reconfigureVertex(eq(1), any(), anyMap());
     verify(mockContext, times(1)).doneReconfiguringVertex(); // reconfig done
-    Assert.assertTrue(scheduledTasks.size() == 1); // all tasks scheduled and parallelism changed
+    assertEquals(1, scheduledTasks.size()); // all tasks scheduled and parallelism changed
     scheduledTasks.clear();
     // TODO TEZ-1714 locking verify(mockContext, times(1)).vertexManagerDone(); // notified after scheduling all tasks
   }
 
   // Test zero source tasks and onVertexStateUpdated is called
   // before onVertexStarted.
-  @Test(timeout = 5000)
-  public void testZeroSourceTasksWithVertexStateUpdatedFirst() {
+  @ParameterizedTest(name = "test[{0}]")
+  @MethodSource("data")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testZeroSourceTasksWithVertexStateUpdatedFirst(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
 
@@ -140,7 +139,7 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
         mockSrcVertexId1, 0, mockSrcVertexId2, 0, mockSrcVertexId3, 1,
         mockManagedVertexId, 4, scheduledTasks, null);
     // check initialization
-    manager = createManager(conf, mockContext, 0.1f, 0.1f); // Tez notified of reconfig
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.1f, 0.1f); // Tez notified of reconfig
 
     verify(mockContext, times(1)).vertexReconfigurationPlanned();
     // source vertices have 0 tasks. so only 1 notification needed. does not trigger scheduling
@@ -149,19 +148,21 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
     verify(mockContext, times(0)).doneReconfiguringVertex(); // no change. will trigger after start
-    Assert.assertTrue(scheduledTasks.size() == 0); // no tasks scheduled
+    assertEquals(0, scheduledTasks.size()); // no tasks scheduled
     // trigger start and processing of pending notification events
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertTrue(manager.bipartiteSources == 2);
+    assertEquals(2, manager.bipartiteSources);
     verify(mockContext, times(1)).reconfigureVertex(eq(1), any(), anyMap());
     verify(mockContext, times(1)).doneReconfiguringVertex(); // reconfig done
-    Assert.assertTrue(manager.pendingTasks.isEmpty());
-    Assert.assertTrue(scheduledTasks.size() == 1); // all tasks scheduled and parallelism changed
+    assertTrue(manager.pendingTasks.isEmpty());
+    assertEquals(1, scheduledTasks.size()); // all tasks scheduled and parallelism changed
   }
 
   // Test vmEvent and vertexStatusUpdate before started.
-  @Test(timeout = 5000)
-  public void testVMEventFirst() throws IOException {
+  @ParameterizedTest(name = "test[{0}]")
+  @MethodSource("data")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testVMEventFirst(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws IOException {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
 
@@ -177,22 +178,24 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
         mockManagedVertexId, 4, scheduledTasks, null);
     VertexManagerEvent vmEvent = getVertexManagerEvent(null, 1L, "Vertex");
 
-    manager = createManager(conf, mockContext, 0.01f, 0.75f);
-    Assert.assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.01f, 0.75f);
+    assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
 
     TezTaskAttemptID taId1 = TezTaskAttemptID.fromString("attempt_1436907267600_195589_1_00_000000_0");
     vmEvent.setProducerAttemptIdentifier(new TaskAttemptIdentifierImpl("dag", mockSrcVertexId1, taId1));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexManagerEventReceived(vmEvent);
-    Assert.assertEquals(0, manager.numVertexManagerEventsReceived); // nothing happens
+    assertEquals(0, manager.numVertexManagerEventsReceived); // nothing happens
     manager.onVertexStarted(emptyCompletions); // now the processing happens
-    Assert.assertEquals(1, manager.numVertexManagerEventsReceived);
+    assertEquals(1, manager.numVertexManagerEventsReceived);
   }
 
   // Test partition stats.
-  @Test(timeout = 5000)
-  public void testPartitionStats() throws IOException {
+  @ParameterizedTest(name = "test[{0}]")
+  @MethodSource("data")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testPartitionStats(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws IOException {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
 
@@ -211,65 +214,67 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     long[] sizes = new long[]{(0l), (1 * MB), (964 * MB), (48 * MB)};
     VertexManagerEvent vmEvent = getVertexManagerEvent(sizes, 0, "Vertex", false);
 
-    manager = createManager(conf, mockContext, 0.01f, 0.75f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.01f, 0.75f);
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
 
     TezTaskAttemptID taId1 = TezTaskAttemptID.fromString("attempt_1436907267600_195589_1_00_000000_0");
     vmEvent.setProducerAttemptIdentifier(new TaskAttemptIdentifierImpl("dag", mockSrcVertexId1, taId1));
     manager.onVertexManagerEventReceived(vmEvent);
-    Assert.assertEquals(1, manager.numVertexManagerEventsReceived);
+    assertEquals(1, manager.numVertexManagerEventsReceived);
 
-    Assert.assertEquals(0, manager.getCurrentlyKnownStatsAtIndex(0)); //0 MB bucket
-    Assert.assertEquals(1, manager.getCurrentlyKnownStatsAtIndex(1)); //1 MB bucket
-    Assert.assertEquals(100, manager.getCurrentlyKnownStatsAtIndex(2)); //100 MB bucket
-    Assert.assertEquals(10, manager.getCurrentlyKnownStatsAtIndex(3)); //10 MB bucket
+    assertEquals(0, manager.getCurrentlyKnownStatsAtIndex(0)); //0 MB bucket
+    assertEquals(1, manager.getCurrentlyKnownStatsAtIndex(1)); //1 MB bucket
+    assertEquals(100, manager.getCurrentlyKnownStatsAtIndex(2)); //100 MB bucket
+    assertEquals(10, manager.getCurrentlyKnownStatsAtIndex(3)); //10 MB bucket
 
     // sending again from a different version of the same task has not impact
     TezTaskAttemptID taId2 = TezTaskAttemptID.fromString("attempt_1436907267600_195589_1_00_000000_1");
     vmEvent.setProducerAttemptIdentifier(new TaskAttemptIdentifierImpl("dag", mockSrcVertexId1, taId2));
     manager.onVertexManagerEventReceived(vmEvent);
-    Assert.assertEquals(1, manager.numVertexManagerEventsReceived);
+    assertEquals(1, manager.numVertexManagerEventsReceived);
 
-    Assert.assertEquals(0, manager.getCurrentlyKnownStatsAtIndex(0)); //0 MB bucket
-    Assert.assertEquals(1, manager.getCurrentlyKnownStatsAtIndex(1)); //1 MB bucket
-    Assert.assertEquals(100, manager.getCurrentlyKnownStatsAtIndex(2)); //100 MB bucket
-    Assert.assertEquals(10, manager.getCurrentlyKnownStatsAtIndex(3)); //10 MB bucket
+    assertEquals(0, manager.getCurrentlyKnownStatsAtIndex(0)); //0 MB bucket
+    assertEquals(1, manager.getCurrentlyKnownStatsAtIndex(1)); //1 MB bucket
+    assertEquals(100, manager.getCurrentlyKnownStatsAtIndex(2)); //100 MB bucket
+    assertEquals(10, manager.getCurrentlyKnownStatsAtIndex(3)); //10 MB bucket
 
     // Testing for detailed partition stats
     vmEvent = getVertexManagerEvent(sizes, 0, "Vertex", true);
 
-    manager = createManager(conf, mockContext, 0.01f, 0.75f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.01f, 0.75f);
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
 
     taId1 = TezTaskAttemptID.fromString("attempt_1436907267600_195589_1_00_000000_0");
     vmEvent.setProducerAttemptIdentifier(new TaskAttemptIdentifierImpl("dag", mockSrcVertexId1, taId1));
     manager.onVertexManagerEventReceived(vmEvent);
-    Assert.assertEquals(1, manager.numVertexManagerEventsReceived);
+    assertEquals(1, manager.numVertexManagerEventsReceived);
 
-    Assert.assertEquals(0, manager.getCurrentlyKnownStatsAtIndex(0));
-    Assert.assertEquals(1, manager.getCurrentlyKnownStatsAtIndex(1));
-    Assert.assertEquals(964, manager.getCurrentlyKnownStatsAtIndex(2));
-    Assert.assertEquals(48, manager.getCurrentlyKnownStatsAtIndex(3));
+    assertEquals(0, manager.getCurrentlyKnownStatsAtIndex(0));
+    assertEquals(1, manager.getCurrentlyKnownStatsAtIndex(1));
+    assertEquals(964, manager.getCurrentlyKnownStatsAtIndex(2));
+    assertEquals(48, manager.getCurrentlyKnownStatsAtIndex(3));
 
     // sending again from a different version of the same task has not impact
     taId2 = TezTaskAttemptID.fromString("attempt_1436907267600_195589_1_00_000000_1");
     vmEvent.setProducerAttemptIdentifier(new TaskAttemptIdentifierImpl("dag", mockSrcVertexId1, taId2));
     manager.onVertexManagerEventReceived(vmEvent);
-    Assert.assertEquals(1, manager.numVertexManagerEventsReceived);
+    assertEquals(1, manager.numVertexManagerEventsReceived);
 
-    Assert.assertEquals(0, manager.getCurrentlyKnownStatsAtIndex(0));
-    Assert.assertEquals(1, manager.getCurrentlyKnownStatsAtIndex(1));
-    Assert.assertEquals(964, manager.getCurrentlyKnownStatsAtIndex(2));
-    Assert.assertEquals(48, manager.getCurrentlyKnownStatsAtIndex(3));
+    assertEquals(0, manager.getCurrentlyKnownStatsAtIndex(0));
+    assertEquals(1, manager.getCurrentlyKnownStatsAtIndex(1));
+    assertEquals(964, manager.getCurrentlyKnownStatsAtIndex(2));
+    assertEquals(48, manager.getCurrentlyKnownStatsAtIndex(3));
   }
 
   // Delay determining parallelism until enough data has been received.
-  @Test(timeout = 5000)
-  public void testTez978() throws IOException {
+  @ParameterizedTest(name = "test[{0}]")
+  @MethodSource("data")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testTez978(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws IOException {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
 
@@ -285,50 +290,50 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
             mockManagedVertexId, 4, scheduledTasks, null);
 
     //min/max fraction of 0.01/0.75 would ensure that we hit determineParallelism code path on receiving first event itself.
-    manager = createManager(conf, mockContext, 0.01f, 0.75f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.01f, 0.75f);
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(4, manager.totalNumBipartiteSourceTasks);
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
 
     //First task in src1 completed with small payload
     VertexManagerEvent vmEvent = getVertexManagerEvent(null, 1L, mockSrcVertexId1);
     manager.onVertexManagerEventReceived(vmEvent); //small payload
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 0));
-    Assert.assertTrue(manager.determineParallelismAndApply(0f) == false);
-    Assert.assertEquals(4, manager.pendingTasks.size());
-    Assert.assertEquals(0, scheduledTasks.size()); // no tasks scheduled
-    Assert.assertEquals(1, manager.numBipartiteSourceTasksCompleted);
-    Assert.assertEquals(1, manager.numVertexManagerEventsReceived);
-    Assert.assertEquals(1L, manager.completedSourceTasksOutputSize);
+    assertFalse(manager.determineParallelismAndApply(0f));
+    assertEquals(4, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size()); // no tasks scheduled
+    assertEquals(1, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(1, manager.numVertexManagerEventsReceived);
+    assertEquals(1L, manager.completedSourceTasksOutputSize);
 
     //First task in src2 completed with small payload
     vmEvent = getVertexManagerEvent(null, 1L, mockSrcVertexId2);
     manager.onVertexManagerEventReceived(vmEvent); //small payload
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 0));
     //Still overall data gathered has not reached threshold; So, ensure parallelism can be determined later
-    Assert.assertTrue(manager.determineParallelismAndApply(0.25f) == false);
-    Assert.assertEquals(4, manager.pendingTasks.size());
-    Assert.assertEquals(0, scheduledTasks.size()); // no tasks scheduled
-    Assert.assertEquals(2, manager.numBipartiteSourceTasksCompleted);
-    Assert.assertEquals(2, manager.numVertexManagerEventsReceived);
-    Assert.assertEquals(2L, manager.completedSourceTasksOutputSize);
+    assertFalse(manager.determineParallelismAndApply(0.25f));
+    assertEquals(4, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size()); // no tasks scheduled
+    assertEquals(2, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(2, manager.numVertexManagerEventsReceived);
+    assertEquals(2L, manager.completedSourceTasksOutputSize);
 
     //First task in src2 completed (with larger payload) to trigger determining parallelism
     vmEvent = getVertexManagerEvent(null, 160 * MB, mockSrcVertexId2);
     manager.onVertexManagerEventReceived(vmEvent);
-    Assert.assertTrue(manager.determineParallelismAndApply(0.25f)); //ensure parallelism is determined
+    assertTrue(manager.determineParallelismAndApply(0.25f)); //ensure parallelism is determined
     verify(mockContext, times(1)).reconfigureVertex(anyInt(), any(), anyMap());
     verify(mockContext, times(1)).reconfigureVertex(eq(2), any(), anyMap());
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 0));
-    Assert.assertEquals(0, manager.pendingTasks.size());
-    Assert.assertEquals(2, scheduledTasks.size());
-    Assert.assertEquals(2, manager.numBipartiteSourceTasksCompleted);
-    Assert.assertEquals(3, manager.numVertexManagerEventsReceived);
-    Assert.assertEquals(160 * MB + 2, manager.completedSourceTasksOutputSize);
+    assertEquals(0, manager.pendingTasks.size());
+    assertEquals(2, scheduledTasks.size());
+    assertEquals(2, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(3, manager.numVertexManagerEventsReceived);
+    assertEquals(160 * MB + 2, manager.completedSourceTasksOutputSize);
 
     //Test for max fraction. Min fraction is just instruction to framework, but honor max fraction
     when(mockContext.getVertexNumTasks(mockSrcVertexId1)).thenReturn(20);
@@ -337,16 +342,16 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     scheduledTasks.clear();
 
     //min/max fraction of 0.0/0.2
-    manager = createManager(conf, mockContext, 0.0f, 0.2f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.0f, 0.2f);
     // initial invocation count == 3
     verify(mockContext, times(1)).reconfigureVertex(anyInt(), any(), anyMap());
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertEquals(40, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(40, manager.totalNumBipartiteSourceTasks);
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(40, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(40, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
     //send 8 events with payload size as 10MB
     for(int i=0;i<8;i++) {
       //small payload - create new event each time or it will be ignored (from same task)
@@ -367,8 +372,10 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     verify(mockContext, times(2)).reconfigureVertex(eq(2), any(), anyMap());
   }
 
-  @Test(timeout = 5000)
-  public void testAutoParallelism() throws Exception {
+  @ParameterizedTest(name = "test[{0}]")
+  @MethodSource("data")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testAutoParallelism(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws Exception {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
 
@@ -386,32 +393,32 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
             mockManagedVertexId, 4, scheduledTasks, newEdgeManagers);
 
     // parallelism changed due to small data size
-    manager = createManager(conf, mockContext, 0.5f, 0.5f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.5f, 0.5f);
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(4, manager.totalNumBipartiteSourceTasks);
+    assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
     // task completion from non-bipartite stage does nothing
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId3, 0));
-    Assert.assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(4, manager.totalNumBipartiteSourceTasks);
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(4, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
     VertexManagerEvent vmEvent = getVertexManagerEvent(null, 50 * MB, mockSrcVertexId1);
     manager.onVertexManagerEventReceived(vmEvent);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 0));
-    Assert.assertEquals(4, manager.pendingTasks.size());
-    Assert.assertEquals(0, scheduledTasks.size()); // no tasks scheduled
-    Assert.assertEquals(1, manager.numBipartiteSourceTasksCompleted);
-    Assert.assertEquals(1, manager.numVertexManagerEventsReceived);
-    Assert.assertEquals(50 * MB, manager.completedSourceTasksOutputSize);
+    assertEquals(4, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size()); // no tasks scheduled
+    assertEquals(1, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(1, manager.numVertexManagerEventsReceived);
+    assertEquals(50 * MB, manager.completedSourceTasksOutputSize);
     // ignore duplicate completion
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 0));
-    Assert.assertEquals(4, manager.pendingTasks.size());
-    Assert.assertEquals(0, scheduledTasks.size()); // no tasks scheduled
-    Assert.assertEquals(1, manager.numBipartiteSourceTasksCompleted);
-    Assert.assertEquals(50 * MB, manager.completedSourceTasksOutputSize);
+    assertEquals(4, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size()); // no tasks scheduled
+    assertEquals(1, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(50 * MB, manager.completedSourceTasksOutputSize);
     vmEvent = getVertexManagerEvent(null, 50 * MB, mockSrcVertexId2);
     manager.onVertexManagerEventReceived(vmEvent);
 
@@ -419,50 +426,52 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     // managedVertex tasks reduced
     verify(mockContext, times(1)).reconfigureVertex(anyInt(), any(), anyMap());
     verify(mockContext, times(1)).reconfigureVertex(eq(2), any(), anyMap());
-    Assert.assertEquals(2, newEdgeManagers.size());
+    assertEquals(2, newEdgeManagers.size());
     // TODO improve tests for parallelism
-    Assert.assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
-    Assert.assertEquals(2, scheduledTasks.size());
-    Assert.assertTrue(scheduledTasks.contains(new Integer(0)));
-    Assert.assertTrue(scheduledTasks.contains(new Integer(1)));
-    Assert.assertEquals(2, manager.numBipartiteSourceTasksCompleted);
-    Assert.assertEquals(2, manager.numVertexManagerEventsReceived);
-    Assert.assertEquals(100 * MB, manager.completedSourceTasksOutputSize);
+    assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
+    assertEquals(2, scheduledTasks.size());
+    assertTrue(scheduledTasks.contains(new Integer(0)));
+    assertTrue(scheduledTasks.contains(new Integer(1)));
+    assertEquals(2, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(2, manager.numVertexManagerEventsReceived);
+    assertEquals(100 * MB, manager.completedSourceTasksOutputSize);
 
     // more completions dont cause recalculation of parallelism
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 0));
     verify(mockContext, times(1)).reconfigureVertex(anyInt(), any(), anyMap());
-    Assert.assertEquals(2, newEdgeManagers.size());
+    assertEquals(2, newEdgeManagers.size());
 
     EdgeManagerPluginOnDemand edgeManager =
         (EdgeManagerPluginOnDemand)newEdgeManagers.values().iterator().next();
 
     // 4 source task outputs - same as original number of partitions
-    Assert.assertEquals(4, edgeManager.getNumSourceTaskPhysicalOutputs(0));
+    assertEquals(4, edgeManager.getNumSourceTaskPhysicalOutputs(0));
     // 4 destination task inputs - 2 source tasks * 2 merged partitions
-    Assert.assertEquals(4, edgeManager.getNumDestinationTaskPhysicalInputs(0));
+    assertEquals(4, edgeManager.getNumDestinationTaskPhysicalInputs(0));
     EdgeManagerPluginOnDemand.EventRouteMetadata routeMetadata =
         edgeManager.routeDataMovementEventToDestination(1, 1, 0);
-    Assert.assertEquals(1, routeMetadata.getNumEvents());
-    Assert.assertEquals(3, routeMetadata.getTargetIndices()[0]);
+    assertEquals(1, routeMetadata.getNumEvents());
+    assertEquals(3, routeMetadata.getTargetIndices()[0]);
 
     routeMetadata = edgeManager.routeDataMovementEventToDestination(0, 2, 1);
-    Assert.assertEquals(1, routeMetadata.getNumEvents());
-    Assert.assertEquals(0, routeMetadata.getTargetIndices()[0]);
+    assertEquals(1, routeMetadata.getNumEvents());
+    assertEquals(0, routeMetadata.getTargetIndices()[0]);
 
     routeMetadata = edgeManager.routeInputSourceTaskFailedEventToDestination(1, 0);
-    Assert.assertEquals(2, routeMetadata.getNumEvents());
-    Assert.assertEquals(2, routeMetadata.getTargetIndices()[0]);
-    Assert.assertEquals(3, routeMetadata.getTargetIndices()[1]);
+    assertEquals(2, routeMetadata.getNumEvents());
+    assertEquals(2, routeMetadata.getTargetIndices()[0]);
+    assertEquals(3, routeMetadata.getTargetIndices()[1]);
 
     routeMetadata = edgeManager.routeInputSourceTaskFailedEventToDestination(1, 1);
-    Assert.assertEquals(2, routeMetadata.getNumEvents());
-    Assert.assertEquals(2, routeMetadata.getTargetIndices()[0]);
-    Assert.assertEquals(3, routeMetadata.getTargetIndices()[1]);
+    assertEquals(2, routeMetadata.getNumEvents());
+    assertEquals(2, routeMetadata.getTargetIndices()[0]);
+    assertEquals(3, routeMetadata.getTargetIndices()[1]);
   }
 
-  @Test(timeout = 5000)
-  public void testShuffleVertexManagerSlowStart() {
+  @ParameterizedTest(name = "test[{0}]")
+  @MethodSource("data")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testShuffleVertexManagerSlowStart(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager = null;
     HashMap<String, EdgeProperty> mockInputVertices =
@@ -501,11 +510,11 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     // fail if there is no bipartite src vertex
     mockInputVertices.put(mockSrcVertexId3, eProp3);
     try {
-      manager = createManager(conf, mockContext, 0.1f, 0.1f);
+      manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.1f, 0.1f);
       manager.onVertexStarted(emptyCompletions);
-      Assert.assertFalse(true);
+      fail();
     } catch (TezUncheckedException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "At least 1 bipartite source should exist"));
     }
 
@@ -513,9 +522,9 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     mockInputVertices.put(mockSrcVertexId2, eProp2);
 
     // check initialization
-    manager = createManager(conf, mockContext, 0.1f, 0.1f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.1f, 0.1f);
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertTrue(manager.bipartiteSources == 2);
+    assertEquals(2, manager.bipartiteSources);
 
     final List<Integer> scheduledTasks = Lists.newLinkedList();
     doAnswer(new ScheduledTasksAnswer(scheduledTasks)).when(
@@ -528,36 +537,36 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertTrue(manager.pendingTasks.isEmpty());
-    Assert.assertTrue(scheduledTasks.size() == 3); // all tasks scheduled
+    assertTrue(manager.pendingTasks.isEmpty());
+    assertEquals(3, scheduledTasks.size()); // all tasks scheduled
 
     when(mockContext.getVertexNumTasks(mockSrcVertexId1)).thenReturn(2);
     when(mockContext.getVertexNumTasks(mockSrcVertexId2)).thenReturn(2);
 
     try {
       // source vertex have some tasks. min < 0.
-      manager = createManager(conf, mockContext, -0.1f, 0.0f);
-      Assert.assertTrue(false); // should not come here
+      manager = createManager(shuffleVertexManagerClass, conf, mockContext, -0.1f, 0.0f);
+      fail(); // should not come here
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "Invalid values for slowStartMinFraction"));
     }
 
     try {
       // source vertex have some tasks. max > 1.
-      manager = createManager(conf, mockContext, 0.0f, 95.0f);
-      Assert.assertTrue(false); // should not come here
+      manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.0f, 95.0f);
+      fail(); // should not come here
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "Invalid values for slowStartMinFraction"));
     }
 
     try {
       // source vertex have some tasks. min > max
-      manager = createManager(conf, mockContext, 0.5f, 0.3f);
-      Assert.assertTrue(false); // should not come here
+      manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.5f, 0.3f);
+      fail(); // should not come here
     } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(
+      assertTrue(e.getMessage().contains(
           "Invalid values for slowStartMinFraction"));
     }
 
@@ -567,15 +576,15 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     when(mockContext.getVertexNumTasks(mockSrcVertexId2)).thenReturn(numTasks);
     scheduledTasks.clear();
 
-    manager = createManager(conf, mockContext, 0.8f, null);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.8f, null);
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
 
-    Assert.assertEquals(3, manager.pendingTasks.size());
-    Assert.assertEquals(numTasks*2, manager.totalNumBipartiteSourceTasks);
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(3, manager.pendingTasks.size());
+    assertEquals(numTasks*2, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
     float completedTasksThreshold = 0.8f * numTasks;
     // Finish all tasks before exceeding the threshold
     for (String mockSrcVertex : new String[] { mockSrcVertexId1, mockSrcVertexId2 }) {
@@ -589,213 +598,215 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
       }
     }
     // Since we haven't exceeded the threshold, all tasks are still pending
-    Assert.assertEquals(manager.totalTasksToSchedule, manager.pendingTasks.size());
-    Assert.assertEquals(0, scheduledTasks.size()); // no tasks scheduled
+    assertEquals(manager.totalTasksToSchedule, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size()); // no tasks scheduled
 
     // Cross the threshold min/max threshold to schedule all tasks
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 0));
-    Assert.assertEquals(3, manager.pendingTasks.size());
-    Assert.assertEquals(0, scheduledTasks.size());
+    assertEquals(3, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size());
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 0));
-    Assert.assertEquals(0, manager.pendingTasks.size());
-    Assert.assertEquals(manager.totalTasksToSchedule, scheduledTasks.size()); // all tasks scheduled
+    assertEquals(0, manager.pendingTasks.size());
+    assertEquals(manager.totalTasksToSchedule, scheduledTasks.size()); // all tasks scheduled
 
     // reset vertices for next test
     when(mockContext.getVertexNumTasks(mockSrcVertexId1)).thenReturn(2);
     when(mockContext.getVertexNumTasks(mockSrcVertexId2)).thenReturn(2);
 
     // source vertex have some tasks. min, max == 0
-    manager = createManager(conf, mockContext, 0.0f, 0.0f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.0f, 0.0f);
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertTrue(manager.totalTasksToSchedule == 3);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 0);
+    assertEquals(3, manager.totalTasksToSchedule);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
     // all source vertices need to be configured
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 4);
-    Assert.assertTrue(manager.pendingTasks.isEmpty());
-    Assert.assertTrue(scheduledTasks.size() == 3); // all tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
+    assertTrue(manager.pendingTasks.isEmpty());
+    assertEquals(3, scheduledTasks.size()); // all tasks scheduled
 
     // min, max > 0 and min == max
-    manager = createManager(conf, mockContext, 0.25f, 0.25f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.25f, 0.25f);
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 4);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
     // task completion from non-bipartite stage does nothing
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId3, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 4);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 0);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
     // task completion on only 1 SG edge does nothing
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 4);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 1);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
+    assertEquals(1, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 0));
-    Assert.assertTrue(manager.pendingTasks.isEmpty());
-    Assert.assertTrue(scheduledTasks.size() == 3); // all tasks scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 2);
+    assertTrue(manager.pendingTasks.isEmpty());
+    assertEquals(3, scheduledTasks.size()); // all tasks scheduled
+    assertEquals(2, manager.numBipartiteSourceTasksCompleted);
 
     // min, max > 0 and min == max == absolute max 1.0
-    manager = createManager(conf, mockContext, 1.0f, 1.0f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 1.0f, 1.0f);
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 4);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
     // task completion from non-bipartite stage does nothing
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId3, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 4);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 0);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 3);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 1);
+    assertEquals(3, manager.pendingTasks.size());
+    assertEquals(1, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 1));
-    Assert.assertTrue(manager.pendingTasks.size() == 3);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 2);
+    assertEquals(3, manager.pendingTasks.size());
+    assertEquals(2, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 3);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 3);
+    assertEquals(3, manager.pendingTasks.size());
+    assertEquals(3, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 1));
-    Assert.assertTrue(manager.pendingTasks.isEmpty());
-    Assert.assertTrue(scheduledTasks.size() == 3); // all tasks scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 4);
+    assertTrue(manager.pendingTasks.isEmpty());
+    assertEquals(3, scheduledTasks.size()); // all tasks scheduled
+    assertEquals(4, manager.numBipartiteSourceTasksCompleted);
 
     // min, max > 0 and min == max
-    manager = createManager(conf, mockContext, 1.0f, 1.0f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 1.0f, 1.0f);
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 4);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
     // task completion from non-bipartite stage does nothing
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId3, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 4);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 0);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(4, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 3);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 1);
+    assertEquals(3, manager.pendingTasks.size());
+    assertEquals(1, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 1));
-    Assert.assertTrue(manager.pendingTasks.size() == 3);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 2);
+    assertEquals(3, manager.pendingTasks.size());
+    assertEquals(2, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 3);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 3);
+    assertEquals(3, manager.pendingTasks.size());
+    assertEquals(3, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 1));
-    Assert.assertTrue(manager.pendingTasks.isEmpty());
-    Assert.assertTrue(scheduledTasks.size() == 3); // all tasks scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 4);
+    assertTrue(manager.pendingTasks.isEmpty());
+    assertEquals(3, scheduledTasks.size()); // all tasks scheduled
+    assertEquals(4, manager.numBipartiteSourceTasksCompleted);
 
     // reset vertices for next test
     when(mockContext.getVertexNumTasks(mockSrcVertexId1)).thenReturn(4);
     when(mockContext.getVertexNumTasks(mockSrcVertexId2)).thenReturn(4);
 
     // min, max > and min < max
-    manager = createManager(conf, mockContext, 0.25f, 0.75f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.25f, 0.75f);
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 8);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(8, manager.totalNumBipartiteSourceTasks);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 0));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 1));
-    Assert.assertTrue(manager.pendingTasks.size() == 3);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 2);
+    assertEquals(3, manager.pendingTasks.size());
+    assertEquals(2, manager.numBipartiteSourceTasksCompleted);
     // completion of same task again should not get counted
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 1));
-    Assert.assertTrue(manager.pendingTasks.size() == 3);
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 2);
+    assertEquals(3, manager.pendingTasks.size());
+    assertEquals(2, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 1));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 1);
-    Assert.assertTrue(scheduledTasks.size() == 2); // 2 task scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 4);
+    assertEquals(1, manager.pendingTasks.size());
+    assertEquals(2, scheduledTasks.size()); // 2 task scheduled
+    assertEquals(4, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 2));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 2));
-    Assert.assertTrue(manager.pendingTasks.size() == 0);
-    Assert.assertTrue(scheduledTasks.size() == 1); // 1 tasks scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 6);
+    assertEquals(0, manager.pendingTasks.size());
+    assertEquals(1, scheduledTasks.size()); // 1 tasks scheduled
+    assertEquals(6, manager.numBipartiteSourceTasksCompleted);
     scheduledTasks.clear();
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 3)); // we are done. no action
-    Assert.assertTrue(manager.pendingTasks.size() == 0);
-    Assert.assertTrue(scheduledTasks.size() == 0); // no task scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 7);
+    assertEquals(0, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size()); // no task scheduled
+    assertEquals(7, manager.numBipartiteSourceTasksCompleted);
 
     // min, max > and min < max
-    manager = createManager(conf, mockContext, 0.25f, 1.0f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.25f, 1.0f);
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 8);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(8, manager.totalNumBipartiteSourceTasks);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 0));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 1));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 1));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 2);
-    Assert.assertTrue(scheduledTasks.size() == 1); // 1 task scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 4);
+    assertEquals(2, manager.pendingTasks.size());
+    assertEquals(1, scheduledTasks.size()); // 1 task scheduled
+    assertEquals(4, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 2));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 2));
-    Assert.assertTrue(manager.pendingTasks.size() == 1);
-    Assert.assertTrue(scheduledTasks.size() == 1); // 1 task scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 6);
+    assertEquals(1, manager.pendingTasks.size());
+    assertEquals(1, scheduledTasks.size()); // 1 task scheduled
+    assertEquals(6, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 3));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 3));
-    Assert.assertTrue(manager.pendingTasks.size() == 0);
-    Assert.assertTrue(scheduledTasks.size() == 1); // no task scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 8);
+    assertEquals(0, manager.pendingTasks.size());
+    assertEquals(1, scheduledTasks.size()); // no task scheduled
+    assertEquals(8, manager.numBipartiteSourceTasksCompleted);
 
     // if there is single task to schedule, it should be schedule when src completed
     // fraction is more than min slow start fraction
     scheduledTasks.clear();
     when(mockContext.getVertexNumTasks(mockManagedVertexId)).thenReturn(1);
-    manager = createManager(conf, mockContext, 0.25f, 0.75f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.25f, 0.75f);
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(mockSrcVertexId3, VertexState.CONFIGURED));
-    Assert.assertTrue(manager.pendingTasks.size() == 1); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 8);
+    assertEquals(1, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(8, manager.totalNumBipartiteSourceTasks);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 0));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 1));
-    Assert.assertTrue(manager.pendingTasks.size() == 1);
-    Assert.assertTrue(scheduledTasks.size() == 0); // no task scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 2);
+    assertEquals(1, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size()); // no task scheduled
+    assertEquals(2, manager.numBipartiteSourceTasksCompleted);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 1));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 0);
-    Assert.assertTrue(scheduledTasks.size() == 1); // 1 task scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 4);
+    assertEquals(0, manager.pendingTasks.size());
+    assertEquals(1, scheduledTasks.size()); // 1 task scheduled
+    assertEquals(4, manager.numBipartiteSourceTasksCompleted);
     scheduledTasks.clear();
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 2));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId2, 2));
-    Assert.assertTrue(manager.pendingTasks.size() == 0);
-    Assert.assertTrue(scheduledTasks.size() == 0); // no task scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 6);
+    assertEquals(0, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size()); // no task scheduled
+    assertEquals(6, manager.numBipartiteSourceTasksCompleted);
     scheduledTasks.clear();
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(mockSrcVertexId1, 3)); // we are done. no action
-    Assert.assertTrue(manager.pendingTasks.size() == 0);
-    Assert.assertTrue(scheduledTasks.size() == 0); // no task scheduled
-    Assert.assertTrue(manager.numBipartiteSourceTasksCompleted == 7);
+    assertEquals(0, manager.pendingTasks.size());
+    assertEquals(0, scheduledTasks.size()); // no task scheduled
+    assertEquals(7, manager.numBipartiteSourceTasksCompleted);
   }
 
   /**
    * Tasks should be scheduled only when all source vertices are configured completely
    * @throws IOException
    */
-  @Test(timeout = 5000)
-  public void test_Tez1649_with_scatter_gather_edges() throws IOException {
+  @ParameterizedTest(name = "test[{0}]")
+  @MethodSource("data")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void test_Tez1649_with_scatter_gather_edges(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws IOException {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager = null;
 
@@ -837,43 +848,43 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
 
     VertexManagerEvent vmEvent = getVertexManagerEvent(null, 50L, r1);
     // check initialization
-    manager = createManager(conf, mockContext_R2, 0.001f, 0.001f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext_R2, 0.001f, 0.001f);
 
     final List<Integer> scheduledTasks = Lists.newLinkedList();
     doAnswer(new ScheduledTasksAnswer(scheduledTasks)).when(
         mockContext_R2).scheduleTasks(anyList());
 
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertTrue(manager.bipartiteSources == 3);
+    assertEquals(3, manager.bipartiteSources);
     manager.onVertexStateUpdated(new VertexStateUpdate(m2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(m3, VertexState.CONFIGURED));
 
     manager.onVertexManagerEventReceived(vmEvent);
-    Assert.assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(6, manager.totalNumBipartiteSourceTasks);
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(6, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
 
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 6);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(6, manager.totalNumBipartiteSourceTasks);
 
     //Send events for all tasks of m3.
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(m3, 0));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(m3, 1));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(m3, 2));
 
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 6);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(6, manager.totalNumBipartiteSourceTasks);
 
     //Send events for m2. But still we need to wait for at least 1 event from r1.
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(m2, 0));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(m2, 1));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 6);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(6, manager.totalNumBipartiteSourceTasks);
 
     // we need to wait for at least 1 event from r1 to make sure all vertices cross min threshold
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(r1, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 6);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(6, manager.totalNumBipartiteSourceTasks);
 
     //Ensure that setVertexParallelism is not called for R2.
     verify(mockContext_R2, times(0)).reconfigureVertex(anyInt(), any(), anyMap());
@@ -883,11 +894,11 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
 
     // complete configuration of r1 triggers the scheduling
     manager.onVertexStateUpdated(new VertexStateUpdate(r1, VertexState.CONFIGURED));
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 9);
+    assertEquals(9, manager.totalNumBipartiteSourceTasks);
     verify(mockContext_R2, times(1)).reconfigureVertex(eq(1), any(), anyMap());
 
-    Assert.assertTrue(manager.pendingTasks.size() == 0); // all tasks scheduled
-    Assert.assertTrue(scheduledTasks.size() == 1);
+    assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
+    assertEquals(1, scheduledTasks.size());
 
     //try with zero task vertices
     scheduledTasks.clear();
@@ -898,23 +909,25 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     when(mockContext_R2.getVertexNumTasks(m2)).thenReturn(0);
     when(mockContext_R2.getVertexNumTasks(m3)).thenReturn(3);
 
-    manager = createManager(conf, mockContext_R2, 0.001f, 0.001f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext_R2, 0.001f, 0.001f);
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
 
     // Only need completed configuration notification from m3
     manager.onVertexStateUpdated(new VertexStateUpdate(m3, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(m2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(r1, VertexState.CONFIGURED));
-    Assert.assertEquals(3, manager.totalNumBipartiteSourceTasks);
+    assertEquals(3, manager.totalNumBipartiteSourceTasks);
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(m3, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 0); // all tasks scheduled
-    Assert.assertTrue(scheduledTasks.size() == 3);
+    assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
+    assertEquals(3, scheduledTasks.size());
   }
 
-  @Test(timeout = 5000)
-  public void test_Tez1649_with_mixed_edges() {
+  @ParameterizedTest(name = "test[{0}]")
+  @MethodSource("data")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void test_Tez1649_with_mixed_edges(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager = null;
 
@@ -960,37 +973,37 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     doAnswer(new ScheduledTasksAnswer(scheduledTasks)).when(
         mockContext).scheduleTasks(anyList());
     // check initialization
-    manager = createManager(conf, mockContext, 0.001f, 0.001f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.001f, 0.001f);
     manager.onVertexStarted(emptyCompletions);
-    Assert.assertTrue(manager.bipartiteSources == 1);
+    assertEquals(1, manager.bipartiteSources);
 
     manager.onVertexStateUpdated(new VertexStateUpdate(r1, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(m2, VertexState.CONFIGURED));
 
-    Assert.assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(3, manager.totalNumBipartiteSourceTasks);
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(3, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
 
     //Send events for 2 tasks of r1.
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(r1, 0));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(r1, 1));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 3);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(3, manager.totalNumBipartiteSourceTasks);
 
     //Send an event for m2.
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(m2, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 3);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(3, manager.totalNumBipartiteSourceTasks);
 
     //Send an event for m3.
     manager.onVertexStateUpdated(new VertexStateUpdate(m3, VertexState.CONFIGURED));
-    Assert.assertTrue(manager.pendingTasks.size() == 0); // all tasks scheduled
-    Assert.assertTrue(scheduledTasks.size() == 3);
+    assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
+    assertEquals(3, scheduledTasks.size());
 
     //Scenario when numBipartiteSourceTasksCompleted == totalNumBipartiteSourceTasks.
     //Still, wait for a configuration to be completed from other edges
     scheduledTasks.clear();
-    manager = createManager(conf, mockContext, 0.001f, 0.001f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.001f, 0.001f);
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(r1, VertexState.CONFIGURED));
 
@@ -1000,24 +1013,24 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     when(mockContext.getVertexNumTasks(r1)).thenReturn(3);
     when(mockContext.getVertexNumTasks(m2)).thenReturn(3);
     when(mockContext.getVertexNumTasks(m3)).thenReturn(3);
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(manager.totalNumBipartiteSourceTasks == 3);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(3, manager.totalNumBipartiteSourceTasks);
 
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(r1, 0));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(r1, 1));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(r1, 2));
     //Tasks from non-scatter edges of m2 and m3 are not complete.
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
     manager.onVertexStateUpdated(new VertexStateUpdate(m2, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(m3, VertexState.CONFIGURED));
     //Got an event from other edges. Schedule all
-    Assert.assertTrue(manager.pendingTasks.size() == 0); // all tasks scheduled
-    Assert.assertTrue(scheduledTasks.size() == 3);
+    assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
+    assertEquals(3, scheduledTasks.size());
 
 
     //try with a zero task vertex (with non-scatter-gather edges)
     scheduledTasks.clear();
-    manager = createManager(conf, mockContext, 0.001f, 0.001f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.001f, 0.001f);
     manager.onVertexStarted(emptyCompletions);
     when(mockContext.getInputVertexEdgeProperties()).thenReturn(mockInputVertices);
     when(mockContext.getVertexName()).thenReturn(mockManagedVertexId);
@@ -1026,29 +1039,29 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     when(mockContext.getVertexNumTasks(m2)).thenReturn(0); //broadcast
     when(mockContext.getVertexNumTasks(m3)).thenReturn(3); //broadcast
 
-    manager = createManager(conf, mockContext, 0.001f, 0.001f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.001f, 0.001f);
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(r1, VertexState.CONFIGURED));
 
-    Assert.assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(3, manager.totalNumBipartiteSourceTasks);
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(3, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
 
     //Send 2 events for tasks of r1.
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(r1, 0));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(r1, 1));
-    Assert.assertTrue(manager.pendingTasks.size() == 3); // no tasks scheduled
-    Assert.assertTrue(scheduledTasks.size() == 0);
+    assertEquals(3, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(0, scheduledTasks.size());
 
     // event from m3 triggers scheduling
     manager.onVertexStateUpdated(new VertexStateUpdate(m3, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(m2, VertexState.CONFIGURED));
-    Assert.assertTrue(manager.pendingTasks.size() == 0); // all tasks scheduled
-    Assert.assertTrue(scheduledTasks.size() == 3);
+    assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
+    assertEquals(3, scheduledTasks.size());
 
     //try with all zero task vertices in non-SG edges
     scheduledTasks.clear();
-    manager = createManager(conf, mockContext, 0.001f, 0.001f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.001f, 0.001f);
     manager.onVertexStarted(emptyCompletions);
     when(mockContext.getInputVertexEdgeProperties()).thenReturn(mockInputVertices);
     when(mockContext.getVertexName()).thenReturn(mockManagedVertexId);
@@ -1062,12 +1075,13 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     manager.onVertexStateUpdated(new VertexStateUpdate(m3, VertexState.CONFIGURED));
     manager.onVertexStateUpdated(new VertexStateUpdate(m2, VertexState.CONFIGURED));
     manager.onSourceTaskCompleted(createTaskAttemptIdentifier(r1, 0));
-    Assert.assertTrue(manager.pendingTasks.size() == 0); // all tasks scheduled
-    Assert.assertTrue(scheduledTasks.size() == 3);
+    assertEquals(0, manager.pendingTasks.size()); // all tasks scheduled
+    assertEquals(3, scheduledTasks.size());
   }
 
-  @Test
-  public void testZeroTasksSendsConfigured() throws IOException {
+  @ParameterizedTest(name = "test[{0}]")
+  @MethodSource("data")
+  public void testZeroTasksSendsConfigured(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws IOException {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager = null;
 
@@ -1089,7 +1103,7 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
     when(mockContext.getVertexNumTasks(mockManagedVertexId)).thenReturn(0);
 
     // check initialization
-    manager = createManager(conf, mockContext, 0.001f, 0.001f);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.001f, 0.001f);
 
     final List<Integer> scheduledTasks = Lists.newLinkedList();
     doAnswer(new ScheduledTasksAnswer(scheduledTasks)).when(
@@ -1097,17 +1111,19 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
 
     manager.onVertexStarted(emptyCompletions);
     manager.onVertexStateUpdated(new VertexStateUpdate(r1, VertexState.CONFIGURED));
-    Assert.assertEquals(1, manager.bipartiteSources);
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
-    Assert.assertEquals(0, manager.totalNumBipartiteSourceTasks);
-    Assert.assertEquals(0, manager.pendingTasks.size()); // no tasks scheduled
-    Assert.assertEquals(0, scheduledTasks.size());
+    assertEquals(1, manager.bipartiteSources);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(0, manager.totalNumBipartiteSourceTasks);
+    assertEquals(0, manager.pendingTasks.size()); // no tasks scheduled
+    assertEquals(0, scheduledTasks.size());
     verify(mockContext).doneReconfiguringVertex();
   }
 
 
-  @Test(timeout=5000)
-  public void testTezDrainCompletionsOnVertexStart() throws IOException {
+  @ParameterizedTest(name = "test[{0}]")
+  @MethodSource("data")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testTezDrainCompletionsOnVertexStart(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws IOException {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
 
@@ -1123,17 +1139,17 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
       mockManagedVertexId, 4, scheduledTasks, null);
 
     //min/max fraction of 0.01/0.75 would ensure that we hit determineParallelism code path on receiving first event itself.
-    manager = createManager(conf, mockContext, 0.01f, 0.75f);
-    Assert.assertEquals(0, manager.numBipartiteSourceTasksCompleted);
+    manager = createManager(shuffleVertexManagerClass, conf, mockContext, 0.01f, 0.75f);
+    assertEquals(0, manager.numBipartiteSourceTasksCompleted);
     manager.onVertexStarted(Collections.singletonList(
       TestShuffleVertexManager.createTaskAttemptIdentifier(mockSrcVertexId1, 0)));
-    Assert.assertEquals(1, manager.numBipartiteSourceTasksCompleted);
+    assertEquals(1, manager.numBipartiteSourceTasksCompleted);
 
   }
 
-  private ShuffleVertexManagerBase createManager(Configuration conf,
+  private ShuffleVertexManagerBase createManager(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass, Configuration conf,
       VertexManagerPluginContext context, Float min, Float max) {
-    return createManager(this.shuffleVertexManagerClass, conf, context, true,
+    return createManager(shuffleVertexManagerClass, conf, context, true,
         null, min, max);
   }
 }

--- a/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestShuffleVertexManagerBase.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestShuffleVertexManagerBase.java
@@ -61,8 +61,9 @@ import org.apache.tez.runtime.api.events.VertexManagerEvent;
 import com.google.common.collect.Lists;
 
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.*;
-import org.junit.jupiter.params.provider.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils {
@@ -71,10 +72,7 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
 
   @SuppressWarnings("deprecation")
   public static Stream<Arguments> data() {
-    return Stream.of(
-        Arguments.of(ShuffleVertexManager.class),
-        Arguments.of(FairShuffleVertexManager.class)
-    );
+    return Stream.of(Arguments.of(ShuffleVertexManager.class), Arguments.of(FairShuffleVertexManager.class));
   }
 
   // Test zero source tasks and onVertexStarted is called
@@ -82,7 +80,8 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
   @ParameterizedTest(name = "test[{0}]")
   @MethodSource("data")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testZeroSourceTasksWithVertexStartedFirst(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) {
+  public void testZeroSourceTasksWithVertexStartedFirst(
+      Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
 
@@ -124,7 +123,8 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
   @ParameterizedTest(name = "test[{0}]")
   @MethodSource("data")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testZeroSourceTasksWithVertexStateUpdatedFirst(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) {
+  public void testZeroSourceTasksWithVertexStateUpdatedFirst(
+      Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
 
@@ -195,7 +195,8 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
   @ParameterizedTest(name = "test[{0}]")
   @MethodSource("data")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testPartitionStats(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws IOException {
+  public void testPartitionStats(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass)
+      throws IOException {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
 
@@ -375,7 +376,8 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
   @ParameterizedTest(name = "test[{0}]")
   @MethodSource("data")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testAutoParallelism(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws Exception {
+  public void testAutoParallelism(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass)
+      throws Exception {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
 
@@ -806,7 +808,8 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
   @ParameterizedTest(name = "test[{0}]")
   @MethodSource("data")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void test_Tez1649_with_scatter_gather_edges(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws IOException {
+  public void test_Tez1649_with_scatter_gather_edges(
+      Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws IOException {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager = null;
 
@@ -1081,7 +1084,7 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
 
   @ParameterizedTest(name = "test[{0}]")
   @MethodSource("data")
-  public void testZeroTasksSendsConfigured(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws IOException {
+  public void testZeroTasksSendsConfigured(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager = null;
 
@@ -1123,7 +1126,7 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
   @ParameterizedTest(name = "test[{0}]")
   @MethodSource("data")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testTezDrainCompletionsOnVertexStart(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) throws IOException {
+  public void testTezDrainCompletionsOnVertexStart(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass) {
     Configuration conf = new Configuration();
     ShuffleVertexManagerBase manager;
 
@@ -1147,9 +1150,9 @@ public class TestShuffleVertexManagerBase extends TestShuffleVertexManagerUtils 
 
   }
 
-  private ShuffleVertexManagerBase createManager(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass, Configuration conf,
-      VertexManagerPluginContext context, Float min, Float max) {
-    return createManager(shuffleVertexManagerClass, conf, context, true,
-        null, min, max);
+  private ShuffleVertexManagerBase createManager(Class<? extends ShuffleVertexManagerBase> shuffleVertexManagerClass,
+                                                 Configuration conf, VertexManagerPluginContext context, Float min,
+                                                 Float max) {
+    return createManager(shuffleVertexManagerClass, conf, context, true, null, min, max);
   }
 }

--- a/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestShuffleVertexManagerUtils.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestShuffleVertexManagerUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.tez.dag.library.vertexmanager;
 
-
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyList;

--- a/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestVertexManagerWithConcurrentInput.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/dag/library/vertexmanager/TestVertexManagerWithConcurrentInput.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tez.dag.library.vertexmanager;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.dag.api.EdgeManagerPluginDescriptor;
 import org.apache.tez.dag.api.EdgeProperty;
@@ -37,9 +39,9 @@ import org.apache.tez.dag.api.event.VertexState;
 import org.apache.tez.dag.api.event.VertexStateUpdate;
 import org.apache.tez.dag.library.edgemanager.SilentEdgeManager;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
@@ -49,12 +51,13 @@ public class TestVertexManagerWithConcurrentInput {
   @Captor
   ArgumentCaptor<List<VertexManagerPluginContext.ScheduleTaskRequest>> requestCaptor;
 
-  @Before
+  @BeforeEach
   public void init() {
     MockitoAnnotations.initMocks(this);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testBasicVertexWithConcurrentInput() throws Exception {
     HashMap<String, EdgeProperty> mockInputVertices =
         new HashMap<String, EdgeProperty>();
@@ -110,6 +113,6 @@ public class TestVertexManagerWithConcurrentInput {
     manager.onVertexStarted(Collections.singletonList(
         TestShuffleVertexManager.createTaskAttemptIdentifier(mockSrcVertexId1, 0)));
     verify(mockContext, times(1)).scheduleTasks(requestCaptor.capture());
-    Assert.assertEquals(0, manager.completedUpstreamTasks);
+    assertEquals(0, manager.completedUpstreamTasks);
   }
 }

--- a/tez-runtime-library/src/test/java/org/apache/tez/http/TestHttpConnection.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/http/TestHttpConnection.java
@@ -193,8 +193,7 @@ public class TestHttpConnection {
           if (t instanceof ConnectException) {
             //ClosedByInterruptException via NettyConnectListener.operationComplete()
             assertInstanceOf(ClosedByInterruptException.class, t.getCause(),
-                "Expected ClosedByInterruptException, received "
-                    + Throwables.getStackTraceAsString(t.getCause()));
+                "Expected ClosedByInterruptException, received " + Throwables.getStackTraceAsString(t.getCause()));
           } else {
             // InterruptedException if TezBodyDeferringAsyncHandler quits
             assertInstanceOf(InterruptedException.class, t);

--- a/tez-runtime-library/src/test/java/org/apache/tez/http/TestHttpConnection.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/http/TestHttpConnection.java
@@ -18,8 +18,11 @@
  */
 package org.apache.tez.http;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -38,15 +41,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.common.security.JobTokenSecretManager;
 import org.apache.tez.http.async.netty.AsyncHttpConnection;
 
 import com.google.common.base.Throwables;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestHttpConnection {
 
@@ -67,7 +72,7 @@ public class TestHttpConnection {
 
   private Thread currentThread;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException, URISyntaxException {
     executorService = Executors.newFixedThreadPool(1,
         new ThreadFactory() {
@@ -82,7 +87,7 @@ public class TestHttpConnection {
     when(tokenSecretManager.computeHash(any())).thenReturn("1234".getBytes());
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws Exception {
     executorService.shutdownNow();
   }
@@ -94,16 +99,16 @@ public class TestHttpConnection {
       Future<Void> future = executorService.submit(worker);
       future.get();
     } catch (ExecutionException e) {
-      assertTrue(e.getCause().getCause() instanceof IOException);
-      assertTrue(e.getMessage(), e.getMessage().contains(message));
+      assertInstanceOf(IOException.class, e.getCause().getCause());
+      assertTrue(e.getMessage().contains(message), e.getMessage());
       long elapsedTime = System.currentTimeMillis() - startTime;
-      assertTrue("elapasedTime=" + elapsedTime + " should be greater than " + connTimeout,
-          elapsedTime > connTimeout);
+      assertTrue(elapsedTime > connTimeout, "elapasedTime=" + elapsedTime + " should be greater than " + connTimeout);
     }
-    assertTrue(latch.getCount() == 0);
+    assertEquals(0, latch.getCount());
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testConnectionTimeout() throws IOException, InterruptedException {
     HttpConnectionParams params = getConnectionParams();
 
@@ -118,7 +123,8 @@ public class TestHttpConnection {
     baseTest(new Worker(latch, asyncHttpConn, false), latch, "connection timed out");
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   //Should be interruptible
   public void testAsyncHttpConnectionInterrupt()
       throws IOException, InterruptedException, ExecutionException {
@@ -132,14 +138,14 @@ public class TestHttpConnection {
         wait(100);
       }
     }
-    assertTrue("currentThread is still null", currentThread != null);
+    assertNotNull(currentThread, "currentThread is still null");
     Thread.sleep(1000); //To avoid race to interrupt the thread before connect()
 
     //Try interrupting the thread (exception verification happens in the worker itself)
     currentThread.interrupt();
 
     future.get();
-    assertTrue(latch.getCount() == 0);
+    assertEquals(0, latch.getCount());
   }
 
   HttpConnectionParams getConnectionParams() {
@@ -186,12 +192,12 @@ public class TestHttpConnection {
         if (expectingInterrupt) {
           if (t instanceof ConnectException) {
             //ClosedByInterruptException via NettyConnectListener.operationComplete()
-            assertTrue("Expected ClosedByInterruptException, received "
-                    + Throwables.getStackTraceAsString(t.getCause()),
-                t.getCause() instanceof ClosedByInterruptException);
+            assertInstanceOf(ClosedByInterruptException.class, t.getCause(),
+                "Expected ClosedByInterruptException, received "
+                    + Throwables.getStackTraceAsString(t.getCause()));
           } else {
             // InterruptedException if TezBodyDeferringAsyncHandler quits
-            assertTrue(t instanceof InterruptedException);
+            assertInstanceOf(InterruptedException.class, t);
           }
         }
       } finally {

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/common/resources/TestWeightedScalingMemoryDistributor.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/common/resources/TestWeightedScalingMemoryDistributor.java
@@ -18,9 +18,11 @@
  */
 package org.apache.tez.runtime.common.resources;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.dag.api.InputDescriptor;
@@ -41,10 +43,13 @@ import org.apache.tez.runtime.library.resources.WeightedScalingMemoryDistributor
 
 import com.google.common.base.Joiner;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestWeightedScalingMemoryDistributor extends TestMemoryDistributor {
 
+  @BeforeEach
   @Override
   public void setup() {
     conf.setBoolean(TezConfiguration.TEZ_TASK_SCALE_MEMORY_ENABLED, true);
@@ -54,7 +59,8 @@ public class TestWeightedScalingMemoryDistributor extends TestMemoryDistributor 
     conf.setDouble(TezConfiguration.TEZ_TASK_SCALE_MEMORY_ADDITIONAL_RESERVATION_FRACTION_PER_IO, 0.0d);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleWeightedScaling() throws TezException {
     Configuration conf = new Configuration(this.conf);
     conf.setStrings(TezConfiguration.TEZ_TASK_SCALE_MEMORY_WEIGHTED_RATIOS,
@@ -101,7 +107,8 @@ public class TestWeightedScalingMemoryDistributor extends TestMemoryDistributor 
     assertEquals(2000, e4Callback.assigned);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAdditionalReserveFractionWeightedScaling() throws TezException {
     Configuration conf = new Configuration(this.conf);
     conf.setStrings(TezConfiguration.TEZ_TASK_SCALE_MEMORY_WEIGHTED_RATIOS,
@@ -148,7 +155,8 @@ public class TestWeightedScalingMemoryDistributor extends TestMemoryDistributor 
     assertEquals(1500, e4Callback.assigned);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWeightedScalingNonConcurrent() throws TezException {
     Configuration conf = new Configuration(this.conf);
     conf.setBoolean(TezConfiguration.TEZ_TASK_SCALE_MEMORY_INPUT_OUTPUT_CONCURRENT, false);
@@ -205,7 +213,8 @@ public class TestWeightedScalingMemoryDistributor extends TestMemoryDistributor 
     assertEquals(1000, e5Callback.assigned);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAdditionalReserveFractionWeightedScalingNonConcurrent() throws TezException {
     Configuration conf = new Configuration(this.conf);
     conf.setBoolean(TezConfiguration.TEZ_TASK_SCALE_MEMORY_INPUT_OUTPUT_CONCURRENT, false);
@@ -254,7 +263,8 @@ public class TestWeightedScalingMemoryDistributor extends TestMemoryDistributor 
     assertEquals(4500, e4Callback.assigned);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWeightedScalingNonConcurrentInputsDisabled() throws TezException {
     Configuration conf = new Configuration(this.conf);
     conf.setBoolean(TezConfiguration.TEZ_TASK_SCALE_MEMORY_INPUT_OUTPUT_CONCURRENT, false);

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/api/TestTezRuntimeConfiguration.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/api/TestTezRuntimeConfiguration.java
@@ -18,20 +18,22 @@
  */
 package org.apache.tez.runtime.library.api;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Field;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 
 public class TestTezRuntimeConfiguration {
 
-
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testKeySet() throws IllegalAccessException {
     Class<?> c = TezRuntimeConfiguration.class;
     Set<String> expectedKeys = new HashSet<String>();
@@ -47,7 +49,6 @@ public class TestTezRuntimeConfiguration {
         fail("Found unexpected key: " + key + " in key set");
       }
     }
-    assertTrue("Missing keys in key set: " + expectedKeys, expectedKeys.size() == 0);
+    assertEquals(0, expectedKeys.size(), "Missing keys in key set: " + expectedKeys);
   }
-
 }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductCombination.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductCombination.java
@@ -18,16 +18,19 @@
  */
 package org.apache.tez.runtime.library.cartesianproduct;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import com.google.common.primitives.Ints;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestCartesianProductCombination {
   private void verifyCombination(CartesianProductCombination combination, int[] result, int taskId) {
@@ -72,7 +75,8 @@ public class TestCartesianProductCombination {
     assertFalse(combination.nextTaskWithFixedChunk());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCombinationWithFixedPartition() {
     // two way cartesian product
     testCombinationTwoWayVertex0();
@@ -82,7 +86,8 @@ public class TestCartesianProductCombination {
     testCombinationThreeWay();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCombination() {
     CartesianProductCombination combination = new CartesianProductCombination(new int[]{2,3});
     List<Integer> list = combination.getCombination();
@@ -93,29 +98,31 @@ public class TestCartesianProductCombination {
         } else {
           assertTrue(combination.nextTask());
         }
-        assertTrue(list.get(0) == i);
-        assertTrue(list.get(1) == j);
+        assertEquals((int) list.get(0), i);
+        assertEquals((int) list.get(1), j);
       }
     }
     assertFalse(combination.nextTask());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFromTaskId() {
     for (int i = 0; i < 6; i++) {
       List<Integer> list = CartesianProductCombination.fromTaskId(new int[]{2,3}, i)
                                                       .getCombination();
-      assertTrue(list.get(0) == i/3);
-      assertTrue(list.get(1) == i%3);
+      assertEquals((int) list.get(0), i / 3);
+      assertEquals((int) list.get(1), i % 3);
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRejectZero() {
     int[] numChunk = new int[] {0 ,1};
     try {
       new CartesianProductCombination(numChunk);
-      assertTrue(false);
+      fail();
     } catch (Exception ignored) {}
   }
 }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductConfig.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductConfig.java
@@ -18,10 +18,10 @@
  */
 package org.apache.tez.runtime.library.cartesianproduct;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.UserPayload;
@@ -37,18 +38,20 @@ import org.apache.tez.runtime.library.cartesianproduct.CartesianProductUserPaylo
 
 import com.google.common.primitives.Ints;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestCartesianProductConfig {
   private TezConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf = new TezConfiguration();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSerializationPartitioned() throws IOException {
     Map<String, Integer> vertexPartitionMap = new HashMap<>();
     vertexPartitionMap.put("v1", 2);
@@ -67,7 +70,8 @@ public class TestCartesianProductConfig {
     assertConfigEquals(config, parsedConfig);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSerializationFair() throws Exception {
     List<String> sourceVertices = new ArrayList<>();
     sourceVertices.add("v1");
@@ -114,7 +118,8 @@ public class TestCartesianProductConfig {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFairCartesianProductConfig() {
     List<String> sourceVertices = new ArrayList<>();
     sourceVertices.add("v0");

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductEdgeManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductEdgeManager.java
@@ -52,8 +52,7 @@ public class TestCartesianProductEdgeManager {
     UserPayload payload = UserPayload.create(ByteBuffer.wrap(builder.build().toByteArray()));
     when(context.getUserPayload()).thenReturn(payload);
     edgeManager.initialize();
-    assertInstanceOf(CartesianProductEdgeManagerPartitioned.class,
-        edgeManager.getEdgeManagerReal());
+    assertInstanceOf(CartesianProductEdgeManagerPartitioned.class, edgeManager.getEdgeManagerReal());
 
     // unpartitioned case
     builder.clear();

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductEdgeManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductEdgeManager.java
@@ -19,22 +19,25 @@
 package org.apache.tez.runtime.library.cartesianproduct;
 
 import static org.apache.tez.runtime.library.cartesianproduct.CartesianProductUserPayload.*;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.dag.api.EdgeManagerPluginContext;
 import org.apache.tez.dag.api.UserPayload;
 
 import com.google.common.primitives.Ints;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestCartesianProductEdgeManager {
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInitialize() throws Exception {
     EdgeManagerPluginContext context = mock(EdgeManagerPluginContext.class);
     when(context.getSourceVertexName()).thenReturn("v0");
@@ -49,8 +52,8 @@ public class TestCartesianProductEdgeManager {
     UserPayload payload = UserPayload.create(ByteBuffer.wrap(builder.build().toByteArray()));
     when(context.getUserPayload()).thenReturn(payload);
     edgeManager.initialize();
-    assertTrue(edgeManager.getEdgeManagerReal()
-      instanceof CartesianProductEdgeManagerPartitioned);
+    assertInstanceOf(CartesianProductEdgeManagerPartitioned.class,
+        edgeManager.getEdgeManagerReal());
 
     // unpartitioned case
     builder.clear();
@@ -62,7 +65,6 @@ public class TestCartesianProductEdgeManager {
     when(context.getUserPayload()).thenReturn(payload);
     when(context.getSourceVertexNumTasks()).thenReturn(2);
     edgeManager.initialize();
-    assertTrue(edgeManager.getEdgeManagerReal()
-      instanceof FairCartesianProductEdgeManager);
+    assertInstanceOf(FairCartesianProductEdgeManager.class, edgeManager.getEdgeManagerReal());
   }
 }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductEdgeManagerPartitioned.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductEdgeManagerPartitioned.java
@@ -19,15 +19,16 @@
 package org.apache.tez.runtime.library.cartesianproduct;
 
 import static org.apache.tez.runtime.library.cartesianproduct.CartesianProductUserPayload.*;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.dag.api.EdgeManagerPluginContext;
 import org.apache.tez.dag.api.EdgeManagerPluginOnDemand.CompositeEventRouteMetadata;
@@ -36,14 +37,15 @@ import org.apache.tez.dag.api.UserPayload;
 
 import com.google.protobuf.ByteString;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestCartesianProductEdgeManagerPartitioned {
   private EdgeManagerPluginContext mockContext;
   private CartesianProductEdgeManagerPartitioned edgeManager;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mockContext = mock(EdgeManagerPluginContext.class);
     edgeManager = new CartesianProductEdgeManagerPartitioned(mockContext);
@@ -53,7 +55,8 @@ public class TestCartesianProductEdgeManagerPartitioned {
    * Vertex v0 has 2 tasks which generate 3 partitions
    * Vertex v1 has 3 tasks which generate 4 partitions
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTwoWay() throws Exception {
     CartesianProductConfigProto.Builder builder = CartesianProductConfigProto.newBuilder();
     builder.setIsPartitioned(true).addSources("v0").addSources("v1")
@@ -145,7 +148,8 @@ public class TestCartesianProductEdgeManagerPartitioned {
    * Vertex v0 has 2 tasks which generate 3 partitions
    * Vertex v1 has 3 tasks which generate 4 partitions
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTwoWayWithFilter() throws Exception {
     CartesianProductConfigProto.Builder builder = CartesianProductConfigProto.newBuilder();
     ByteBuffer buffer = ByteBuffer.allocate(2).putChar('>');
@@ -212,7 +216,8 @@ public class TestCartesianProductEdgeManagerPartitioned {
    * Vertex v1 has 3 tasks which generate 3 partitions
    * Vertex v2 has 4 tasks which generate 2 partitions
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testThreeWay() throws Exception {
     CartesianProductConfigProto.Builder builder = CartesianProductConfigProto.newBuilder();
     builder.setIsPartitioned(true).addSources("v0").addSources("v1").addSources("v2")

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductVertexManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductVertexManager.java
@@ -20,7 +20,10 @@ package org.apache.tez.runtime.library.cartesianproduct;
 
 import static org.apache.tez.dag.api.EdgeProperty.DataMovementType.BROADCAST;
 import static org.apache.tez.dag.api.EdgeProperty.DataMovementType.CUSTOM;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +32,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.dag.api.EdgeManagerPluginDescriptor;
 import org.apache.tez.dag.api.EdgeProperty;
@@ -37,8 +41,9 @@ import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.UserPayload;
 import org.apache.tez.dag.api.VertexManagerPluginContext;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -56,7 +61,7 @@ public class TestCartesianProductVertexManager {
   private EdgeProperty broadcastEdge =
     EdgeProperty.create(DataMovementType.BROADCAST, null, null, null, null);
 
-  @Before
+  @BeforeEach
   public void setup() {
     context = mock(VertexManagerPluginContext.class);
     conf = new TezConfiguration();
@@ -75,22 +80,24 @@ public class TestCartesianProductVertexManager {
     vertexManager = new CartesianProductVertexManager(context);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testRejectPredefinedParallelism() throws Exception {
     when(context.getVertexNumTasks(vertexName)).thenReturn(10);
     try {
       vertexManager = new CartesianProductVertexManager(context);
-      assertTrue(false);
+      fail();
     } catch (Exception ignored){}
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testChooseRealVertexManager() throws Exception {
     // partitioned case
     config = new CartesianProductConfig(new int[]{2, 3}, new String[]{"v0", "v1"}, null);
     vertexManager.initialize();
-    assertTrue(vertexManager.getVertexManagerReal()
-      instanceof CartesianProductVertexManagerPartitioned);
+    assertInstanceOf(CartesianProductVertexManagerPartitioned.class,
+        vertexManager.getVertexManagerReal());
 
     // unpartitioned case
     List<String> sourceVertices = new ArrayList<>();
@@ -98,11 +105,11 @@ public class TestCartesianProductVertexManager {
     sourceVertices.add("v1");
     config = new CartesianProductConfig(sourceVertices);
     vertexManager.initialize();
-    assertTrue(vertexManager.getVertexManagerReal()
-      instanceof FairCartesianProductVertexManager);
+    assertInstanceOf(FairCartesianProductVertexManager.class, vertexManager.getVertexManagerReal());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCheckDAGConfigConsistent() throws Exception {
     // positive case
     edgePropertyMap.put("v2", broadcastEdge);
@@ -113,7 +120,7 @@ public class TestCartesianProductVertexManager {
     edgePropertyMap.put("v2", cpEdge);
     try {
       vertexManager.initialize();
-      assertTrue(false);
+      fail();
     } catch (Exception ignored) {}
 
     // non-cartesian-product edge in dag but in config
@@ -121,24 +128,25 @@ public class TestCartesianProductVertexManager {
     config = new CartesianProductConfig(new int[]{2, 3, 4}, new String[]{"v0", "v1", "v2"}, null);
     try {
       vertexManager.initialize();
-      assertTrue(false);
+      fail();
     } catch (Exception ignored) {}
 
     edgePropertyMap.put("v2", customEdge);
     try {
       vertexManager.initialize();
-      assertTrue(false);
+      fail();
     } catch (Exception ignored) {}
 
     // edge in config but not in dag
     edgePropertyMap.remove("v2");
     try {
       vertexManager.initialize();
-      assertTrue(false);
+      fail();
     } catch (Exception ignored) {}
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCheckDAGConfigConsistentWithVertexGroup() throws Exception {
     // positive case
     edgePropertyMap.put("v2", cpEdge);
@@ -152,18 +160,19 @@ public class TestCartesianProductVertexManager {
     edgePropertyMap.put("v2", broadcastEdge);
     try {
       vertexManager.initialize();
-      assertTrue(false);
+      fail();
     } catch (Exception ignored) {}
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOtherEdgeType() throws Exception {
     // forbid other custom edge
     edgePropertyMap.put("v2", customEdge);
     config = new CartesianProductConfig(new int[]{2, 3}, new String[]{"v0", "v1"}, null);
     try {
       vertexManager.initialize();
-      assertTrue(false);
+      fail();
     } catch (Exception ignored) {}
 
     // broadcast edge should be allowed and other non-custom edge shouldn't be allowed
@@ -174,9 +183,9 @@ public class TestCartesianProductVertexManager {
       edgePropertyMap.put("v2", EdgeProperty.create(type, null, null, null, null));
       try {
         vertexManager.initialize();
-        assertTrue(type == BROADCAST);
+        assertSame(type, BROADCAST);
       } catch (Exception e) {
-        assertTrue(type != BROADCAST);
+        assertNotSame(type, BROADCAST);
       }
     }
   }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductVertexManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductVertexManager.java
@@ -96,8 +96,7 @@ public class TestCartesianProductVertexManager {
     // partitioned case
     config = new CartesianProductConfig(new int[]{2, 3}, new String[]{"v0", "v1"}, null);
     vertexManager.initialize();
-    assertInstanceOf(CartesianProductVertexManagerPartitioned.class,
-        vertexManager.getVertexManagerReal());
+    assertInstanceOf(CartesianProductVertexManagerPartitioned.class, vertexManager.getVertexManagerReal());
 
     // unpartitioned case
     List<String> sourceVertices = new ArrayList<>();

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductVertexManagerPartitioned.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestCartesianProductVertexManagerPartitioned.java
@@ -19,8 +19,8 @@
 package org.apache.tez.runtime.library.cartesianproduct;
 
 import static org.apache.tez.dag.api.EdgeProperty.DataMovementType.BROADCAST;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.isNull;
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.dag.api.EdgeManagerPluginDescriptor;
 import org.apache.tez.dag.api.EdgeProperty;
@@ -51,8 +52,9 @@ import org.apache.tez.dag.records.TezVertexID;
 import org.apache.tez.runtime.api.TaskAttemptIdentifier;
 import org.apache.tez.runtime.library.cartesianproduct.CartesianProductUserPayload.CartesianProductConfigProto;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
@@ -66,7 +68,7 @@ public class TestCartesianProductVertexManagerPartitioned {
   private VertexManagerPluginContext context;
   private List<TaskAttemptIdentifier> allCompletions;
 
-  @Before
+  @BeforeEach
   public void setup() throws TezReflectionException {
     CartesianProductConfigProto.Builder builder = CartesianProductConfigProto.newBuilder();
     builder.setIsPartitioned(true).addSources("v0").addSources("v1")
@@ -116,7 +118,8 @@ public class TestCartesianProductVertexManagerPartitioned {
     assertNull(edgePropertiesCaptor.getValue());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testReconfigureVertex() throws Exception {
     CartesianProductConfigProto.Builder builder = CartesianProductConfigProto.newBuilder();
     builder.setIsPartitioned(true).addSources("v0").addSources("v1")
@@ -126,7 +129,8 @@ public class TestCartesianProductVertexManagerPartitioned {
     testReconfigureVertexHelper(builder.build(), 25);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testScheduling() throws Exception {
     vertexManager.onVertexStarted(null);
     vertexManager.onVertexStateUpdated(new VertexStateUpdate("v0", VertexState.CONFIGURED));
@@ -166,12 +170,14 @@ public class TestCartesianProductVertexManagerPartitioned {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOnVertexStartWithBroadcastRunning() throws Exception {
     testOnVertexStartHelper(true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOnVertexStartWithoutBroadcastRunning() throws Exception {
     testOnVertexStartHelper(false);
   }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestFairCartesianProductEdgeManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestFairCartesianProductEdgeManager.java
@@ -19,25 +19,28 @@
 package org.apache.tez.runtime.library.cartesianproduct;
 
 import static org.apache.tez.runtime.library.cartesianproduct.CartesianProductUserPayload.*;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.dag.api.EdgeManagerPluginContext;
 import org.apache.tez.dag.api.EdgeManagerPluginOnDemand.CompositeEventRouteMetadata;
 import org.apache.tez.dag.api.EdgeManagerPluginOnDemand.EventRouteMetadata;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestFairCartesianProductEdgeManager {
   private EdgeManagerPluginContext mockContext;
   private FairCartesianProductEdgeManager edgeManager;
 
-  @Before
+  @BeforeEach
   public void setup() {
     mockContext = mock(EdgeManagerPluginContext.class);
     edgeManager = new FairCartesianProductEdgeManager(mockContext);
@@ -127,7 +130,8 @@ public class TestFairCartesianProductEdgeManager {
    * Vertex v0 has 2 tasks, 2 chunks
    * Vertex v1 has 30 tasks, 3 chunks
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTwoWayAllVertex() throws Exception {
     CartesianProductConfigProto.Builder builder = CartesianProductConfigProto.newBuilder();
     builder.setIsPartitioned(false).addSources("v0").addSources("v1")
@@ -150,7 +154,8 @@ public class TestFairCartesianProductEdgeManager {
    * Vertex v1 has 30 tasks, 3 chunks
    * Vertex v2 has 1 tasks, 4 chunks
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testThreeWayAllVertex() throws Exception {
     CartesianProductConfigProto.Builder builder = CartesianProductConfigProto.newBuilder();
     builder.setIsPartitioned(false).addSources("v0").addSources("v1").addSources("v2")
@@ -181,7 +186,8 @@ public class TestFairCartesianProductEdgeManager {
    * Vertex v2 has 20 tasks
    * Group g0 has 3 chunks
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTwoWayVertexWithVertexGroup() throws Exception {
     CartesianProductConfigProto.Builder builder = CartesianProductConfigProto.newBuilder();
     builder.setIsPartitioned(false).addSources("v0").addSources("g0")
@@ -208,7 +214,8 @@ public class TestFairCartesianProductEdgeManager {
    * Group g0 has 2 chunks
    * Group g1 has 3 chunks
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testTwoWayAllVertexGroup() throws Exception {
     CartesianProductConfigProto.Builder builder = CartesianProductConfigProto.newBuilder();
     builder.setIsPartitioned(false).addSources("g0").addSources("g1")
@@ -227,7 +234,8 @@ public class TestFairCartesianProductEdgeManager {
       dataForInputError(1, 15, 0), dataForDest(1, 25), dataForSrc(1, 10), dataForSrc(1, 3));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNumPartition() throws Exception {
     when(mockContext.getSourceVertexName()).thenReturn("source");
     when(mockContext.getSourceVertexNumTasks()).thenReturn(10);

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestFairCartesianProductVertexManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestFairCartesianProductVertexManager.java
@@ -19,9 +19,9 @@
 package org.apache.tez.runtime.library.cartesianproduct;
 
 import static org.apache.tez.dag.api.EdgeProperty.DataMovementType.BROADCAST;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyMap;
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.dag.api.EdgeManagerPluginDescriptor;
 import org.apache.tez.dag.api.EdgeProperty;
@@ -58,8 +59,9 @@ import com.google.common.primitives.Ints;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
@@ -72,7 +74,7 @@ public class TestFairCartesianProductVertexManager {
   private FairCartesianProductVertexManager vertexManager;
   private VertexManagerPluginContext ctx;
 
-  @Before
+  @BeforeEach
   public void setup() {
     MockitoAnnotations.openMocks(this);
     ctx = mock(VertexManagerPluginContext.class);
@@ -218,7 +220,8 @@ public class TestFairCartesianProductVertexManager {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGVertexOnlyGroupByMaxParallelism() throws Exception {
     setupDAGVertexOnly(30, 1, 30, 1);
     vertexManager.onVertexStateUpdated(new VertexStateUpdate("v0", VertexState.CONFIGURED));
@@ -246,7 +249,8 @@ public class TestFairCartesianProductVertexManager {
     verifyScheduleRequest(2, 12, 13, 18, 19, 24, 25);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGVertexOnlyGroupByMinOpsPerWorker() throws Exception {
     setupDAGVertexOnly(100, 10000, 10, 10);
     vertexManager.onVertexStateUpdated(new VertexStateUpdate("v0", VertexState.CONFIGURED));
@@ -278,7 +282,8 @@ public class TestFairCartesianProductVertexManager {
     verifyScheduleRequest(1, 1);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGVertexGroup() throws Exception {
     setupDAGVertexGroup(100, 1, 1);
 
@@ -310,7 +315,8 @@ public class TestFairCartesianProductVertexManager {
     verifyScheduleRequest(2, 1, 6, 11, 16, 21, 26, 31, 36, 41, 46);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDAGVertexGroupOnly() throws Exception {
     setupDAGVertexGroupOnly(100, 1, 1);
 
@@ -345,7 +351,8 @@ public class TestFairCartesianProductVertexManager {
     verifyScheduleRequest(1, 3, 13, 23);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSchedulingVertexOnlyWithBroadcast() throws Exception {
     setupDAGVertexOnlyWithBroadcast(30, 1, 1);
     vertexManager.onVertexStateUpdated(new VertexStateUpdate("v0", VertexState.CONFIGURED));
@@ -366,7 +373,8 @@ public class TestFairCartesianProductVertexManager {
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOnVertexStart() throws Exception {
     setupDAGVertexOnly(6, 1, 6, 1);
     vertexManager.onVertexStateUpdated(new VertexStateUpdate("v0", VertexState.CONFIGURED));
@@ -380,7 +388,8 @@ public class TestFairCartesianProductVertexManager {
     verifyScheduleRequest(1, 0);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testZeroSrcTask() throws Exception {
     ctx = mock(VertexManagerPluginContext.class);
     vertexManager = new FairCartesianProductVertexManager(ctx);
@@ -420,7 +429,8 @@ public class TestFairCartesianProductVertexManager {
     vertexManager.onVertexStateUpdated(new VertexStateUpdate("v0", VertexState.CONFIGURED));
     vertexManager.onVertexStateUpdated(new VertexStateUpdate("v1", VertexState.CONFIGURED));
   }
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGroupingFraction() throws Exception {
     setupGroupingFractionTest();
     vertexManager.onVertexManagerEventReceived(getVMEvent(10000, "v0", 0));
@@ -439,7 +449,8 @@ public class TestFairCartesianProductVertexManager {
         eq(24), any(), edgePropertiesCaptor.capture());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGroupFractionWithZeroStats() throws Exception {
     setupGroupingFractionTest();
 
@@ -453,7 +464,8 @@ public class TestFairCartesianProductVertexManager {
         anyInt(), any(), anyMap());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGroupingFractionWithZeroOutput() throws Exception {
     setupGroupingFractionTest();
 
@@ -467,7 +479,8 @@ public class TestFairCartesianProductVertexManager {
         eq(0), any(), edgePropertiesCaptor.capture());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testZeroSrcOutput() throws Exception {
     setupDAGVertexOnly(10, 1, 10, 1);
     vertexManager.onVertexStateUpdated(new VertexStateUpdate("v0", VertexState.CONFIGURED));
@@ -481,7 +494,8 @@ public class TestFairCartesianProductVertexManager {
         eq(0), any(), edgePropertiesCaptor.capture());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDisableGrouping() throws Exception {
     when(ctx.getInputVertexEdgeProperties()).thenReturn(getEdgePropertyMap(2));
     setSrcParallelism(ctx, 1, 2, 3);
@@ -500,7 +514,8 @@ public class TestFairCartesianProductVertexManager {
         eq(6), any(), edgePropertiesCaptor.capture());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testParallelismTwoSkewedSource() throws Exception {
     setupDAGVertexOnly(100, 10000, 10, 10);
     vertexManager.onVertexStateUpdated(new VertexStateUpdate("v0", VertexState.CONFIGURED));
@@ -519,7 +534,8 @@ public class TestFairCartesianProductVertexManager {
       new int[]{99, 1}, 100);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testParallelismThreeSkewedSource() throws Exception {
     when(ctx.getInputVertexEdgeProperties()).thenReturn(getEdgePropertyMap(3));
     setSrcParallelism(ctx, 10, 2, 3, 4);

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestGrouper.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/cartesianproduct/TestGrouper.java
@@ -18,18 +18,22 @@
  */
 package org.apache.tez.runtime.library.cartesianproduct;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.runtime.library.utils.Grouper;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestGrouper {
   private Grouper grouper = new Grouper();
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEvenlyGrouping() {
     grouper.init(4, 2);
     assertEquals(0, grouper.getFirstItemInGroup(0));
@@ -44,7 +48,8 @@ public class TestGrouper {
     assertFalse(grouper.isInGroup(2, 0));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testUnevenlyGrouping() {
     grouper.init(5, 2);
     assertEquals(0, grouper.getFirstItemInGroup(0));
@@ -59,7 +64,8 @@ public class TestGrouper {
     assertFalse(grouper.isInGroup(3, 0));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSingleGroup() {
     grouper.init(4, 1);
     assertEquals(0, grouper.getFirstItemInGroup(0));
@@ -70,7 +76,8 @@ public class TestGrouper {
     assertTrue(grouper.isInGroup(3, 0));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNoGrouping() {
     grouper.init(2, 2);
     assertEquals(0, grouper.getFirstItemInGroup(0));

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/TestConfigUtils.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/TestConfigUtils.java
@@ -31,8 +31,6 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 
 import org.junit.jupiter.api.Test;
 
-
-
 public class TestConfigUtils {
 
   private static class CustomKey implements WritableComparable<CustomKey>, Configurable {

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/TestConfigUtils.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/TestConfigUtils.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tez.runtime.library.common;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -29,7 +29,8 @@ import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.io.WritableComparator;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 
 public class TestConfigUtils {

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/TestInputIdentifiers.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/TestInputIdentifiers.java
@@ -18,15 +18,20 @@
  */
 package org.apache.tez.runtime.library.common;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestInputIdentifiers {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInputAttemptIdentifier() {
     Set<InputAttemptIdentifier> set = new HashSet<InputAttemptIdentifier>();
     InputAttemptIdentifier i1 = new InputAttemptIdentifier(1, 1, InputAttemptIdentifier.PATH_PREFIX);
@@ -34,14 +39,15 @@ public class TestInputIdentifiers {
     InputAttemptIdentifier i3 = new InputAttemptIdentifier(1, 0, null);
     InputAttemptIdentifier i4 = new InputAttemptIdentifier(0, 1, null);
 
-    Assert.assertTrue(set.add(i1));
-    Assert.assertFalse(set.add(i1));
-    Assert.assertFalse(set.add(i2));
-    Assert.assertTrue(set.add(i3));
-    Assert.assertTrue(set.add(i4));
+    assertTrue(set.add(i1));
+    assertFalse(set.add(i1));
+    assertFalse(set.add(i2));
+    assertTrue(set.add(i3));
+    assertTrue(set.add(i4));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInputAttemptIdentifierIncludes() {
     InputAttemptIdentifier inputData0Attempt0 = new InputAttemptIdentifier(0, 0);
     InputAttemptIdentifier inputData1Attempt0 = new InputAttemptIdentifier(1, 0);
@@ -50,14 +56,14 @@ public class TestInputIdentifiers {
     InputAttemptIdentifier inputData1Attempt1 = new InputAttemptIdentifier(1, 1);
     CompositeInputAttemptIdentifier inputData12Attempt0 = new CompositeInputAttemptIdentifier(1, 0, null, 2);
 
-    Assert.assertTrue(inputData1Attempt0.includes(inputData1Attempt0));
-    Assert.assertFalse(inputData1Attempt0.includes(inputData2Attempt0));
-    Assert.assertFalse(inputData1Attempt0.includes(inputData1Attempt1));
+    assertTrue(inputData1Attempt0.includes(inputData1Attempt0));
+    assertFalse(inputData1Attempt0.includes(inputData2Attempt0));
+    assertFalse(inputData1Attempt0.includes(inputData1Attempt1));
 
-    Assert.assertFalse(inputData12Attempt0.includes(inputData0Attempt0));
-    Assert.assertTrue(inputData12Attempt0.includes(inputData1Attempt0));
-    Assert.assertTrue(inputData12Attempt0.includes(inputData2Attempt0));
-    Assert.assertFalse(inputData12Attempt0.includes(inputData3Attempt0));
-    Assert.assertFalse(inputData12Attempt0.includes(inputData1Attempt1));
+    assertFalse(inputData12Attempt0.includes(inputData0Attempt0));
+    assertTrue(inputData12Attempt0.includes(inputData1Attempt0));
+    assertTrue(inputData12Attempt0.includes(inputData2Attempt0));
+    assertFalse(inputData12Attempt0.includes(inputData3Attempt0));
+    assertFalse(inputData12Attempt0.includes(inputData1Attempt1));
   }
 }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/TestValuesIterator.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/TestValuesIterator.java
@@ -18,10 +18,10 @@
  */
 package org.apache.tez.runtime.library.common;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
@@ -80,11 +81,10 @@ import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 import org.mockito.internal.util.collections.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,7 +107,6 @@ import org.slf4j.LoggerFactory;
  * limitations under the License.
  */
 
-@RunWith(Parameterized.class)
 public class TestValuesIterator {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestValuesIterator.class);
@@ -123,13 +122,13 @@ public class TestValuesIterator {
   static final Random rnd = new Random();
 
   private SerializationContext serializationContext;
-  final RawComparator comparator;
-  final RawComparator correctComparator;
-  final boolean expectedTestResult;
+  RawComparator comparator;
+  RawComparator correctComparator;
+  boolean expectedTestResult;
 
   int mergeFactor;
   //For storing original data
-  final ListMultimap<Writable, Writable> originalData;
+  ListMultimap<Writable, Writable> originalData;
 
   TezRawKeyValueIterator rawKeyValueIterator;
 
@@ -137,26 +136,17 @@ public class TestValuesIterator {
   Path tmpDir;
   Path[] streamPaths; //merge stream paths
 
-  /**
-   * Constructor
-   *
-   * @param serializationClassName serialization class to be used
-   * @param key                    key class name
-   * @param val                    value class name
-   * @param comparator             to be used
-   * @param correctComparator      (real comparator to be used for correct results)
-   * @param testResult             expected result
-   * @throws IOException
-   */
-  public TestValuesIterator(String serializationClassName, Class<?> key, Class<?> val,
+  public void setupInit(String serializationClassName, Class<?> key, Class<?> val,
       TestWithComparator comparator, TestWithComparator correctComparator, boolean testResult)
-      throws IOException {
+      throws Exception {
     this.comparator = getComparator(comparator);
     this.correctComparator =
         (correctComparator == null) ? this.comparator : getComparator(correctComparator);
     this.expectedTestResult = testResult;
     originalData = LinkedListMultimap.create();
     setupConf(key, val, serializationClassName);
+    fs.mkdirs(baseDir);
+    tmpDir = new Path(baseDir, "tmp");
   }
 
   private void setupConf(Class<?> key, Class<?> val, String serializationClassName) throws IOException {
@@ -178,37 +168,43 @@ public class TestValuesIterator {
     serializationContext.applyToConf(conf);
   }
 
-  @Before
-  public void setup() throws Exception {
-    fs.mkdirs(baseDir);
-    tmpDir = new Path(baseDir, "tmp");
-  }
-
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     fs.delete(baseDir, true);
     originalData.clear();
   }
 
-  @Test(timeout = 20000)
-  public void testIteratorWithInMemoryReader() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}, {5}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
+  public void testIteratorWithInMemoryReader(String serializationClassName, Class<?> key, Class<?> val, TestWithComparator comparator, TestWithComparator correctComparator, boolean testResult) throws Exception {
+    setupInit(serializationClassName, key, val, comparator, correctComparator, testResult);
     ValuesIterator iterator = createIterator(true);
     verifyIteratorData(iterator);
   }
 
-  @Test(timeout = 20000)
-  public void testIteratorWithIFileReader() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}, {5}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
+  public void testIteratorWithIFileReader(String serializationClassName, Class<?> key, Class<?> val, TestWithComparator comparator, TestWithComparator correctComparator, boolean testResult) throws Exception {
+    setupInit(serializationClassName, key, val, comparator, correctComparator, testResult);
     ValuesIterator iterator = createIterator(false);
     verifyIteratorData(iterator);
   }
 
-  @Test(timeout = 20000)
-  public void testCountedIteratorWithInmemoryReader() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}, {5}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
+  public void testCountedIteratorWithInmemoryReader(String serializationClassName, Class<?> key, Class<?> val, TestWithComparator comparator, TestWithComparator correctComparator, boolean testResult) throws Exception {
+    setupInit(serializationClassName, key, val, comparator, correctComparator, testResult);
     verifyCountedIteratorReader(true);
   }
 
-  @Test(timeout = 20000)
-  public void testCountedIteratorWithIFileReader() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}, {5}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
+  public void testCountedIteratorWithIFileReader(String serializationClassName, Class<?> key, Class<?> val, TestWithComparator comparator, TestWithComparator correctComparator, boolean testResult) throws Exception {
+    setupInit(serializationClassName, key, val, comparator, correctComparator, testResult);
     verifyCountedIteratorReader(false);
   }
 
@@ -228,13 +224,16 @@ public class TestValuesIterator {
     }
   }
 
-  @Test(timeout = 20000)
-  public void testIteratorWithIFileReaderEmptyPartitions() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}, {5}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
+  public void testIteratorWithIFileReaderEmptyPartitions(String serializationClassName, Class<?> key, Class<?> val, TestWithComparator comparator, TestWithComparator correctComparator, boolean testResult) throws Exception {
+    setupInit(serializationClassName, key, val, comparator, correctComparator, testResult);
     ValuesIterator iterator = createEmptyIterator(false);
-    assertTrue(iterator.moveToNext() == false);
+    assertFalse(iterator.moveToNext());
 
     iterator = createEmptyIterator(true);
-    assertTrue(iterator.moveToNext() == false);
+    assertFalse(iterator.moveToNext());
   }
 
   private void getNextFromFinishedIterator(ValuesIterator iterator) {
@@ -324,7 +323,7 @@ public class TestValuesIterator {
         valueCount++;
       }
       sequence.add(valueCount);
-      assertTrue("At least 1 value per key", valueCount > 0);
+      assertTrue(valueCount > 0, "At least 1 value per key");
     }
     if (expectedTestResult) {
       assertTrue(result);
@@ -403,7 +402,7 @@ public class TestValuesIterator {
         serializationContext.getValueClass(), conf, keyCounter, tupleCounter);
   }
 
-  @Parameterized.Parameters(name = "test[{0}, {1}, {2}, {3} {4} {5} {6}]")
+
   public static Collection<Object[]> getParameters() {
     Collection<Object[]> parameters = new ArrayList<Object[]>();
 

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/TestValuesIterator.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/TestValuesIterator.java
@@ -83,29 +83,11 @@ import com.google.common.collect.Lists;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.*;
-import org.junit.jupiter.params.provider.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.internal.util.collections.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 
 public class TestValuesIterator {
 
@@ -136,9 +118,16 @@ public class TestValuesIterator {
   Path tmpDir;
   Path[] streamPaths; //merge stream paths
 
-  public void setupInit(String serializationClassName, Class<?> key, Class<?> val,
-      TestWithComparator comparator, TestWithComparator correctComparator, boolean testResult)
-      throws Exception {
+  /**
+   * @param serializationClassName serialization class to be used
+   * @param key                    key class name
+   * @param val                    value class name
+   * @param comparator             to be used
+   * @param correctComparator      (real comparator to be used for correct results)
+   * @param testResult             expected result
+   */
+  public void setupInit(String serializationClassName, Class<?> key, Class<?> val, TestWithComparator comparator,
+                        TestWithComparator correctComparator, boolean testResult) throws Exception {
     this.comparator = getComparator(comparator);
     this.correctComparator =
         (correctComparator == null) ? this.comparator : getComparator(correctComparator);
@@ -186,7 +175,9 @@ public class TestValuesIterator {
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}, {5}]")
   @MethodSource("getParameters")
   @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
-  public void testIteratorWithIFileReader(String serializationClassName, Class<?> key, Class<?> val, TestWithComparator comparator, TestWithComparator correctComparator, boolean testResult) throws Exception {
+  public void testIteratorWithIFileReader(String serializationClassName, Class<?> key, Class<?> val,
+                                          TestWithComparator comparator, TestWithComparator correctComparator,
+                                          boolean testResult) throws Exception {
     setupInit(serializationClassName, key, val, comparator, correctComparator, testResult);
     ValuesIterator iterator = createIterator(false);
     verifyIteratorData(iterator);
@@ -195,7 +186,9 @@ public class TestValuesIterator {
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}, {5}]")
   @MethodSource("getParameters")
   @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
-  public void testCountedIteratorWithInmemoryReader(String serializationClassName, Class<?> key, Class<?> val, TestWithComparator comparator, TestWithComparator correctComparator, boolean testResult) throws Exception {
+  public void testCountedIteratorWithInmemoryReader(String serializationClassName, Class<?> key, Class<?> val,
+                                                    TestWithComparator comparator, TestWithComparator correctComparator,
+                                                    boolean testResult) throws Exception {
     setupInit(serializationClassName, key, val, comparator, correctComparator, testResult);
     verifyCountedIteratorReader(true);
   }
@@ -203,7 +196,9 @@ public class TestValuesIterator {
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}, {5}]")
   @MethodSource("getParameters")
   @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
-  public void testCountedIteratorWithIFileReader(String serializationClassName, Class<?> key, Class<?> val, TestWithComparator comparator, TestWithComparator correctComparator, boolean testResult) throws Exception {
+  public void testCountedIteratorWithIFileReader(String serializationClassName, Class<?> key, Class<?> val,
+                                                 TestWithComparator comparator, TestWithComparator correctComparator,
+                                                 boolean testResult) throws Exception {
     setupInit(serializationClassName, key, val, comparator, correctComparator, testResult);
     verifyCountedIteratorReader(false);
   }
@@ -227,7 +222,10 @@ public class TestValuesIterator {
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}, {5}]")
   @MethodSource("getParameters")
   @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
-  public void testIteratorWithIFileReaderEmptyPartitions(String serializationClassName, Class<?> key, Class<?> val, TestWithComparator comparator, TestWithComparator correctComparator, boolean testResult) throws Exception {
+  public void testIteratorWithIFileReaderEmptyPartitions(String serializationClassName, Class<?> key, Class<?> val,
+                                                         TestWithComparator comparator,
+                                                         TestWithComparator correctComparator, boolean testResult)
+      throws Exception {
     setupInit(serializationClassName, key, val, comparator, correctComparator, testResult);
     ValuesIterator iterator = createEmptyIterator(false);
     assertFalse(iterator.moveToNext());
@@ -401,7 +399,6 @@ public class TestValuesIterator {
     return new ValuesIterator(rawKeyValueIterator, comparator, serializationContext.getKeyClass(),
         serializationContext.getValueClass(), conf, keyCounter, tupleCounter);
   }
-
 
   public static Collection<Object[]> getParameters() {
     Collection<Object[]> parameters = new ArrayList<Object[]>();

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/comparator/TestProxyComparator.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/comparator/TestProxyComparator.java
@@ -18,15 +18,17 @@
  */
 package org.apache.tez.runtime.library.common.comparator;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.io.BytesWritable;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,16 +51,17 @@ public class TestProxyComparator {
     bw.set(b, 0, b.length);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
   }
 
   @SuppressWarnings("unchecked")
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testProxyComparator() {
     final ProxyComparator<BytesWritable> comparator = new TezBytesComparator();
     BytesWritable lhs = new BytesWritable();
@@ -70,12 +73,10 @@ public class TestProxyComparator {
         final int lproxy = comparator.getProxy(lhs);
         final int rproxy = comparator.getProxy(rhs);
         if (lproxy < rproxy) {
-          assertTrue(String.format("(%s) %d < (%s) %d", l, lproxy, r, rproxy),
-              comparator.compare(lhs, rhs) < 0);
+          assertTrue(comparator.compare(lhs, rhs) < 0, String.format("(%s) %d < (%s) %d", l, lproxy, r, rproxy));
         }
         if (lproxy > rproxy) {
-          assertTrue(String.format("(%s) %d > (%s) %d", l, lproxy, r, rproxy),
-              comparator.compare(lhs, rhs) > 0);
+          assertTrue(comparator.compare(lhs, rhs) > 0, String.format("(%s) %d > (%s) %d", l, lproxy, r, rproxy));
         }
       }
     }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/readers/TestUnorderedKVReader.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/readers/TestUnorderedKVReader.java
@@ -18,7 +18,9 @@
  */
 package org.apache.tez.runtime.library.common.readers;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
@@ -27,6 +29,7 @@ import static org.mockito.Mockito.spy;
 
 import java.io.IOException;
 import java.util.LinkedList;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -47,10 +50,10 @@ import org.apache.tez.runtime.library.common.shuffle.LocalDiskFetchedInput;
 import org.apache.tez.runtime.library.common.shuffle.impl.ShuffleManager;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -85,7 +88,7 @@ public class TestUnorderedKVReader {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     outputPath = new Path(workDir, outputFileName);
     setupReader();
@@ -145,13 +148,13 @@ public class TestUnorderedKVReader {
     out.close();
   }
 
-  @Before
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     localFs.delete(workDir, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testReadingMultipleTimes() throws Exception {
     int counter = 0;
     while (unorderedKVReader.next()) {
@@ -159,18 +162,19 @@ public class TestUnorderedKVReader {
       unorderedKVReader.getCurrentKey();
       counter++;
     }
-    Assert.assertEquals(1, counter);
+    assertEquals(1, counter);
 
     //Check the reader again. This shouldn't throw EOF exception in IFile
     try {
       boolean next = unorderedKVReader.next();
       fail();
     } catch(IOException ioe) {
-      Assert.assertTrue(ioe.getMessage().contains("For usage, please refer to"));
+      assertTrue(ioe.getMessage().contains("For usage, please refer to"));
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInterruptOnNext() throws IOException, InterruptedException {
     ShuffleManager shuffleManager = mock(ShuffleManager.class);
 

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/TestFetcher.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/TestFetcher.java
@@ -18,6 +18,10 @@
  */
 package org.apache.tez.runtime.library.common.shuffle;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyLong;
@@ -39,6 +43,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -50,6 +55,9 @@ import org.apache.tez.runtime.api.InputContext;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.CompositeInputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.shuffle.FetchedInput.Type;
+import org.apache.tez.runtime.library.common.shuffle.Fetcher.FetcherBuilder;
+import org.apache.tez.runtime.library.common.shuffle.Fetcher.PathPartition;
 import org.apache.tez.runtime.library.common.shuffle.api.ShuffleHandlerError;
 import org.apache.tez.runtime.library.common.shuffle.impl.ShuffleManager;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.ShuffleHeader;
@@ -58,8 +66,8 @@ import org.apache.tez.runtime.library.testutils.RuntimeTestUtils;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -69,7 +77,8 @@ public class TestFetcher {
   private static String HOST = "localhost";
   private static int PORT = 41;
 
-  @Test(timeout = 3000)
+  @Test
+  @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
   public void testLocalFetchModeSetting() throws Exception {
     TezConfiguration conf = new TezConfiguration();
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_OPTIMIZE_LOCAL_FETCH, true);
@@ -148,7 +157,8 @@ public class TestFetcher {
     verify(fetcher).doHttpFetch();
   }
 
-  @Test(timeout = 3000)
+  @Test
+  @Timeout(value = 3000, unit = TimeUnit.MILLISECONDS)
   public void testSetupLocalDiskFetch() throws Exception {
 
     CompositeInputAttemptIdentifier[] srcAttempts = {
@@ -166,7 +176,7 @@ public class TestFetcher {
     conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_OPTIMIZE_LOCAL_FETCH, "true");
     int partition = 42;
     FetcherCallback callback = mock(FetcherCallback.class);
-    Fetcher.FetcherBuilder builder = new Fetcher.FetcherBuilder(callback, null, null,
+    FetcherBuilder builder = new FetcherBuilder(callback, null, null,
         createMockInputContext(), null, conf, true, HOST, PORT,
         false, true, true);
     ArrayList<InputAttemptIdentifier> inputAttemptIdentifiers = new ArrayList<>();
@@ -182,8 +192,8 @@ public class TestFetcher {
     for(CompositeInputAttemptIdentifier compositeInputAttemptIdentifier : srcAttempts) {
       for(int i=0;i<compositeInputAttemptIdentifier.getInputIdentifierCount();i++) {
         inputAttemptIdentifiers.add(compositeInputAttemptIdentifier.expand(i));
-        Fetcher.PathPartition pathPartition =
-            new Fetcher.PathPartition(compositeInputAttemptIdentifier.getPathComponent(),partition + i);
+        PathPartition pathPartition =
+            new PathPartition(compositeInputAttemptIdentifier.getPathComponent(),partition + i);
         fetcher.getPathToAttemptMap().put(pathPartition, compositeInputAttemptIdentifier.expand(i));
       }
     }
@@ -234,17 +244,15 @@ public class TestFetcher {
             .fromCompositeAttemptLocalFetchFailure(srcAttempts[SECOND_FAILED_ATTEMPT_IDX])),
         eq(false));
 
-    Assert.assertEquals("fetchResult host", fetchResult.getHost(), HOST);
-    Assert.assertEquals("fetchResult partition", fetchResult.getPartition(), partition);
-    Assert.assertEquals("fetchResult port", fetchResult.getPort(), PORT);
+    assertEquals(fetchResult.getHost(), HOST, "fetchResult host");
+    assertEquals(fetchResult.getPartition(), partition, "fetchResult partition");
+    assertEquals(fetchResult.getPort(), PORT, "fetchResult port");
 
     // 3nd and 5th attempt failed
     List<InputAttemptIdentifier> pendingInputs = Lists.newArrayList(fetchResult.getPendingInputs());
-    Assert.assertEquals("fetchResult pendingInput size", pendingInputs.size(), 2);
-    Assert.assertEquals("fetchResult failed attempt", pendingInputs.get(0),
-        srcAttempts[FIRST_FAILED_ATTEMPT_IDX]);
-    Assert.assertEquals("fetchResult failed attempt", pendingInputs.get(1),
-        srcAttempts[SECOND_FAILED_ATTEMPT_IDX]);
+    assertEquals(pendingInputs.size(), 2, "fetchResult pendingInput size");
+    assertEquals(pendingInputs.get(0), srcAttempts[FIRST_FAILED_ATTEMPT_IDX], "fetchResult failed attempt");
+    assertEquals(pendingInputs.get(1), srcAttempts[SECOND_FAILED_ATTEMPT_IDX], "fetchResult failed attempt");
   }
 
   protected void verifyFetchSucceeded(FetcherCallback callback, CompositeInputAttemptIdentifier srcAttempId, Configuration conf) throws IOException {
@@ -257,16 +265,16 @@ public class TestFetcher {
         .fetchSucceeded(eq(HOST), eq(srcAttempId.expand(0)), capturedFetchedInput.capture(), eq(p * 100),
             eq(p * 1000), anyLong());
     LocalDiskFetchedInput f = capturedFetchedInput.getValue();
-    Assert.assertEquals("success callback filename", f.getInputFile().toString(),
-        SHUFFLE_INPUT_FILE_PREFIX + pathComponent);
-    Assert.assertTrue("success callback fs", f.getLocalFS() instanceof RawLocalFileSystem);
-    Assert.assertEquals("success callback filesystem", f.getStartOffset(), p * 10);
-    Assert.assertEquals("success callback compressed size", f.getSize(), p * 100);
-    Assert.assertEquals("success callback input id", f.getInputAttemptIdentifier(), srcAttempId.expand(0));
-    Assert.assertEquals("success callback type", f.getType(), FetchedInput.Type.DISK_DIRECT);
+    assertEquals(f.getInputFile().toString(), SHUFFLE_INPUT_FILE_PREFIX + pathComponent, "success callback filename");
+    assertInstanceOf(RawLocalFileSystem.class, f.getLocalFS(), "success callback fs");
+    assertEquals(f.getStartOffset(), p * 10, "success callback filesystem");
+    assertEquals(f.getSize(), p * 100, "success callback compressed size");
+    assertEquals(f.getInputAttemptIdentifier(), srcAttempId.expand(0), "success callback input id");
+    assertEquals(f.getType(), Type.DISK_DIRECT, "success callback type");
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInputAttemptIdentifierMap() {
     InputAttemptIdentifier[] srcAttempts = {
         new InputAttemptIdentifier(0, 1, InputAttemptIdentifier.PATH_PREFIX + "pathComponent_0",
@@ -311,12 +319,12 @@ public class TestFetcher {
     builder.assignWork(HOST, PORT, partition, 1, Arrays.asList(srcAttempts));
     Fetcher fetcher = spy(builder.build());
     fetcher.populateRemainingMap(new LinkedList<InputAttemptIdentifier>(Arrays.asList(srcAttempts)));
-    Assert.assertTrue(expectedSrcAttempts.length == fetcher.srcAttemptsRemaining.size());
+    assertEquals(expectedSrcAttempts.length, fetcher.srcAttemptsRemaining.size());
     Iterator<Entry<String, InputAttemptIdentifier>> iterator = fetcher.srcAttemptsRemaining.entrySet().iterator();
     int count = 0;
     while(iterator.hasNext()) {
       String key = iterator.next().getKey();
-      Assert.assertTrue(expectedSrcAttempts[count++].toString().compareTo(key) == 0);
+      assertEquals(0, expectedSrcAttempts[count++].toString().compareTo(key));
     }
   }
 
@@ -341,9 +349,9 @@ public class TestFetcher {
 
     InputAttemptFetchFailure[] failures =
         fetcher.fetchInputs(input, null, new InputAttemptIdentifier(0, 0));
-    Assert.assertEquals(1, failures.length);
-    Assert.assertTrue(failures[0].isDiskErrorAtSource());
-    Assert.assertFalse(failures[0].isLocalFetch());
+    assertEquals(1, failures.length);
+    assertTrue(failures[0].isDiskErrorAtSource());
+    assertFalse(failures[0].isLocalFetch());
   }
 
   private InputContext createMockInputContext() {

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/TestShuffleUtils.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/TestShuffleUtils.java
@@ -18,6 +18,12 @@
  */
 package org.apache.tez.runtime.library.common.shuffle;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -73,29 +79,11 @@ import org.apache.tez.runtime.library.shuffle.impl.ShuffleUserPayloads;
 import com.google.common.collect.Lists;
 import com.google.protobuf.ByteString;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.slf4j.Logger;
 
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p/>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p/>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 public class TestShuffleUtils {
 
   private OutputContext outputContext;
@@ -138,7 +126,7 @@ public class TestShuffleUtils {
   }
 
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new Configuration();
     outputContext = createTezOutputContext();
@@ -192,24 +180,25 @@ public class TestShuffleUtils {
         outputContext, spillId, new TezSpillRecord(indexFile, conf),
             physicalOutputs, true, pathComponent, null, false, auxiliaryService, TezCommonUtils.newBestCompressionDeflater());
 
-    Assert.assertTrue(events.size() == 1);
-    Assert.assertTrue(events.get(0) instanceof CompositeDataMovementEvent);
+    assertEquals(1, events.size());
+    assertInstanceOf(CompositeDataMovementEvent.class, events.get(0));
 
     CompositeDataMovementEvent cdme = (CompositeDataMovementEvent) events.get(0);
-    Assert.assertTrue(cdme.getCount() == physicalOutputs);
-    Assert.assertTrue(cdme.getSourceIndexStart() == 0);
+    assertEquals(physicalOutputs, cdme.getCount());
+    assertEquals(0, cdme.getSourceIndexStart());
 
     ByteBuffer payload = cdme.getUserPayload();
     ShuffleUserPayloads.DataMovementEventPayloadProto dmeProto =
         ShuffleUserPayloads.DataMovementEventPayloadProto.parseFrom(ByteString.copyFrom(payload));
 
-    Assert.assertTrue(dmeProto.getSpillId() == 0);
-    Assert.assertTrue(dmeProto.hasLastEvent() && !dmeProto.getLastEvent());
+    assertEquals(0, dmeProto.getSpillId());
+    assertTrue(dmeProto.hasLastEvent() && !dmeProto.getLastEvent());
 
     byte[] emptyPartitions = TezCommonUtils.decompressByteStringToByteArray(dmeProto.getEmptyPartitions());
     BitSet emptyPartitionsBitSet = TezUtilsInternal.fromByteArray(emptyPartitions);
-    Assert.assertTrue("emptyPartitionBitSet cardinality (expecting 5) = " + emptyPartitionsBitSet
-        .cardinality(), emptyPartitionsBitSet.cardinality() == 5);
+    assertEquals(5, emptyPartitionsBitSet.cardinality(),
+        "emptyPartitionBitSet cardinality (expecting 5) = " + emptyPartitionsBitSet
+            .cardinality());
 
     events.clear();
 
@@ -233,26 +222,27 @@ public class TestShuffleUtils {
         outputContext, spillId, new TezSpillRecord(indexFile, conf),
             physicalOutputs, true, pathComponent, null, false, auxiliaryService, TezCommonUtils.newBestCompressionDeflater());
 
-    Assert.assertTrue(events.size() == 2); //one for VM
-    Assert.assertTrue(events.get(0) instanceof VertexManagerEvent);
-    Assert.assertTrue(events.get(1) instanceof CompositeDataMovementEvent);
+    assertEquals(2, events.size()); //one for VM
+    assertInstanceOf(VertexManagerEvent.class, events.get(0));
+    assertInstanceOf(CompositeDataMovementEvent.class, events.get(1));
 
     CompositeDataMovementEvent cdme = (CompositeDataMovementEvent) events.get(1);
-    Assert.assertTrue(cdme.getCount() == physicalOutputs);
-    Assert.assertTrue(cdme.getSourceIndexStart() == 0);
+    assertEquals(physicalOutputs, cdme.getCount());
+    assertEquals(0, cdme.getSourceIndexStart());
 
     ShuffleUserPayloads.DataMovementEventPayloadProto dmeProto =
         ShuffleUserPayloads.DataMovementEventPayloadProto.parseFrom(ByteString.copyFrom( cdme.getUserPayload()));
 
     //With final merge, spill details should not be present
-    Assert.assertFalse(dmeProto.hasSpillId());
-    Assert.assertFalse(dmeProto.hasLastEvent() || dmeProto.getLastEvent());
+    assertFalse(dmeProto.hasSpillId());
+    assertFalse(dmeProto.hasLastEvent() || dmeProto.getLastEvent());
 
     byte[]  emptyPartitions = TezCommonUtils.decompressByteStringToByteArray(dmeProto
         .getEmptyPartitions());
     BitSet  emptyPartitionsBitSet = TezUtilsInternal.fromByteArray(emptyPartitions);
-    Assert.assertTrue("emptyPartitionBitSet cardinality (expecting 5) = " + emptyPartitionsBitSet
-        .cardinality(), emptyPartitionsBitSet.cardinality() == 5);
+    assertEquals(5, emptyPartitionsBitSet.cardinality(),
+        "emptyPartitionBitSet cardinality (expecting 5) = " + emptyPartitionsBitSet
+            .cardinality());
 
   }
 
@@ -260,7 +250,7 @@ public class TestShuffleUtils {
   public void testGenerateOnSpillEvent_With_All_EmptyPartitions() throws Exception {
     List<Event> events = Lists.newLinkedList();
 
-    //Create an index file with all empty partitions
+    // Create an index file with all empty partitions
     Path indexFile = createIndexFile(10, true);
 
     boolean finalMergeDisabled = false;
@@ -268,37 +258,52 @@ public class TestShuffleUtils {
     int spillId = 0;
     int physicalOutputs = 10;
     String pathComponent = "/attempt_x_y_0/file.out";
-    String auxiliaryService = conf.get(TezConfiguration.TEZ_AM_SHUFFLE_AUXILIARY_SERVICE_ID,
-        TezConfiguration.TEZ_AM_SHUFFLE_AUXILIARY_SERVICE_ID_DEFAULT);
+    String auxiliaryService =
+        conf.get(
+            TezConfiguration.TEZ_AM_SHUFFLE_AUXILIARY_SERVICE_ID,
+            TezConfiguration.TEZ_AM_SHUFFLE_AUXILIARY_SERVICE_ID_DEFAULT);
 
-    //normal code path where we do final merge all the time
-    ShuffleUtils.generateEventOnSpill(events, finalMergeDisabled, isLastEvent,
-        outputContext, spillId, new TezSpillRecord(indexFile, conf),
-            physicalOutputs, true, pathComponent, null, false, auxiliaryService, TezCommonUtils.newBestCompressionDeflater());
+    // normal code path where we do final merge all the time
+    ShuffleUtils.generateEventOnSpill(
+        events,
+        finalMergeDisabled,
+        isLastEvent,
+        outputContext,
+        spillId,
+        new TezSpillRecord(indexFile, conf),
+        physicalOutputs,
+        true,
+        pathComponent,
+        null,
+        false,
+        auxiliaryService,
+        TezCommonUtils.newBestCompressionDeflater());
 
-    Assert.assertEquals(2, events.size()); //one for VM
-    Assert.assertTrue(events.get(0) instanceof VertexManagerEvent);
-    Assert.assertTrue(events.get(1) instanceof CompositeDataMovementEvent);
+    assertEquals(2, events.size()); // one for VM
+    assertInstanceOf(VertexManagerEvent.class, events.get(0));
+    assertInstanceOf(CompositeDataMovementEvent.class, events.get(1));
 
     CompositeDataMovementEvent cdme = (CompositeDataMovementEvent) events.get(1);
-    Assert.assertEquals(cdme.getCount(), physicalOutputs);
-    Assert.assertEquals(0, cdme.getSourceIndexStart());
+    assertEquals(cdme.getCount(), physicalOutputs);
+    assertEquals(0, cdme.getSourceIndexStart());
 
     ShuffleUserPayloads.DataMovementEventPayloadProto dmeProto =
-        ShuffleUserPayloads.DataMovementEventPayloadProto.parseFrom(ByteString.copyFrom( cdme.getUserPayload()));
+        ShuffleUserPayloads.DataMovementEventPayloadProto.parseFrom(
+            ByteString.copyFrom(cdme.getUserPayload()));
 
-    //spill details should be present
-    Assert.assertEquals(0, dmeProto.getSpillId());
-    Assert.assertTrue(dmeProto.hasLastEvent() && dmeProto.getLastEvent());
+    // spill details should be present
+    assertEquals(0, dmeProto.getSpillId());
+    assertTrue(dmeProto.hasLastEvent() && dmeProto.getLastEvent());
 
-    Assert.assertEquals("", dmeProto.getPathComponent());
+    assertEquals("", dmeProto.getPathComponent());
 
-    byte[]  emptyPartitions = TezCommonUtils.decompressByteStringToByteArray(dmeProto
-        .getEmptyPartitions());
-    BitSet  emptyPartitionsBitSet = TezUtilsInternal.fromByteArray(emptyPartitions);
-    Assert.assertEquals("emptyPartitionBitSet cardinality (expecting 10) = " + emptyPartitionsBitSet
-            .cardinality(), 10, emptyPartitionsBitSet.cardinality());
-
+    byte[] emptyPartitions =
+        TezCommonUtils.decompressByteStringToByteArray(dmeProto.getEmptyPartitions());
+    BitSet emptyPartitionsBitSet = TezUtilsInternal.fromByteArray(emptyPartitions);
+    assertEquals(
+        10,
+        emptyPartitionsBitSet.cardinality(),
+        "emptyPartitionBitSet cardinality (expecting 10) = " + emptyPartitionsBitSet.cardinality());
   }
 
   @Test
@@ -317,10 +322,10 @@ public class TestShuffleUtils {
     try {
       ShuffleUtils.shuffleToMemory(new byte[1024], new ByteArrayInputStream(header),
           1024, 128, mockCodec, false, 0, mock(Logger.class), null);
-      Assert.fail("shuffle was supposed to throw!");
+      fail("shuffle was supposed to throw!");
     } catch (IOException e) {
-      Assert.assertTrue(e.getCause() instanceof InternalError);
-      Assert.assertTrue(e.getMessage().contains(codecErrorMsg));
+      assertInstanceOf(InternalError.class, e.getCause());
+      assertTrue(e.getMessage().contains(codecErrorMsg));
     }
   }
 
@@ -340,10 +345,10 @@ public class TestShuffleUtils {
     try {
       ShuffleUtils.shuffleToMemory(new byte[1024], new ByteArrayInputStream(header),
           1024, 128, mockCodec, false, 0, mock(Logger.class), null);
-      Assert.fail("shuffle was supposed to throw!");
+      fail("shuffle was supposed to throw!");
     } catch (IOException e) {
-      Assert.assertTrue(e.getCause() instanceof IllegalArgumentException);
-      Assert.assertTrue(e.getMessage().contains(codecErrorMsg));
+      assertInstanceOf(IllegalArgumentException.class, e.getCause());
+      assertTrue(e.getMessage().contains(codecErrorMsg));
     }
     CompressionInputStream mockCodecStream1 = mock(CompressionInputStream.class);
     when(mockCodecStream1.read(any(byte[].class), anyInt(), anyInt()))
@@ -356,10 +361,10 @@ public class TestShuffleUtils {
     try {
       ShuffleUtils.shuffleToMemory(new byte[1024], new ByteArrayInputStream(header),
           1024, 128, mockCodec1, false, 0, mock(Logger.class), null);
-      Assert.fail("shuffle was supposed to throw!");
+      fail("shuffle was supposed to throw!");
     } catch (IOException e) {
-      Assert.assertTrue(e instanceof SocketTimeoutException);
-      Assert.assertTrue(e.getMessage().contains(codecErrorMsg));
+      assertInstanceOf(SocketTimeoutException.class, e);
+      assertTrue(e.getMessage().contains(codecErrorMsg));
     }
     CompressionInputStream mockCodecStream2 = mock(CompressionInputStream.class);
     when(mockCodecStream2.read(any(byte[].class), anyInt(), anyInt()))
@@ -372,10 +377,10 @@ public class TestShuffleUtils {
     try {
       ShuffleUtils.shuffleToMemory(new byte[1024], new ByteArrayInputStream(header),
           1024, 128, mockCodec2, false, 0, mock(Logger.class), null);
-      Assert.fail("shuffle was supposed to throw!");
+      fail("shuffle was supposed to throw!");
     } catch (IOException e) {
-      Assert.assertTrue(e.getCause() instanceof InternalError);
-      Assert.assertTrue(e.getMessage().contains(codecErrorMsg));
+      assertInstanceOf(InternalError.class, e.getCause());
+      assertTrue(e.getMessage().contains(codecErrorMsg));
     }
   }
 
@@ -389,14 +394,14 @@ public class TestShuffleUtils {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     ShuffleUtils.shuffleToDisk(baos, "somehost", in,
         bogusData.length, 2000, mock(Logger.class), null, false, 0, false);
-    Assert.assertArrayEquals(bogusData, baos.toByteArray());
+    assertArrayEquals(bogusData, baos.toByteArray());
 
     // verify sending same stream of zeroes with validation generates an exception
     in.reset();
     try {
       ShuffleUtils.shuffleToDisk(mock(OutputStream.class), "somehost", in,
           bogusData.length, 2000, mock(Logger.class), null, false, 0, true);
-      Assert.fail("shuffle was supposed to throw!");
+      fail("shuffle was supposed to throw!");
     } catch (IOException e) {
     }
   }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/TestShuffleUtils.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/TestShuffleUtils.java
@@ -197,8 +197,7 @@ public class TestShuffleUtils {
     byte[] emptyPartitions = TezCommonUtils.decompressByteStringToByteArray(dmeProto.getEmptyPartitions());
     BitSet emptyPartitionsBitSet = TezUtilsInternal.fromByteArray(emptyPartitions);
     assertEquals(5, emptyPartitionsBitSet.cardinality(),
-        "emptyPartitionBitSet cardinality (expecting 5) = " + emptyPartitionsBitSet
-            .cardinality());
+        "emptyPartitionBitSet cardinality (expecting 5) = " + emptyPartitionsBitSet.cardinality());
 
     events.clear();
 
@@ -241,9 +240,7 @@ public class TestShuffleUtils {
         .getEmptyPartitions());
     BitSet  emptyPartitionsBitSet = TezUtilsInternal.fromByteArray(emptyPartitions);
     assertEquals(5, emptyPartitionsBitSet.cardinality(),
-        "emptyPartitionBitSet cardinality (expecting 5) = " + emptyPartitionsBitSet
-            .cardinality());
-
+        "emptyPartitionBitSet cardinality (expecting 5) = " + emptyPartitionsBitSet.cardinality());
   }
 
   @Test
@@ -258,25 +255,12 @@ public class TestShuffleUtils {
     int spillId = 0;
     int physicalOutputs = 10;
     String pathComponent = "/attempt_x_y_0/file.out";
-    String auxiliaryService =
-        conf.get(
-            TezConfiguration.TEZ_AM_SHUFFLE_AUXILIARY_SERVICE_ID,
-            TezConfiguration.TEZ_AM_SHUFFLE_AUXILIARY_SERVICE_ID_DEFAULT);
+    String auxiliaryService = conf.get(TezConfiguration.TEZ_AM_SHUFFLE_AUXILIARY_SERVICE_ID,
+        TezConfiguration.TEZ_AM_SHUFFLE_AUXILIARY_SERVICE_ID_DEFAULT);
 
     // normal code path where we do final merge all the time
-    ShuffleUtils.generateEventOnSpill(
-        events,
-        finalMergeDisabled,
-        isLastEvent,
-        outputContext,
-        spillId,
-        new TezSpillRecord(indexFile, conf),
-        physicalOutputs,
-        true,
-        pathComponent,
-        null,
-        false,
-        auxiliaryService,
+    ShuffleUtils.generateEventOnSpill(events, finalMergeDisabled, isLastEvent, outputContext, spillId,
+        new TezSpillRecord(indexFile, conf), physicalOutputs, true, pathComponent, null, false, auxiliaryService,
         TezCommonUtils.newBestCompressionDeflater());
 
     assertEquals(2, events.size()); // one for VM
@@ -284,12 +268,11 @@ public class TestShuffleUtils {
     assertInstanceOf(CompositeDataMovementEvent.class, events.get(1));
 
     CompositeDataMovementEvent cdme = (CompositeDataMovementEvent) events.get(1);
-    assertEquals(cdme.getCount(), physicalOutputs);
+    assertEquals(physicalOutputs, cdme.getCount());
     assertEquals(0, cdme.getSourceIndexStart());
 
     ShuffleUserPayloads.DataMovementEventPayloadProto dmeProto =
-        ShuffleUserPayloads.DataMovementEventPayloadProto.parseFrom(
-            ByteString.copyFrom(cdme.getUserPayload()));
+        ShuffleUserPayloads.DataMovementEventPayloadProto.parseFrom(ByteString.copyFrom(cdme.getUserPayload()));
 
     // spill details should be present
     assertEquals(0, dmeProto.getSpillId());
@@ -297,12 +280,9 @@ public class TestShuffleUtils {
 
     assertEquals("", dmeProto.getPathComponent());
 
-    byte[] emptyPartitions =
-        TezCommonUtils.decompressByteStringToByteArray(dmeProto.getEmptyPartitions());
+    byte[] emptyPartitions = TezCommonUtils.decompressByteStringToByteArray(dmeProto.getEmptyPartitions());
     BitSet emptyPartitionsBitSet = TezUtilsInternal.fromByteArray(emptyPartitions);
-    assertEquals(
-        10,
-        emptyPartitionsBitSet.cardinality(),
+    assertEquals(10, emptyPartitionsBitSet.cardinality(),
         "emptyPartitionBitSet cardinality (expecting 10) = " + emptyPartitionsBitSet.cardinality());
   }
 

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/TestShuffleInputEventHandlerImpl.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/TestShuffleInputEventHandlerImpl.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -71,9 +72,10 @@ import org.apache.tez.runtime.library.shuffle.impl.ShuffleUserPayloads.DataMovem
 
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.MockedStatic;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -87,17 +89,18 @@ public class TestShuffleInputEventHandlerImpl {
 
   private TezExecutors sharedExecutor;
 
-  @Before
+  @BeforeEach
   public void setup() {
     sharedExecutor = new TezSharedExecutor(conf);
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     sharedExecutor.shutdownNow();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSimple() throws IOException {
     InputContext inputContext = mock(InputContext.class);
     ShuffleManager shuffleManager = mock(ShuffleManager.class);
@@ -119,7 +122,8 @@ public class TestShuffleInputEventHandlerImpl {
     verify(shuffleManager).addKnownInput(eq(HOST), eq(PORT), eq(expectedIdentifier), eq(0));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCurrentPartitionEmpty() throws IOException {
     InputContext inputContext = mock(InputContext.class);
     ShuffleManager shuffleManager = mock(ShuffleManager.class);
@@ -140,7 +144,8 @@ public class TestShuffleInputEventHandlerImpl {
     verify(shuffleManager).addCompletedInputWithNoData(eq(expectedIdentifier));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOtherPartitionEmpty() throws IOException {
     InputContext inputContext = mock(InputContext.class);
     ShuffleManager shuffleManager = mock(ShuffleManager.class);
@@ -160,7 +165,8 @@ public class TestShuffleInputEventHandlerImpl {
     verify(shuffleManager).addKnownInput(eq(HOST), eq(PORT), eq(expectedIdentifier), eq(0));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleEvents1() throws IOException {
     InputContext inputContext = mock(InputContext.class);
     ShuffleManager shuffleManager = mock(ShuffleManager.class);
@@ -243,7 +249,8 @@ public class TestShuffleInputEventHandlerImpl {
    *
    * @throws IOException
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPipelinedShuffleEvents() throws IOException {
 
     InputContext inputContext = createInputContext();
@@ -284,7 +291,8 @@ public class TestShuffleInputEventHandlerImpl {
    *
    * @throws IOException
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPipelinedShuffleEvents_WithOutOfOrderAttempts() throws IOException {
     InputContext inputContext = createInputContext();
     ShuffleManager shuffleManager = createShuffleManager(inputContext);
@@ -316,7 +324,8 @@ public class TestShuffleInputEventHandlerImpl {
    *
    * @throws IOException
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPipelinedShuffleEvents_WithEmptyPartitions() throws IOException {
     InputContext inputContext = createInputContext();
     ShuffleManager shuffleManager = createShuffleManager(inputContext);
@@ -356,7 +365,8 @@ public class TestShuffleInputEventHandlerImpl {
    *
    * @throws IOException
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDataMovementEventsWithShuffleData() throws IOException {
     InputContext inputContext = mock(InputContext.class);
     ShuffleManager shuffleManager = mock(ShuffleManager.class);

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/TestShuffleManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/TestShuffleManager.java
@@ -229,18 +229,13 @@ public class TestShuffleManager {
   public void testFetchFailed() throws Exception {
     InputContext inputContext = createInputContext();
     final ShuffleManager shuffleManager = spy(createShuffleManager(inputContext, 1));
-    Thread schedulerGetHostThread =
-        new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                try {
-                  shuffleManager.run();
-                } catch (Exception e) {
-                  e.printStackTrace();
-                }
-              }
-            });
+    Thread schedulerGetHostThread = new Thread(() -> {
+      try {
+        shuffleManager.run();
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    });
     InputAttemptFetchFailure inputAttemptFetchFailure =
         new InputAttemptFetchFailure(new InputAttemptIdentifier(1, 1));
 
@@ -251,12 +246,11 @@ public class TestShuffleManager {
 
     ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
     verify(inputContext, times(1)).sendEvents(captor.capture());
-    assertEquals(captor.getAllValues().size(), 1, "Size was: " + captor.getAllValues().size());
+    assertEquals(1, captor.getAllValues().size(), "Size was: " + captor.getAllValues().size());
     List<Event> capturedList = captor.getAllValues().get(0);
-    assertEquals(capturedList.size(), 1, "Size was: " + capturedList.size());
+    assertEquals(1, capturedList.size(), "Size was: " + capturedList.size());
     InputReadErrorEvent inputEvent = (InputReadErrorEvent) capturedList.get(0);
-    assertEquals(
-        inputEvent.getNumFailures(), 1, "Number of failures was: " + inputEvent.getNumFailures());
+    assertEquals(1, inputEvent.getNumFailures(), "Number of failures was: " + inputEvent.getNumFailures());
 
     shuffleManager.fetchFailed("host1", inputAttemptFetchFailure, false);
     shuffleManager.fetchFailed("host1", inputAttemptFetchFailure, false);
@@ -268,12 +262,11 @@ public class TestShuffleManager {
     Thread.sleep(5000);
     captor = ArgumentCaptor.forClass(List.class);
     verify(inputContext, times(2)).sendEvents(captor.capture());
-    assertEquals(captor.getAllValues().size(), 2, "Size was: " + captor.getAllValues().size());
+    assertEquals(2, captor.getAllValues().size(), "Size was: " + captor.getAllValues().size());
     capturedList = captor.getAllValues().get(1);
-    assertEquals(capturedList.size(), 1, "Size was: " + capturedList.size());
+    assertEquals(1, capturedList.size(), "Size was: " + capturedList.size());
     inputEvent = (InputReadErrorEvent) capturedList.get(0);
-    assertEquals(
-        inputEvent.getNumFailures(), 2, "Number of failures was: " + inputEvent.getNumFailures());
+    assertEquals(2, inputEvent.getNumFailures(), "Number of failures was: " + inputEvent.getNumFailures());
 
     schedulerGetHostThread.interrupt();
   }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/TestShuffleManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/TestShuffleManager.java
@@ -18,8 +18,8 @@
  */
 package org.apache.tez.runtime.library.common.shuffle.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -39,6 +39,7 @@ import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -69,10 +70,10 @@ import org.apache.tez.runtime.library.shuffle.impl.ShuffleUserPayloads.DataMovem
 
 import com.google.common.annotations.VisibleForTesting;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -86,12 +87,12 @@ public class TestShuffleManager {
   private final Configuration conf = new Configuration();
   private TezExecutors sharedExecutor;
 
-  @Before
+  @BeforeEach
   public void setup() {
     sharedExecutor = new TezSharedExecutor(conf);
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     sharedExecutor.shutdownNow();
   }
@@ -103,7 +104,8 @@ public class TestShuffleManager {
    * rest of the partitions. Then do the same thing for the next mapper.
    * Verify ShuffleManager is able to get all the events.
   */
-  @Test(timeout = 50000)
+  @Test
+  @Timeout(value = 50000, unit = TimeUnit.MILLISECONDS)
   public void testMultiplePartitions() throws Exception {
     final int numOfMappers = 3;
     final int numOfPartitions = 5;
@@ -188,7 +190,8 @@ public class TestShuffleManager {
     return inputContext;
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testUseSharedExecutor() throws Exception {
     InputContext inputContext = createInputContext();
     createShuffleManager(inputContext, 2);
@@ -200,7 +203,8 @@ public class TestShuffleManager {
     verify(inputContext).createTezFrameworkExecutorService(anyInt(), anyString());
   }
 
-  @Test (timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testProgressWithEmptyPendingHosts() throws Exception {
     InputContext inputContext = createInputContext();
     final ShuffleManager shuffleManager = spy(createShuffleManager(inputContext, 1));
@@ -220,20 +224,23 @@ public class TestShuffleManager {
     verify(inputContext, atLeast(3)).notifyProgress();
   }
 
-  @Test (timeout = 200000)
+  @Test
+  @Timeout(value = 200000, unit = TimeUnit.MILLISECONDS)
   public void testFetchFailed() throws Exception {
     InputContext inputContext = createInputContext();
     final ShuffleManager shuffleManager = spy(createShuffleManager(inputContext, 1));
-    Thread schedulerGetHostThread = new Thread(new Runnable() {
-      @Override
-      public void run() {
-        try {
-          shuffleManager.run();
-        } catch (Exception e) {
-          e.printStackTrace();
-        }
-      }
-    });
+    Thread schedulerGetHostThread =
+        new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  shuffleManager.run();
+                } catch (Exception e) {
+                  e.printStackTrace();
+                }
+              }
+            });
     InputAttemptFetchFailure inputAttemptFetchFailure =
         new InputAttemptFetchFailure(new InputAttemptIdentifier(1, 1));
 
@@ -243,16 +250,13 @@ public class TestShuffleManager {
     Thread.sleep(1000);
 
     ArgumentCaptor<List> captor = ArgumentCaptor.forClass(List.class);
-    verify(inputContext, times(1))
-        .sendEvents(captor.capture());
-    Assert.assertEquals("Size was: " + captor.getAllValues().size(),
-        captor.getAllValues().size(), 1);
+    verify(inputContext, times(1)).sendEvents(captor.capture());
+    assertEquals(captor.getAllValues().size(), 1, "Size was: " + captor.getAllValues().size());
     List<Event> capturedList = captor.getAllValues().get(0);
-    Assert.assertEquals("Size was: " + capturedList.size(),
-        capturedList.size(), 1);
-    InputReadErrorEvent inputEvent = (InputReadErrorEvent)capturedList.get(0);
-    Assert.assertEquals("Number of failures was: " + inputEvent.getNumFailures(),
-        inputEvent.getNumFailures(), 1);
+    assertEquals(capturedList.size(), 1, "Size was: " + capturedList.size());
+    InputReadErrorEvent inputEvent = (InputReadErrorEvent) capturedList.get(0);
+    assertEquals(
+        inputEvent.getNumFailures(), 1, "Number of failures was: " + inputEvent.getNumFailures());
 
     shuffleManager.fetchFailed("host1", inputAttemptFetchFailure, false);
     shuffleManager.fetchFailed("host1", inputAttemptFetchFailure, false);
@@ -263,17 +267,13 @@ public class TestShuffleManager {
     // Wait more than five seconds for the batch to go out
     Thread.sleep(5000);
     captor = ArgumentCaptor.forClass(List.class);
-    verify(inputContext, times(2))
-        .sendEvents(captor.capture());
-    Assert.assertEquals("Size was: " + captor.getAllValues().size(),
-        captor.getAllValues().size(), 2);
+    verify(inputContext, times(2)).sendEvents(captor.capture());
+    assertEquals(captor.getAllValues().size(), 2, "Size was: " + captor.getAllValues().size());
     capturedList = captor.getAllValues().get(1);
-    Assert.assertEquals("Size was: " + capturedList.size(),
-        capturedList.size(), 1);
-    inputEvent = (InputReadErrorEvent)capturedList.get(0);
-    Assert.assertEquals("Number of failures was: " + inputEvent.getNumFailures(),
-        inputEvent.getNumFailures(), 2);
-
+    assertEquals(capturedList.size(), 1, "Size was: " + capturedList.size());
+    inputEvent = (InputReadErrorEvent) capturedList.get(0);
+    assertEquals(
+        inputEvent.getNumFailures(), 2, "Number of failures was: " + inputEvent.getNumFailures());
 
     schedulerGetHostThread.interrupt();
   }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/TestSimpleFetchedInputAllocator.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/impl/TestSimpleFetchedInputAllocator.java
@@ -18,12 +18,13 @@
  */
 package org.apache.tez.runtime.library.common.shuffle.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.common.TezRuntimeFrameworkConfigs;
@@ -31,7 +32,8 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.shuffle.FetchedInput;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +41,8 @@ public class TestSimpleFetchedInputAllocator {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestSimpleFetchedInputAllocator.class);
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInMemAllocation() throws IOException {
     File localDirs = new File(System.getProperty("test.build.data", "/tmp"), this.getClass().getName());
     Configuration conf = new Configuration();
@@ -91,7 +94,8 @@ public class TestSimpleFetchedInputAllocator {
    * a high `maxMemory` is reported by the Runtime.The allocation results in a
    * DISK input because the `requestSize` exceeds the `maxSingleShuffleLimit`.
    */
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInMemAllocationWithJvmMaxMemory() throws IOException {
     File localDirs = new File(System.getProperty("test.build.data", "/tmp"), this.getClass().getName());
     Configuration conf = new Configuration();

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/DummyCompressionCodec.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/DummyCompressionCodec.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.io.compress.Decompressor;
 
 import com.google.common.annotations.VisibleForTesting;
 
+
 /**
  * A dummy codec. It passes everything to underlying stream
  */

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/DummyCompressionCodec.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/DummyCompressionCodec.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.io.compress.Decompressor;
 
 import com.google.common.annotations.VisibleForTesting;
 
-
 /**
  * A dummy codec. It passes everything to underlying stream
  */

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestFetcher.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestFetcher.java
@@ -18,7 +18,10 @@
  */
 package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
@@ -50,6 +53,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -76,8 +80,8 @@ import org.apache.tez.runtime.library.testutils.RuntimeTestUtils;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -114,7 +118,8 @@ public class TestFetcher {
 
   static final Logger LOG = LoggerFactory.getLogger(TestFetcher.class);
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInputsReturnedOnConnectionException() throws Exception {
     Configuration conf = new TezConfiguration();
     ShuffleScheduler scheduler = mock(ShuffleScheduler.class);
@@ -141,7 +146,8 @@ public class TestFetcher {
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLocalFetchModeSetting1() throws Exception {
     Configuration conf = new TezConfiguration();
     ShuffleScheduler scheduler = mock(ShuffleScheduler.class);
@@ -211,7 +217,8 @@ public class TestFetcher {
     verify(spyFetcher, times(1)).copyFromHost(mapHost);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSetupLocalDiskFetch() throws Exception {
     Configuration conf = new TezConfiguration();
     ShuffleScheduler scheduler = mock(ShuffleScheduler.class);
@@ -322,7 +329,8 @@ public class TestFetcher {
     verify(scheduler).putBackKnownMapOutput(host, srcAttempts.get(SECOND_FAILED_ATTEMPT_IDX));
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSetupLocalDiskFetchEmptyPartitions() throws Exception {
     Configuration conf = new TezConfiguration();
     ShuffleScheduler scheduler = mock(ShuffleScheduler.class);
@@ -394,7 +402,8 @@ public class TestFetcher {
     verify(spyFetcher).putBackRemainingMapOutputs(host);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSetupLocalDiskFetchAutoReduce() throws Exception {
     Configuration conf = new TezConfiguration();
     ShuffleScheduler scheduler = mock(ShuffleScheduler.class);
@@ -532,7 +541,7 @@ public class TestFetcher {
 
     // cannot use the equals of MapOutput as it compares id which is private. so doing it manually
     MapOutput m = captureMapOutput.getAllValues().get(0);
-    Assert.assertTrue(m.getType().equals(MapOutput.Type.DISK_DIRECT) &&
+    assertTrue(m.getType().equals(MapOutput.Type.DISK_DIRECT) &&
         m.getAttemptIdentifier().equals(srcAttemptToMatch));
   }
 
@@ -567,7 +576,8 @@ public class TestFetcher {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   @SuppressWarnings("unchecked")
   public void testWithRetry() throws Exception {
     Configuration conf = new TezConfiguration();
@@ -677,15 +687,16 @@ public class TestFetcher {
     try {
       long currentIOErrors = ioErrsCounter.getValue();
       boolean connected = fetcher.setupConnection(host, srcAttempts);
-      Assert.assertTrue(connected == false);
+      assertFalse(connected);
       //Ensure that counters are incremented (i.e it followed the exception codepath)
-      Assert.assertTrue(ioErrsCounter.getValue() > currentIOErrors);
+      assertTrue(ioErrsCounter.getValue() > currentIOErrors);
     } catch (IOException e) {
       fail();
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInputAttemptIdentifierMap() {
     InputAttemptIdentifier[] srcAttempts = {
       new InputAttemptIdentifier(0, 1, InputAttemptIdentifier.PATH_PREFIX + "pathComponent_0",
@@ -731,12 +742,12 @@ public class TestFetcher {
         ioErrsCounter, wrongLengthErrsCounter, badIdErrsCounter, wrongMapErrsCounter,
         connectionErrsCounter, wrongReduceErrsCounter, false, false, true, false, createMockInputContext());
     fetcher.populateRemainingMap(new LinkedList<InputAttemptIdentifier>(Arrays.asList(srcAttempts)));
-    Assert.assertEquals(expectedSrcAttempts.length, fetcher.remaining.size());
+    assertEquals(expectedSrcAttempts.length, fetcher.remaining.size());
     Iterator<Entry<String, InputAttemptIdentifier>> iterator = fetcher.remaining.entrySet().iterator();
     int count = 0;
     while(iterator.hasNext()) {
       String key = iterator.next().getKey();
-      Assert.assertTrue(expectedSrcAttempts[count++].toString().compareTo(key) == 0);
+      assertEquals(0, expectedSrcAttempts[count++].toString().compareTo(key));
     }
   }
 
@@ -761,9 +772,9 @@ public class TestFetcher {
     InputAttemptFetchFailure[] failures =
         fetcher.copyMapOutput(mapHost, input, inputAttemptIdentifier);
 
-    Assert.assertEquals(1, failures.length);
-    Assert.assertTrue(failures[0].isDiskErrorAtSource());
-    Assert.assertFalse(failures[0].isLocalFetch());
+    assertEquals(1, failures.length);
+    assertTrue(failures[0].isDiskErrorAtSource());
+    assertFalse(failures[0].isLocalFetch());
   }
 
   private RawLocalFileSystem getRawFs(Configuration conf) {

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestMergeManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestMergeManager.java
@@ -397,7 +397,7 @@ public class TestMergeManager {
   }
 
   @Test
-  @org.junit.jupiter.api.Timeout(value = 60000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testIntermediateMemoryMerge() throws Throwable {
     Configuration conf = new TezConfiguration(defaultConf);
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS, false);

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestMergeManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestMergeManager.java
@@ -18,10 +18,12 @@
  */
 package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -34,6 +36,7 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -55,10 +58,10 @@ import org.apache.tez.runtime.library.common.sort.impl.TezIndexRecord;
 
 import com.google.common.collect.Sets;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,13 +89,14 @@ public class TestMergeManager {
     }
   }
 
-  @Before
-  @After
+  @BeforeEach
+  @AfterEach
   public void cleanup() throws IOException {
     localFs.delete(workDir, true);
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testConfigs() throws IOException {
     long maxTaskMem = 8192 * 1024 * 1024l;
 
@@ -100,59 +104,59 @@ public class TestMergeManager {
     Configuration conf = new TezConfiguration(defaultConf);
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 0.8f);
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, 0.5f);
-    Assert.assertTrue(MergeManager.getInitialMemoryRequirement(conf, maxTaskMem) == 6871947776l);
+    assertEquals(6871947776l, MergeManager.getInitialMemoryRequirement(conf, maxTaskMem));
 
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 0.5f);
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, 0.5f);
-    Assert.assertTrue(MergeManager.getInitialMemoryRequirement(conf, maxTaskMem) > Integer.MAX_VALUE);
+    assertTrue(MergeManager.getInitialMemoryRequirement(conf, maxTaskMem) > Integer.MAX_VALUE);
 
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 0.4f);
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, 0.9f);
-    Assert.assertTrue(MergeManager.getInitialMemoryRequirement(conf, maxTaskMem) > Integer.MAX_VALUE);
+    assertTrue(MergeManager.getInitialMemoryRequirement(conf, maxTaskMem) > Integer.MAX_VALUE);
 
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 0.1f);
     conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, 0.1f);
-    Assert.assertTrue(MergeManager.getInitialMemoryRequirement(conf, maxTaskMem) < Integer.MAX_VALUE);
+    assertTrue(MergeManager.getInitialMemoryRequirement(conf, maxTaskMem) < Integer.MAX_VALUE);
 
     try {
       conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 2.4f);
       MergeManager.getInitialMemoryRequirement(conf, maxTaskMem);
-      Assert.fail("Should have thrown wrong buffer percent configuration exception");
+      fail("Should have thrown wrong buffer percent configuration exception");
     } catch(IllegalArgumentException ie) {
     }
 
     try {
       conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, -2.4f);
       MergeManager.getInitialMemoryRequirement(conf, maxTaskMem);
-      Assert.fail("Should have thrown wrong buffer percent configuration exception");
+      fail("Should have thrown wrong buffer percent configuration exception");
     } catch(IllegalArgumentException ie) {
     }
 
     try {
       conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, 1.4f);
       MergeManager.getInitialMemoryRequirement(conf, maxTaskMem);
-      Assert.fail("Should have thrown wrong post merge buffer percent configuration exception");
+      fail("Should have thrown wrong post merge buffer percent configuration exception");
     } catch(IllegalArgumentException ie) {
     }
 
     try {
       conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, -1.4f);
       MergeManager.getInitialMemoryRequirement(conf, maxTaskMem);
-      Assert.fail("Should have thrown wrong post merge buffer percent configuration exception");
+      fail("Should have thrown wrong post merge buffer percent configuration exception");
     } catch(IllegalArgumentException ie) {
     }
 
     try {
       conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 1.4f);
       MergeManager.getInitialMemoryRequirement(conf, maxTaskMem);
-      Assert.fail("Should have thrown wrong shuffle fetch buffer percent configuration exception");
+      fail("Should have thrown wrong shuffle fetch buffer percent configuration exception");
     } catch(IllegalArgumentException ie) {
     }
 
     try {
       conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, -1.4f);
       MergeManager.getInitialMemoryRequirement(conf, maxTaskMem);
-      Assert.fail("Should have thrown wrong shuffle fetch buffer percent configuration exception");
+      fail("Should have thrown wrong shuffle fetch buffer percent configuration exception");
     } catch(IllegalArgumentException ie) {
     }
 
@@ -168,16 +172,17 @@ public class TestMergeManager {
     MergeManager mergeManager =
         new MergeManager(conf, localFs, localDirAllocator, t0inputContext, null, null, null, null,
             t0exceptionReporter, initialMemoryAvailable, null, false, -1);
-    Assert.assertTrue(mergeManager.postMergeMemLimit > Integer.MAX_VALUE);
+    assertTrue(mergeManager.postMergeMemLimit > Integer.MAX_VALUE);
 
     initialMemoryAvailable = 200 * 1024 * 1024l; //initial mem < memlimit
     mergeManager =
         new MergeManager(conf, localFs, localDirAllocator, t0inputContext, null, null, null, null,
             t0exceptionReporter, initialMemoryAvailable, null, false, -1);
-    Assert.assertTrue(mergeManager.postMergeMemLimit == initialMemoryAvailable);
+    assertEquals(mergeManager.postMergeMemLimit, initialMemoryAvailable);
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testReservationAccounting() throws IOException {
     Configuration conf = new TezConfiguration(defaultConf);
     FileSystem localFs = FileSystem.getLocal(conf);
@@ -203,7 +208,8 @@ public class TestMergeManager {
     assertEquals(0, mergeManager.getCommitMemory());
   }
 
-  @Test(timeout=20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testIntermediateMemoryMergeAccounting() throws Exception {
     Configuration conf = new TezConfiguration(defaultConf);
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS, false);
@@ -387,10 +393,11 @@ public class TestMergeManager {
     mo4.commit();
 
     mergeManager.close(true);
-    Assert.assertTrue(dummyCodec.createInputStreamCalled > 0);
+    assertTrue(dummyCodec.createInputStreamCalled > 0);
   }
 
-  @Test(timeout = 60000l)
+  @Test
+  @org.junit.jupiter.api.Timeout(value = 60000, unit = java.util.concurrent.TimeUnit.MILLISECONDS)
   public void testIntermediateMemoryMerge() throws Throwable {
     Configuration conf = new TezConfiguration(defaultConf);
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS, false);
@@ -699,8 +706,8 @@ public class TestMergeManager {
     //Check if inMemorySegment has got the MapOutput back for merging later
     assertEquals(numberOfMapOutputs, mergeManager.inMemoryMapOutputs.size());
 
-    Assert.assertNull(mergeManager.close(false));
-    Assert.assertFalse(mergeManager.isMergeComplete());
+    assertNull(mergeManager.close(false));
+    assertFalse(mergeManager.isMergeComplete());
   }
 
   private byte[] generateDataBySize(Configuration conf, int rawLen, InputAttemptIdentifier inputAttemptIdentifier) throws IOException {
@@ -783,13 +790,15 @@ public class TestMergeManager {
     }
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testLocalDiskMergeMultipleTasks() throws IOException, InterruptedException {
     testLocalDiskMergeMultipleTasks(false);
     testLocalDiskMergeMultipleTasks(true);
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testOnDiskMergerFilenames() throws IOException, InterruptedException {
     Configuration conf = new TezConfiguration(defaultConf);
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS, false);
@@ -847,7 +856,7 @@ public class TestMergeManager {
     mergeManager.onDiskMapOutputs.clear();
 
     mergeManager.onDiskMerger.merge(mergeFiles);
-    Assert.assertEquals(1, mergeManager.onDiskMapOutputs.size());
+    assertEquals(1, mergeManager.onDiskMapOutputs.size());
 
     FileChunk fcMerged1 = mergeManager.onDiskMapOutputs.iterator().next();
     Path m1Path = fcMerged1.getPath();
@@ -871,7 +880,7 @@ public class TestMergeManager {
     mergeManager.onDiskMapOutputs.clear();
 
     mergeManager.onDiskMerger.merge(mergeFiles);
-    Assert.assertEquals(1, mergeManager.onDiskMapOutputs.size());
+    assertEquals(1, mergeManager.onDiskMapOutputs.size());
 
     FileChunk fcMerged2 = mergeManager.onDiskMapOutputs.iterator().next();
     Path m2Path = fcMerged2.getPath();
@@ -901,7 +910,7 @@ public class TestMergeManager {
     mergeManager.onDiskMapOutputs.clear();
 
     mergeManager.onDiskMerger.merge(mergeFiles);
-    Assert.assertEquals(1, mergeManager.onDiskMapOutputs.size());
+    assertEquals(1, mergeManager.onDiskMapOutputs.size());
 
     FileChunk fcMerged3 = mergeManager.onDiskMapOutputs.iterator().next();
     Path m3Path = fcMerged3.getPath();
@@ -1027,7 +1036,7 @@ public class TestMergeManager {
 
     if (!interruptInMiddle) {
       t0mergeManager.onDiskMerger.merge(t0MergeFiles);
-      Assert.assertEquals(1, t0mergeManager.onDiskMapOutputs.size());
+      assertEquals(1, t0mergeManager.onDiskMapOutputs.size());
     } else {
 
       //Start Interrupting thread
@@ -1042,7 +1051,7 @@ public class TestMergeManager {
       //Will be interrupted in the middle by interruptingThread.
       t0mergeManager.onDiskMerger.startMerge(Sets.newHashSet(t0MergeFiles));
       t0mergeManager.onDiskMerger.waitForMerge();
-      Assert.assertNotEquals(1, t0mergeManager.onDiskMapOutputs.size());
+      assertNotEquals(1, t0mergeManager.onDiskMapOutputs.size());
     }
 
     if (!interruptInMiddle) {
@@ -1056,14 +1065,14 @@ public class TestMergeManager {
       t1MergeFiles.addAll(t1mergeManager.onDiskMapOutputs);
       t1mergeManager.onDiskMapOutputs.clear();
       t1mergeManager.onDiskMerger.merge(t1MergeFiles);
-      Assert.assertEquals(1, t1mergeManager.onDiskMapOutputs.size());
+      assertEquals(1, t1mergeManager.onDiskMapOutputs.size());
 
-      Assert.assertNotEquals(t0mergeManager.onDiskMapOutputs.iterator().next().getPath(),
+      assertNotEquals(t0mergeManager.onDiskMapOutputs.iterator().next().getPath(),
           t1mergeManager.onDiskMapOutputs.iterator().next().getPath());
 
-      Assert.assertTrue(t0mergeManager.onDiskMapOutputs.iterator().next().getPath().toString()
+      assertTrue(t0mergeManager.onDiskMapOutputs.iterator().next().getPath().toString()
           .contains(t0inputContext.getUniqueIdentifier()));
-      Assert.assertTrue(t1mergeManager.onDiskMapOutputs.iterator().next().getPath().toString()
+      assertTrue(t1mergeManager.onDiskMapOutputs.iterator().next().getPath().toString()
           .contains(t1inputContext.getUniqueIdentifier()));
     }
   }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestMergeManager.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestMergeManager.java
@@ -262,7 +262,8 @@ public class TestMergeManager {
     assertEquals(data1.length + data2.length, mergeManager.getUsedMemory());
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testWaitForShuffleToMergeMemoryNoDeadlock() throws Throwable {
     Configuration conf = new TezConfiguration(defaultConf);
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS, false);
@@ -311,8 +312,8 @@ public class TestMergeManager {
     assertEquals(MapOutput.Type.MEMORY, mo5.getType());
 
     // Verify deadlock precondition: usedMemory > memoryLimit, commitMemory < mergeThreshold
-    assertTrue("usedMemory should exceed memoryLimit", mergeManager.getUsedMemory() > 2000000L);
-    assertTrue("commitMemory should be below mergeThreshold", mergeManager.getCommitMemory() < 1800000L);
+    assertTrue(mergeManager.getUsedMemory() > 2000000L, "usedMemory should exceed memoryLimit");
+    assertTrue(mergeManager.getCommitMemory() < 1800000L, "commitMemory should be below mergeThreshold");
 
     // waitForShuffleToMergeMemory() should complete without deadlock:
     // the fix forces a merge when memory is exhausted but commitMemory < mergeThreshold
@@ -325,7 +326,7 @@ public class TestMergeManager {
     });
     waitThread.start();
     waitThread.join(15000);
-    assertFalse("waitForShuffleToMergeMemory deadlocked", waitThread.isAlive());
+    assertFalse(waitThread.isAlive(), "waitForShuffleToMergeMemory deadlocked");
 
     if (waitThread.isAlive()) {
       waitThread.interrupt();

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestShuffle.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestShuffle.java
@@ -18,8 +18,8 @@
  */
 package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -50,9 +51,10 @@ import org.apache.tez.runtime.api.TaskFailureType;
 import org.apache.tez.runtime.api.impl.ExecutionContextImpl;
 import org.apache.tez.runtime.library.common.Constants;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -61,17 +63,18 @@ public class TestShuffle {
 
   private TezExecutors sharedExecutor;
 
-  @Before
+  @BeforeEach
   public void setup() {
     sharedExecutor = new TezSharedExecutor(new Configuration());
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     sharedExecutor.shutdownNow();
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testSchedulerTerminatesOnException() throws IOException, InterruptedException {
 
     InputContext inputContext = createTezInputContext();
@@ -113,7 +116,8 @@ public class TestShuffle {
 
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testKillSelf() throws IOException, InterruptedException {
     InputContext inputContext = createTezInputContext();
     TezConfiguration conf = new TezConfiguration();
@@ -122,14 +126,14 @@ public class TestShuffle {
     try {
       shuffle.run();
       ShuffleScheduler scheduler = shuffle.scheduler;
-      assertFalse("scheduler.isShutdown should be false", scheduler.isShutdown());
+      assertFalse(scheduler.isShutdown(), "scheduler.isShutdown should be false");
 
       // killSelf() would invoke close(). Internally Shuffle --> merge.close() --> finalMerge()
       // gets called. In MergeManager::finalMerge(), it would throw illegal argument exception as
       // uniqueIdentifier is not present in inputContext. This is used as means of simulating
       // exception.
       scheduler.killSelf(new Exception(), "due to internal error");
-      assertTrue("scheduler.isShutdown should be true", scheduler.isShutdown());
+      assertTrue(scheduler.isShutdown(), "scheduler.isShutdown should be true");
 
       //killSelf() should not result in reporting failure to AM
       ArgumentCaptor<Throwable> throwableArgumentCaptor = ArgumentCaptor.forClass(Throwable.class);

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestShuffleInputEventHandlerOrderedGrouped.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestShuffleInputEventHandlerOrderedGrouped.java
@@ -18,7 +18,9 @@
  */
 package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -37,6 +39,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
@@ -58,14 +61,16 @@ import org.apache.tez.runtime.api.events.InputFailedEvent;
 import org.apache.tez.runtime.api.impl.ExecutionContextImpl;
 import org.apache.tez.runtime.library.common.CompositeInputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
+import org.apache.tez.runtime.library.common.InputAttemptIdentifier.SPILL_INFO;
 import org.apache.tez.runtime.library.common.shuffle.ShuffleUtils;
 import org.apache.tez.runtime.library.shuffle.impl.ShuffleUserPayloads;
 
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -173,13 +178,13 @@ public class TestShuffleInputEventHandlerOrderedGrouped {
         .create(srcIndex, targetIndex, attemptNum, builder.build().toByteString().asReadOnlyByteBuffer());
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     sharedExecutor = new TezSharedExecutor(new Configuration());
     setupScheduler(2);
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     sharedExecutor.shutdownNow();
   }
@@ -204,7 +209,8 @@ public class TestShuffleInputEventHandlerOrderedGrouped {
     mergeManager = mock(MergeManager.class);
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testPiplinedShuffleEvents() throws IOException, InterruptedException {
     //test with 2 events per input (2 inputs)
     int attemptNum = 0;
@@ -230,16 +236,16 @@ public class TestShuffleInputEventHandlerOrderedGrouped {
     assertTrue(scheduler.pipelinedShuffleInfoEventsMap.containsKey(id2.getInputIdentifier()));
 
     MapHost host = scheduler.getHost();
-    assertTrue(host != null);
+    assertNotNull(host);
     List<InputAttemptIdentifier> list = scheduler.getMapsForHost(host);
-    assertTrue(!list.isEmpty());
+    assertFalse(list.isEmpty());
     //Let the final_update event pass
     MapOutput output = MapOutput.createMemoryMapOutput(id2, mergeManager, 1000, true);
     scheduler.copySucceeded(id2, host, 1000, 10000, 10000, output, false);
-    assertTrue(!scheduler.isDone()); //we haven't downloaded id1 yet
+    assertFalse(scheduler.isDone()); //we haven't downloaded id1 yet
     output = MapOutput.createMemoryMapOutput(id1, mergeManager, 1000, true);
     scheduler.copySucceeded(id1, host, 1000, 10000, 10000, output, false);
-    assertTrue(!scheduler.isDone()); //we haven't downloaded another source yet
+    assertFalse(scheduler.isDone()); //we haven't downloaded another source yet
 
     //Send events for source 2
     attemptNum = 0;
@@ -253,16 +259,17 @@ public class TestShuffleInputEventHandlerOrderedGrouped {
     //Send final_update event (empty partition directly invoking copySucceeded).
     InputAttemptIdentifier id4 = new InputAttemptIdentifier(inputIdx,
         attemptNum, PATH_COMPONENT, false, InputAttemptIdentifier.SPILL_INFO.FINAL_UPDATE, 1);
-    assertTrue(!scheduler.isInputFinished(id4.getInputIdentifier()));
+    assertFalse(scheduler.isInputFinished(id4.getInputIdentifier()));
     scheduler.copySucceeded(id4, null, 0, 0, 0, null, false);
-    assertTrue(!scheduler.isDone()); //we haven't downloaded another id yet
+    assertFalse(scheduler.isDone()); //we haven't downloaded another id yet
     //Let the incremental event pass
     output = MapOutput.createMemoryMapOutput(id3, mergeManager, 1000, true);
     scheduler.copySucceeded(id3, host, 1000, 10000, 10000, output, false);
     assertTrue(scheduler.isDone());
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPiplinedShuffleEvents_WithOutofOrderAttempts() throws IOException, InterruptedException {
     //Process attempt #1 first
     int attemptNum = 1;
@@ -273,15 +280,14 @@ public class TestShuffleInputEventHandlerOrderedGrouped {
 
     CompositeInputAttemptIdentifier id1 =
         new CompositeInputAttemptIdentifier(inputIdx, attemptNum,
-            PATH_COMPONENT, false, InputAttemptIdentifier.SPILL_INFO.INCREMENTAL_UPDATE, 0, 1);
+            PATH_COMPONENT, false, SPILL_INFO.INCREMENTAL_UPDATE, 0, 1);
 
     verify(scheduler, times(1)).addKnownMapOutput(eq(HOST), eq(PORT), eq(1), eq(id1));
-    assertTrue("Shuffle info events should not be empty for pipelined shuffle",
-        !scheduler.pipelinedShuffleInfoEventsMap.isEmpty());
+    assertFalse(scheduler.pipelinedShuffleInfoEventsMap.isEmpty(),
+        "Shuffle info events should not be empty for pipelined shuffle");
 
     int valuesInMapLocations = scheduler.mapLocations.values().size();
-    assertTrue("Maplocations should have values. current size: " + valuesInMapLocations,
-        valuesInMapLocations > 0);
+    assertTrue(valuesInMapLocations > 0, "Maplocations should have values. current size: " + valuesInMapLocations);
 
     // start scheduling for download
     scheduler.getMapsForHost(scheduler.mapLocations.values().iterator().next());
@@ -296,7 +302,8 @@ public class TestShuffleInputEventHandlerOrderedGrouped {
     verify(scheduler, times(1)).killSelf(any(), any());
   }
 
-  @Test (timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPipelinedShuffle_WithObsoleteEvents() throws IOException, InterruptedException {
     //Process attempt #1 first
     int attemptNum = 1;
@@ -307,15 +314,14 @@ public class TestShuffleInputEventHandlerOrderedGrouped {
 
     CompositeInputAttemptIdentifier id1 =
         new CompositeInputAttemptIdentifier(inputIdx, attemptNum,
-            PATH_COMPONENT, false, InputAttemptIdentifier.SPILL_INFO.INCREMENTAL_UPDATE, 0, 1);
+            PATH_COMPONENT, false, SPILL_INFO.INCREMENTAL_UPDATE, 0, 1);
 
     verify(scheduler, times(1)).addKnownMapOutput(eq(HOST), eq(PORT), eq(1), eq(id1));
-    assertTrue("Shuffle info events should not be empty for pipelined shuffle",
-        !scheduler.pipelinedShuffleInfoEventsMap.isEmpty());
+    assertFalse(scheduler.pipelinedShuffleInfoEventsMap.isEmpty(),
+        "Shuffle info events should not be empty for pipelined shuffle");
 
     int valuesInMapLocations = scheduler.mapLocations.values().size();
-    assertTrue("Maplocations should have values. current size: " + valuesInMapLocations,
-        valuesInMapLocations > 0);
+    assertTrue(valuesInMapLocations > 0, "Maplocations should have values. current size: " + valuesInMapLocations);
 
     // start scheduling for download. Sets up scheduledForDownload in eventInfo.
     scheduler.getMapsForHost(scheduler.mapLocations.values().iterator().next());
@@ -331,7 +337,8 @@ public class TestShuffleInputEventHandlerOrderedGrouped {
     verify(scheduler, times(1)).killSelf(any(), any());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void basicTest() throws IOException {
     List<Event> events = new LinkedList<Event>();
     int srcIdx = 0;
@@ -344,11 +351,11 @@ public class TestShuffleInputEventHandlerOrderedGrouped {
     int partitionId = srcIdx;
     verify(scheduler).addKnownMapOutput(eq(HOST), eq(PORT), eq(partitionId),
         eq(expectedIdentifier));
-    assertTrue("Shuffle info events should be empty for regular shuffle codepath",
-        scheduler.pipelinedShuffleInfoEventsMap.isEmpty());
+    assertTrue(scheduler.pipelinedShuffleInfoEventsMap.isEmpty(), "Shuffle info events should be empty for regular shuffle codepath");
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testFailedEvent() throws IOException {
     List<Event> events = new LinkedList<Event>();
     int targetIdx = 1;
@@ -359,7 +366,8 @@ public class TestShuffleInputEventHandlerOrderedGrouped {
     verify(scheduler).obsoleteInput(eq(expectedIdentifier));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testAllPartitionsEmpty() throws IOException {
     List<Event> events = new LinkedList<Event>();
     int srcIdx = 0;
@@ -373,7 +381,8 @@ public class TestShuffleInputEventHandlerOrderedGrouped {
             eq(0L), eq(0L), any(), eq(true));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCurrentPartitionEmpty() throws IOException {
     List<Event> events = new LinkedList<Event>();
     int srcIdx = 0;
@@ -387,7 +396,8 @@ public class TestShuffleInputEventHandlerOrderedGrouped {
         eq(0L), eq(0L), any(), eq(true));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOtherPartitionEmpty() throws IOException {
     List<Event> events = new LinkedList<Event>();
     int srcIdx = 0;

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestShuffleScheduler.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/shuffle/orderedgrouped/TestShuffleScheduler.java
@@ -18,9 +18,10 @@
  */
 package org.apache.tez.runtime.library.common.shuffle.orderedgrouped;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -60,11 +61,12 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.CompositeInputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.InputAttemptIdentifier;
 import org.apache.tez.runtime.library.common.shuffle.InputAttemptFetchFailure;
+import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.MapHost.State;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -72,17 +74,18 @@ public class TestShuffleScheduler {
 
   private TezExecutors sharedExecutor;
 
-  @Before
+  @BeforeEach
   public void setup() {
     sharedExecutor = new TezSharedExecutor(new Configuration());
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     sharedExecutor.shutdownNow();
   }
 
-  @Test (timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testNumParallelScheduledFetchers() throws IOException, InterruptedException {
     InputContext inputContext = createTezInputContext();
     Configuration conf = new TezConfiguration();
@@ -129,7 +132,8 @@ public class TestShuffleScheduler {
     }
   }
 
-  @Test(timeout=5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testUseSharedExecutor() throws Exception {
     InputContext inputContext = createTezInputContext();
     Configuration conf = new TezConfiguration();
@@ -150,7 +154,8 @@ public class TestShuffleScheduler {
     scheduler.close();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleFlow() throws Exception {
     InputContext inputContext = createTezInputContext();
     Configuration conf = new TezConfiguration();
@@ -206,7 +211,8 @@ public class TestShuffleScheduler {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   /**
    * Scenario
    *    - reducer has not progressed enough
@@ -279,7 +285,8 @@ public class TestShuffleScheduler {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   /**
    * Scenario
    *    - reducer has progressed enough
@@ -398,7 +405,8 @@ public class TestShuffleScheduler {
 
 
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   /**
    * Scenario
    *    - reducer has progressed enough
@@ -460,7 +468,8 @@ public class TestShuffleScheduler {
     verify(shuffle, times(0)).reportException(any());
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   /**
    * Scenario
    *    - reducer has progressed enough
@@ -553,7 +562,8 @@ public class TestShuffleScheduler {
 
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   /**
    * Scenario
    *    - Shuffle has progressed enough
@@ -616,7 +626,8 @@ public class TestShuffleScheduler {
   }
 
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   /**
    * Scenario
    *    - Shuffle has NOT progressed enough
@@ -709,7 +720,8 @@ public class TestShuffleScheduler {
 
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   /**
    * Scenario
    *    - reducer has not progressed enough
@@ -781,7 +793,8 @@ public class TestShuffleScheduler {
         TezConfiguration());
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testPenalty() throws IOException, InterruptedException {
     long startTime = System.currentTimeMillis();
     Shuffle shuffle = mock(Shuffle.class);
@@ -791,8 +804,8 @@ public class TestShuffleScheduler {
         new CompositeInputAttemptIdentifier(0, 0, "attempt_", 1);
     scheduler.addKnownMapOutput("host0", 10000, 0, inputAttemptIdentifier);
 
-    assertTrue(scheduler.pendingHosts.size() == 1);
-    assertTrue(scheduler.pendingHosts.iterator().next().getState() == MapHost.State.PENDING);
+    assertEquals(1, scheduler.pendingHosts.size());
+    assertSame(scheduler.pendingHosts.iterator().next().getState(), State.PENDING);
     MapHost mapHost = scheduler.pendingHosts.iterator().next();
 
     //Fails to pull from host0. host0 should be added to penalties
@@ -801,16 +814,17 @@ public class TestShuffleScheduler {
 
     //Should not get host, as it is added to penalty loop
     MapHost host = scheduler.getHost();
-    assertFalse("Host identifier mismatch", (host.getHost() + ":" + host.getPort() + ":" + host.getPartitionId()).equalsIgnoreCase("host0:10000"));
+    assertFalse((host.getHost() + ":" + host.getPort() + ":" + host.getPartitionId()).equalsIgnoreCase("host0:10000"), "Host identifier mismatch");
 
 
     //Refree thread would release it after INITIAL_PENALTY timeout
     Thread.sleep(ShuffleScheduler.INITIAL_PENALTY + 1000);
     host = scheduler.getHost();
-    assertFalse("Host identifier mismatch", (host.getHost() + ":" + host.getPort() + ":" + host.getPartitionId()).equalsIgnoreCase("host0:10000"));
+    assertFalse((host.getHost() + ":" + host.getPort() + ":" + host.getPartitionId()).equalsIgnoreCase("host0:10000"), "Host identifier mismatch");
   }
 
-  @Test (timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testProgressDuringGetHostWait() throws IOException, InterruptedException {
     long startTime = System.currentTimeMillis();
     Configuration conf = new TezConfiguration();
@@ -832,7 +846,8 @@ public class TestShuffleScheduler {
     verify(scheduler.inputContext, atLeast(3)).notifyProgress();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testShutdown() throws Exception {
     InputContext inputContext = createTezInputContext();
     Configuration conf = new TezConfiguration();
@@ -888,7 +903,8 @@ public class TestShuffleScheduler {
     }
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testShutdownWithInterrupt() throws Exception {
     InputContext inputContext = createTezInputContext();
     Configuration conf = new TezConfiguration();
@@ -945,13 +961,13 @@ public class TestShuffleScheduler {
       thread.start();
       thread.join();
     } finally {
-      assertTrue("Fetcher executor should be shutdown, but still running",
-          scheduler.hasFetcherExecutorStopped());
+      assertTrue(scheduler.hasFetcherExecutorStopped(), "Fetcher executor should be shutdown, but still running");
       executor.shutdownNow();
     }
   }
 
-  @Test (timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testPenalties() throws Exception {
     InputContext inputContext = createTezInputContext();
     Configuration conf = new TezConfiguration();
@@ -997,7 +1013,7 @@ public class TestShuffleScheduler {
     ShuffleScheduler.Penalty[] penaltyArray = new ShuffleScheduler.Penalty[scheduler.getPenalties().size()];
     scheduler.getPenalties().toArray(penaltyArray);
     for (int i = 0; i < penaltyArray.length; i++) {
-      Assert.assertTrue(penaltyArray[i].getDelay(TimeUnit.MILLISECONDS) <= 20000);
+      assertTrue(penaltyArray[i].getDelay(TimeUnit.MILLISECONDS) <= 20000);
     }
   }
 

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestIFile.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestIFile.java
@@ -419,8 +419,7 @@ public class TestIFile {
     for (int i = 0; i < 5; i++) {
       bytes = new byte[(int) raws[i]];
       assertEquals(inStream.getPos(), compTotal, "Compressed stream out-of-sync");
-      Reader.readToMemory(bytes, inStream, (int) compressed[i], codec,
-          false, -1);
+      Reader.readToMemory(bytes, inStream, (int) compressed[i], codec, false, -1);
       compTotal += compressed[i];
 
       // Now read the data
@@ -780,16 +779,12 @@ public class TestIFile {
   public void testSmallDataCompression() throws IOException {
     assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          tryWriteFileWithBufferSize(17, "org.apache.hadoop.io.compress.Lz4Codec");
-        });
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          tryWriteFileWithBufferSize(32, "org.apache.hadoop.io.compress.Lz4Codec");
-        });
+    assertThrows(IllegalArgumentException.class, () -> {
+      tryWriteFileWithBufferSize(17, "org.apache.hadoop.io.compress.Lz4Codec");
+    });
+    assertThrows(IllegalArgumentException.class, () -> {
+      tryWriteFileWithBufferSize(32, "org.apache.hadoop.io.compress.Lz4Codec");
+    });
   }
 
   private void tryWriteFileWithBufferSize(int bufferSize, String codecClassName)
@@ -987,21 +982,14 @@ public class TestIFile {
       readValue = valDeserializer.deserialize(readValue);
 
       KVPair expected = data.get(numRecordsRead);
-      assertEquals(
-          expected.getKey(),
-          readKey,
+      assertEquals(expected.getKey(), readKey,
           "Key does not match: Expected: " + expected.getKey() + ", Read: " + readKey);
-      assertEquals(
-          expected.getvalue(),
-          readValue,
+      assertEquals(expected.getvalue(), readValue,
           "Value does not match: Expected: " + expected.getvalue() + ", Read: " + readValue);
 
       numRecordsRead++;
     }
-    assertEquals(
-        data.size(),
-        numRecordsRead,
-        "Expected: " + data.size() + " records, but found: " + numRecordsRead);
+    assertEquals(data.size(), numRecordsRead, "Expected: " + data.size() + " records, but found: " + numRecordsRead);
     LOG.info("Found: " + numRecordsRead + " records");
   }
 

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestIFile.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestIFile.java
@@ -18,12 +18,14 @@
  */
 package org.apache.tez.runtime.library.common.sort.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -35,6 +37,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
@@ -69,11 +72,10 @@ import org.apache.tez.runtime.library.utils.CodecUtils;
 
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,7 +107,7 @@ public class TestIFile {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     CompressionCodecFactory codecFactory = new CompressionCodecFactory(new
         Configuration());
@@ -113,20 +115,22 @@ public class TestIFile {
     outputPath = new Path(workDir, outputFileName);
   }
 
-  @Before
-  @After
+  @BeforeEach
+  @AfterEach
   public void cleanup() throws Exception {
     localFs.delete(workDir, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   //empty IFile
   public void testWithEmptyIFile() throws IOException {
     testWriterAndReader(new LinkedList<KVPair>());
     testWithDataBuffer(new LinkedList<KVPair>());
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCompressedFlag() throws IOException {
     byte[] HEADER = new byte[] { (byte) 'T', (byte) 'I', (byte) 'F' , (byte) 1};
     ByteArrayInputStream bin = new ByteArrayInputStream(HEADER);
@@ -144,7 +148,8 @@ public class TestIFile {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   //Write empty key value pairs
   public void testWritingEmptyKeyValues() throws IOException {
     DataInputBuffer key = new DataInputBuffer();
@@ -167,11 +172,12 @@ public class TestIFile {
       assert(keyIn.getLength() == 0);
       assert(valIn.getLength() == 0);
     }
-    assertTrue("Number of records read does not match", (records == 4));
+    assertTrue((records == 4), "Number of records read does not match");
     reader.close();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   //test with unsorted data and repeat keys
   public void testWithUnsortedData() throws IOException {
     List<KVPair> unsortedData = KVDataGen.generateTestData(false, rnd.nextInt(100));
@@ -179,7 +185,8 @@ public class TestIFile {
     testWithDataBuffer(unsortedData);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   //test with sorted data and repeat keys
   public void testWithSortedData() throws IOException {
     List<KVPair> sortedData = KVDataGen.generateTestData(true, rnd.nextInt(100));
@@ -188,7 +195,8 @@ public class TestIFile {
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   //test overflow
   public void testExceedMaxSize() throws IOException {
     final int oldMaxBufferSize = IFile.Reader.MAX_BUFFER_SIZE;
@@ -223,7 +231,7 @@ public class TestIFile {
 
     try {
       reader.nextRawKey(keyIn);
-      Assert.fail("Expected IllegalArgumentException to be thrown");
+      fail("Expected IllegalArgumentException to be thrown");
     } catch (IllegalArgumentException e) {
       // test passed
     }
@@ -247,7 +255,7 @@ public class TestIFile {
     try {
       reader.nextRawKey(keyIn);
       reader.nextRawValue(valIn);
-      Assert.fail("Expected IllegalArgumentException to be thrown");
+      fail("Expected IllegalArgumentException to be thrown");
     } catch (IllegalArgumentException e) {
       // test passed
     }
@@ -296,7 +304,8 @@ public class TestIFile {
     IFile.Reader.MAX_BUFFER_SIZE = oldMaxBufferSize;
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   //test with sorted data and repeat keys
   public void testWithRLEMarker() throws IOException {
     //Test with append(Object, Object)
@@ -373,7 +382,8 @@ public class TestIFile {
     boundedOut.close();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   //test with unique keys
   public void testWithUniqueKeys() throws IOException {
     //all keys are unique
@@ -386,7 +396,8 @@ public class TestIFile {
   //This specific input is valid but the decompressor can leave lingering
   // bytes between segments. If the lingering bytes aren't handled correctly,
   // the stream will get out-of-sync.
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConcatenatedZlibPadding()
       throws IOException, URISyntaxException {
     byte[] bytes;
@@ -401,14 +412,14 @@ public class TestIFile {
 
     URL url = getClass().getClassLoader()
         .getResource("TestIFile_concatenated_compressed.bin");
-    assertNotEquals("IFileinput file must exist", null, url);
+    assertNotNull(url, "IFileinput file must exist");
     Path p = new Path(url.toURI());
     FSDataInputStream inStream = localFs.open(p);
 
     for (int i = 0; i < 5; i++) {
       bytes = new byte[(int) raws[i]];
-      assertEquals("Compressed stream out-of-sync", inStream.getPos(), compTotal);
-      IFile.Reader.readToMemory(bytes, inStream, (int) compressed[i], codec,
+      assertEquals(inStream.getPos(), compTotal, "Compressed stream out-of-sync");
+      Reader.readToMemory(bytes, inStream, (int) compressed[i], codec,
           false, -1);
       compTotal += compressed[i];
 
@@ -434,7 +445,8 @@ public class TestIFile {
     inStream.close();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   //Test InMemoryWriter
   public void testInMemoryWriter() throws IOException {
     InMemoryWriter writer = null;
@@ -466,7 +478,8 @@ public class TestIFile {
     readUsingInMemoryReader(bout.getBuffer(), data);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   //Test appendValue feature
   public void testAppendValue() throws IOException {
     List<KVPair> data = KVDataGen.generateTestData(false, rnd.nextInt(100));
@@ -488,7 +501,8 @@ public class TestIFile {
     readAndVerifyData(writer.getRawLength(), writer.getCompressedLength(), data, codec);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   //Test appendValues feature
   public void testAppendValues() throws IOException {
     List<KVPair> data = new ArrayList<KVPair>();
@@ -516,7 +530,8 @@ public class TestIFile {
     readAndVerifyData(writer.getRawLength(), writer.getCompressedLength(), data, codec);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Basic test
   public void testFileBackedInMemIFileWriter() throws IOException {
     List<KVPair> data = new ArrayList<>();
@@ -548,7 +563,8 @@ public class TestIFile {
     readUsingInMemoryReader(bytes, data);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Basic test
   public void testFileBackedInMemIFileWriterWithSmallBuffer() throws IOException {
     List<KVPair> data = new ArrayList<>();
@@ -563,7 +579,7 @@ public class TestIFile {
 
     // Buffer should have self adjusted. So for this empty file, it shouldn't
     // hit disk.
-    assertFalse("Data should have been flushed to disk", writer.isDataFlushedToDisk());
+    assertFalse(writer.isDataFlushedToDisk(), "Data should have been flushed to disk");
 
     byte[] bytes = new byte[(int) writer.getRawLength()];
     IFile.Reader.readToMemory(bytes,
@@ -573,7 +589,8 @@ public class TestIFile {
     readUsingInMemoryReader(bytes, data);
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   // Test file spill over scenario
   public void testFileBackedInMemIFileWriter_withSpill() throws IOException {
     List<KVPair> data = new ArrayList<>();
@@ -602,7 +619,7 @@ public class TestIFile {
     writer.append(lastKey, lastVal);
     writer.close();
 
-    assertTrue("Data should have been flushed to disk", writer.isDataFlushedToDisk());
+    assertTrue(writer.isDataFlushedToDisk(), "Data should have been flushed to disk");
 
     // Read output content to memory
     FSDataInputStream inStream = localFs.open(outputPath);
@@ -615,7 +632,8 @@ public class TestIFile {
     readUsingInMemoryReader(bytes, data);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   // Test empty file case
   public void testEmptyFileBackedInMemIFileWriter() throws IOException {
     List<KVPair> data = new ArrayList<>();
@@ -640,7 +658,8 @@ public class TestIFile {
   }
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   //Test appendKeyValues feature
   public void testAppendKeyValues() throws IOException {
     List<KVPair> data = new ArrayList<KVPair>();
@@ -667,7 +686,8 @@ public class TestIFile {
     readAndVerifyData(writer.getRawLength(), writer.getCompressedLength(), data, codec);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   //Test appendValue with DataInputBuffer
   public void testAppendValueWithDataInputBuffer() throws IOException {
     List<KVPair> data = KVDataGen.generateTestData(false, rnd.nextInt(100));
@@ -693,7 +713,8 @@ public class TestIFile {
     readAndVerifyData(writer.getRawLength(), writer.getCompressedLength(), data, codec);
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testReadToDisk() throws IOException {
     // verify sending a stream of zeroes generates an error
     byte[] zeroData = new byte[1000];
@@ -715,7 +736,7 @@ public class TestIFile {
           new ByteArrayInputStream(baos.toByteArray()), zeroData.length, false, 0);
       fail("Exception should have been thrown");
     } catch (IOException e) {
-      assertTrue(e instanceof ChecksumException);
+      assertInstanceOf(ChecksumException.class, e);
     }
 
     // verify valid data is copied properly
@@ -742,7 +763,7 @@ public class TestIFile {
     Writer writer = writeTestFile(false, false, data, codec);
     readAndVerifyData(writer.getRawLength(), writer.getCompressedLength(), data, codec);
 
-    Assert.assertEquals(originalCodecBufferSize, // original size is repaired
+    assertEquals(originalCodecBufferSize, // original size is repaired
         configurableCodec.getConf().getInt(CodecUtils.getBufferSizeProperty(codec), 0));
 
     // buffer size cannot grow infinitely with compressed data size
@@ -750,16 +771,25 @@ public class TestIFile {
     writer = writeTestFile(false, false, data, codec);
     readAndVerifyData(writer.getRawLength(), writer.getCompressedLength(), data, codec);
 
-    Assert.assertEquals(originalCodecBufferSize, // original size is repaired
+    assertEquals(originalCodecBufferSize, // original size is repaired
         configurableCodec.getConf().getInt(CodecUtils.getBufferSizeProperty(codec), 0));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSmallDataCompression() throws IOException {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
 
-    tryWriteFileWithBufferSize(17, "org.apache.hadoop.io.compress.Lz4Codec");
-    tryWriteFileWithBufferSize(32, "org.apache.hadoop.io.compress.Lz4Codec");
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          tryWriteFileWithBufferSize(17, "org.apache.hadoop.io.compress.Lz4Codec");
+        });
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> {
+          tryWriteFileWithBufferSize(32, "org.apache.hadoop.io.compress.Lz4Codec");
+        });
   }
 
   private void tryWriteFileWithBufferSize(int bufferSize, String codecClassName)
@@ -775,9 +805,10 @@ public class TestIFile {
     writeTestFile(false, false, data, codecToTest);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testLz4CompressedDataIsLargerThanOriginal() throws IOException {
-    Assume.assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
+    assumeTrue(NativeCodeLoader.isNativeCodeLoaded());
 
     // this one succeeds
     byte[] buf = new byte[32];
@@ -934,8 +965,7 @@ public class TestIFile {
    * @param data
    * @throws IOException
    */
-  private void verifyData(Reader reader, List<KVPair> data)
-      throws IOException {
+  private void verifyData(Reader reader, List<KVPair> data) throws IOException {
     LOG.info("Data verification");
     Text readKey = new Text();
     IntWritable readValue = new IntWritable();
@@ -943,8 +973,7 @@ public class TestIFile {
     DataInputBuffer valIn = new DataInputBuffer();
     Deserializer<Text> keyDeserializer;
     Deserializer<IntWritable> valDeserializer;
-    SerializationFactory serializationFactory = new SerializationFactory(
-        defaultConf);
+    SerializationFactory serializationFactory = new SerializationFactory(defaultConf);
     keyDeserializer = serializationFactory.getDeserializer(Text.class);
     valDeserializer = serializationFactory.getDeserializer(IntWritable.class);
     keyDeserializer.open(keyIn);
@@ -958,15 +987,21 @@ public class TestIFile {
       readValue = valDeserializer.deserialize(readValue);
 
       KVPair expected = data.get(numRecordsRead);
-      assertEquals("Key does not match: Expected: " + expected.getKey()
-          + ", Read: " + readKey, expected.getKey(), readKey);
-      assertEquals("Value does not match: Expected: " + expected.getvalue()
-          + ", Read: " + readValue, expected.getvalue(), readValue);
+      assertEquals(
+          expected.getKey(),
+          readKey,
+          "Key does not match: Expected: " + expected.getKey() + ", Read: " + readKey);
+      assertEquals(
+          expected.getvalue(),
+          readValue,
+          "Value does not match: Expected: " + expected.getvalue() + ", Read: " + readValue);
 
       numRecordsRead++;
     }
-    assertEquals("Expected: " + data.size() + " records, but found: "
-        + numRecordsRead, data.size(), numRecordsRead);
+    assertEquals(
+        data.size(),
+        numRecordsRead,
+        "Expected: " + data.size() + " records, but found: " + numRecordsRead);
     LOG.info("Found: " + numRecordsRead + " records");
   }
 

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestPipelinedSorter.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestPipelinedSorter.java
@@ -18,8 +18,11 @@
  */
 package org.apache.tez.runtime.library.common.sort.impl;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
@@ -69,11 +72,10 @@ import org.apache.tez.runtime.library.testutils.RandomTextGenerator;
 
 import com.google.common.collect.Maps;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestPipelinedSorter {
   private static Configuration conf;
@@ -102,12 +104,12 @@ public class TestPipelinedSorter {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws IOException {
     localFs.delete(workDir, true);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = getConf();
     ApplicationId appId = ApplicationId.newInstance(10000, 1);
@@ -139,7 +141,7 @@ public class TestPipelinedSorter {
     return conf;
   }
 
-  @After
+  @AfterEach
   public void reset() throws IOException {
     cleanup();
     localFs.mkdirs(workDir);
@@ -183,7 +185,7 @@ public class TestPipelinedSorter {
     writeData(sorter, 0, 1<<20);
 
     // final merge is disabled. Final output file would not be populated in this case.
-    assertTrue(sorter.finalOutputFile == null);
+    assertNull(sorter.finalOutputFile);
     TezCounter numShuffleChunks = outputContext.getCounters().findCounter(TaskCounter.SHUFFLE_CHUNK_COUNT);
 //    assertTrue(sorter.getNumSpills() == numShuffleChunks.getValue());
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_ENABLE_FINAL_MERGE_IN_OUTPUT, true);
@@ -223,9 +225,9 @@ public class TestPipelinedSorter {
 
     writeData(sorter, numKeys, 1000000);
     if (numKeys == 0) {
-      assertTrue(sorter.getNumSpills() == 1);
+      assertEquals(1, sorter.getNumSpills());
     } else {
-      assertTrue(sorter.getNumSpills() == numKeys + 1);
+      assertEquals(sorter.getNumSpills(), numKeys + 1);
     }
     verifyCounters(sorter, outputContext);
     verifyOutputPermissions(outputContext.getUniqueIdentifier());
@@ -237,9 +239,9 @@ public class TestPipelinedSorter {
         continue;
       }
       if (sendEmptyPartitionDetails) {
-        Assert.assertEquals("Unexpected raw length for " + i + "th partition", 0, tezIndexRecord.getRawLength());
+        assertEquals(0, tezIndexRecord.getRawLength(), "Unexpected raw length for " + i + "th partition");
       } else {
-        Assert.assertEquals("Unexpected raw length for " + i + "th partition", 6, tezIndexRecord.getRawLength());
+        assertEquals(6, tezIndexRecord.getRawLength(), "Unexpected raw length for " + i + "th partition");
       }
     }
   }
@@ -297,9 +299,9 @@ public class TestPipelinedSorter {
     writeData(sorter, 5, 1<<20);
 
     // final merge is disabled. Final output file would not be populated in this case.
-    assertTrue(sorter.finalOutputFile == null);
+    assertNull(sorter.finalOutputFile);
     TezCounter numShuffleChunks = outputContext.getCounters().findCounter(TaskCounter.SHUFFLE_CHUNK_COUNT);
-    assertTrue(sorter.getNumSpills() == numShuffleChunks.getValue());
+    assertEquals(sorter.getNumSpills(), numShuffleChunks.getValue());
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_ENABLE_FINAL_MERGE_IN_OUTPUT, true);
   }
 
@@ -410,7 +412,7 @@ public class TestPipelinedSorter {
     List<Event> events = sorter.close();
 
     //final merge is disabled. Final output file would not be populated in this case.
-    assertTrue(sorter.finalOutputFile == null);
+    assertNull(sorter.finalOutputFile);
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_ENABLE_FINAL_MERGE_IN_OUTPUT, true);
     verify(outputContext, times(0)).sendEvents(any());
     assertTrue(events.size() > 0);
@@ -442,7 +444,7 @@ public class TestPipelinedSorter {
         initialAvailableMem);
 
     writeData(sorter, 25000, 1000);
-    assertFalse("Expecting needsRLE to be false", sorter.needsRLE());
+    assertFalse(sorter.needsRLE(), "Expecting needsRLE to be false");
     verifyCounters(sorter, outputContext);
     verifyOutputPermissions(outputContext.getUniqueIdentifier());
   }
@@ -495,7 +497,7 @@ public class TestPipelinedSorter {
         initialAvailableMem);
 
     writeSimilarKeys(sorter, 25000, 1000, true);
-    assertTrue("Expecting needsRLE to be true", sorter.needsRLE());
+    assertTrue(sorter.needsRLE(), "Expecting needsRLE to be true");
     verifyCounters(sorter, outputContext);
     verifyOutputPermissions(outputContext.getUniqueIdentifier());
   }
@@ -509,7 +511,7 @@ public class TestPipelinedSorter {
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
 
     PipelinedSorter sorter = new PipelinedSorter(this.outputContext, conf, numOutputs, (100 << 20));
-    Assert.assertTrue(sorter.maxNumberOfBlocks >= 2);
+    assertTrue(sorter.maxNumberOfBlocks >= 2);
 
     // Start filling in with data 1MB Key, 1MB Val.
     for (int i = 0; i < 200; i++) {
@@ -521,8 +523,8 @@ public class TestPipelinedSorter {
 
     for(int i = 0; i< sorter.bufferUsage.size(); i++) {
       int usage = sorter.bufferUsage.get(i);
-      Assert.assertTrue("Buffer index " + i + " is not used correctly. "
-              + " usage: " + usage + ", avg: " + avg, usage >= avg);
+      assertTrue(usage >= avg, "Buffer index " + i + " is not used correctly. "
+              + " usage: " + usage + ", avg: " + avg);
     }
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, false);
   }
@@ -572,7 +574,7 @@ public class TestPipelinedSorter {
         TezRuntimeConfiguration.TEZ_RUNTIME_REPORT_PARTITION_STATS,
         TezRuntimeConfiguration.TEZ_RUNTIME_REPORT_PARTITION_STATS_DEFAULT));
     if (partitionStats.isEnabled()) {
-      assertTrue(sorter.getPartitionStats() != null);
+      assertNotNull(sorter.getPartitionStats());
     }
 
     verifyCounters(sorter, outputContext);
@@ -600,19 +602,19 @@ public class TestPipelinedSorter {
         context.getCounters().findCounter(TaskCounter.ADDITIONAL_SPILLS_BYTES_READ);
 
     if (sorter.isFinalMergeEnabled()) {
-      assertTrue(additionalSpills.getValue() == (sorter.getNumSpills() - 1));
+      assertEquals(additionalSpills.getValue(), (sorter.getNumSpills() - 1));
       //Number of files served by shuffle-handler
-      assertTrue(1 == numShuffleChunks.getValue());
+      assertEquals(1, numShuffleChunks.getValue());
       if (sorter.getNumSpills() > 1) {
         assertTrue(additionalSpillBytesRead.getValue() > 0);
         assertTrue(additionalSpillBytesWritten.getValue() > 0);
       }
     } else {
-      assertTrue(0 == additionalSpills.getValue());
+      assertEquals(0, additionalSpills.getValue());
       //Number of files served by shuffle-handler
-      assertTrue(sorter.getNumSpills() == numShuffleChunks.getValue());
-      assertTrue(additionalSpillBytesRead.getValue() == 0);
-      assertTrue(additionalSpillBytesWritten.getValue() == 0);
+      assertEquals(sorter.getNumSpills(), numShuffleChunks.getValue());
+      assertEquals(0, additionalSpillBytesRead.getValue());
+      assertEquals(0, additionalSpillBytesWritten.getValue());
     }
 
     TezCounter finalOutputBytes =
@@ -632,7 +634,7 @@ public class TestPipelinedSorter {
     //Verify if > 2 GB can be set via config
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 3076);
     long size = ExternalSorter.getInitialMemoryRequirement(conf, 4096 * 1024 * 1024l);
-    Assert.assertTrue(size == (3076l << 20));
+    assertEquals((3076l << 20), size);
 
     //Verify number of block buffers allocated
     this.initialAvailableMem = 10 * 1024 * 1024;
@@ -640,39 +642,39 @@ public class TestPipelinedSorter {
         .TEZ_RUNTIME_PIPELINED_SORTER_MIN_BLOCK_SIZE_IN_MB, 1);
     PipelinedSorter sorter = new PipelinedSorter(this.outputContext, conf, numOutputs,
         initialAvailableMem);
-    Assert.assertTrue(sorter.maxNumberOfBlocks == 10);
+    assertEquals(10, sorter.maxNumberOfBlocks);
 
     //10 MB available, request for 3 MB chunk. Last 1 MB gets added to previous chunk.
     conf.setInt(TezRuntimeConfiguration
         .TEZ_RUNTIME_PIPELINED_SORTER_MIN_BLOCK_SIZE_IN_MB, 3);
     sorter = new PipelinedSorter(this.outputContext, conf, numOutputs,
         initialAvailableMem);
-    Assert.assertTrue(sorter.maxNumberOfBlocks == 3);
+    assertEquals(3, sorter.maxNumberOfBlocks);
 
     //10 MB available, request for 10 MB min chunk.  Would get 1 block.
     conf.setInt(TezRuntimeConfiguration
         .TEZ_RUNTIME_PIPELINED_SORTER_MIN_BLOCK_SIZE_IN_MB, 10);
     sorter = new PipelinedSorter(this.outputContext, conf, numOutputs,
         initialAvailableMem);
-    Assert.assertTrue(sorter.maxNumberOfBlocks == 1);
+    assertEquals(1, sorter.maxNumberOfBlocks);
 
     //Verify block sizes (10 MB min chunk size), but available mem is zero.
     conf.setInt(TezRuntimeConfiguration
         .TEZ_RUNTIME_PIPELINED_SORTER_MIN_BLOCK_SIZE_IN_MB, 10);
     sorter = new PipelinedSorter(this.outputContext, conf, numOutputs, initialAvailableMem);
-    Assert.assertTrue(sorter.maxNumberOfBlocks == 1);
+    assertEquals(1, sorter.maxNumberOfBlocks);
     int blockSize = sorter.computeBlockSize(0, (10 << 20));
     //available is zero. Can't allocate any more buffer.
-    Assert.assertTrue(blockSize == 0);
+    assertEquals(0, blockSize);
 
     //300 MB available. Request for 200 MB min block size. It would allocate a block with 200 MB,
     // but last 100 would get clubbed. Hence, it would return 300 MB block.
     conf.setInt(TezRuntimeConfiguration
         .TEZ_RUNTIME_PIPELINED_SORTER_MIN_BLOCK_SIZE_IN_MB, 200);
     sorter = new PipelinedSorter(this.outputContext, conf, numOutputs, (300 << 20));
-    Assert.assertTrue(sorter.maxNumberOfBlocks == 1);
+    assertEquals(1, sorter.maxNumberOfBlocks);
     blockSize = sorter.computeBlockSize((300 << 20), (300 << 20));
-    Assert.assertTrue(blockSize == (300 << 20));
+    assertEquals((300 << 20), blockSize);
 
     //300 MB available. Request for 3500 MB min block size. throw exception
     conf.setInt(TezRuntimeConfiguration
@@ -690,24 +692,24 @@ public class TestPipelinedSorter {
     conf.setInt(TezRuntimeConfiguration
         .TEZ_RUNTIME_PIPELINED_SORTER_MIN_BLOCK_SIZE_IN_MB, 32);
     sorter = new PipelinedSorter(this.outputContext, conf, numOutputs, (64 << 20));
-    Assert.assertTrue(sorter.maxNumberOfBlocks == 2);
+    assertEquals(2, sorter.maxNumberOfBlocks);
     blockSize = sorter.computeBlockSize((64 << 20), (64 << 20));
-    Assert.assertTrue(blockSize == (32 << 20));
+    assertEquals((32 << 20), blockSize);
 
     blockSize = sorter.computeBlockSize((32 << 20), (64 << 20));
-    Assert.assertTrue(blockSize == (32 << 20));
+    assertEquals((32 << 20), blockSize);
 
     blockSize = sorter.computeBlockSize((48 << 20), (64 << 20));
-    Assert.assertTrue(blockSize == (48 << 20));
+    assertEquals((48 << 20), blockSize);
 
     //64 MB available. Request for 8 MB min block size.
     conf.setInt(TezRuntimeConfiguration
         .TEZ_RUNTIME_PIPELINED_SORTER_MIN_BLOCK_SIZE_IN_MB, 8);
     sorter = new PipelinedSorter(this.outputContext, conf, numOutputs, (64 << 20));
-    Assert.assertTrue(sorter.maxNumberOfBlocks == 8);
+    assertEquals(8, sorter.maxNumberOfBlocks);
     blockSize = sorter.computeBlockSize((64 << 20), (64 << 20));
     //Should return 16 instead of 8 which is min block size.
-    Assert.assertTrue(blockSize == (8 << 20));
+    assertEquals((8 << 20), blockSize);
   }
 
   @Test
@@ -724,8 +726,8 @@ public class TestPipelinedSorter {
         .TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, false);
     PipelinedSorter sorter = new PipelinedSorter(this.outputContext, conf,
         numOutputs, (128l << 20));
-    assertTrue("Expected 1 sort buffers. current len=" + sorter.buffers.size(),
-        sorter.buffers.size() == 1);
+    assertEquals(1, sorter.buffers.size(),
+        "Expected 1 sort buffers. current len=" + sorter.buffers.size());
 
     //128 MB. Pre-allocate. Get 2 buffer
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 128);
@@ -735,8 +737,8 @@ public class TestPipelinedSorter {
         .TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, false);
     sorter = new PipelinedSorter(this.outputContext, conf,
         numOutputs, (128l << 20));
-    assertTrue("Expected 2 sort buffers. current len=" + sorter.buffers.size(),
-        sorter.buffers.size() == 2);
+    assertEquals(2, sorter.buffers.size(),
+        "Expected 2 sort buffers. current len=" + sorter.buffers.size());
 
     //48 MB. Pre-allocate. But request for lesser block size (62). Get 2 buffer
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 48);
@@ -746,66 +748,65 @@ public class TestPipelinedSorter {
         .TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, false);
     sorter = new PipelinedSorter(this.outputContext, conf,
         numOutputs, (48l << 20));
-    assertTrue("Expected 1 sort buffers. current len=" + sorter.buffers.size(),
-        sorter.buffers.size() == 1);
+    assertEquals(1, sorter.buffers.size(),
+        "Expected 1 sort buffers. current len=" + sorter.buffers.size());
   }
 
   @Test
-  //Intentionally not having timeout
+  // Intentionally not having timeout
   public void test_with_lazyMemAllocation() throws IOException {
     this.numOutputs = 10;
 
-    //128 MB. Do not pre-allocate.
+    // 128 MB. Do not pre-allocate.
     // Get 32 MB buffer first and the another buffer with 96 on filling up
     // the 32 MB buffer.
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 128);
-    conf.setBoolean(TezRuntimeConfiguration
-        .TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
-    PipelinedSorter sorter = new PipelinedSorter(this.outputContext, conf,
-        numOutputs, (128l << 20));
-    assertTrue("Expected 1 sort buffers. current len=" + sorter.buffers.size(),
-        sorter.buffers.size() == 1);
-    assertTrue(sorter.buffers.get(0).capacity() == 32 * 1024 * 1024 - 64);
-    writeData(sorter, 100, 1024*1024, false); //100 1 MB KV. Will spill
+    conf.setBoolean(
+        TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
+    PipelinedSorter sorter =
+        new PipelinedSorter(this.outputContext, conf, numOutputs, (128l << 20));
+    assertEquals(1, sorter.buffers.size(),
+        "Expected 1 sort buffers. current len=" + sorter.buffers.size());
+    assertEquals(32 * 1024 * 1024 - 64, sorter.buffers.get(0).capacity());
+    writeData(sorter, 100, 1024 * 1024, false); // 100 1 MB KV. Will spill
 
-    //Now it should have created 2 buffers, 32 & 96 MB buffers.
-    assertTrue(sorter.buffers.size() == 2);
-    assertTrue(sorter.buffers.get(0).capacity() == 32 * 1024 * 1024 - 64);
-    assertTrue(sorter.buffers.get(1).capacity() == 96 * 1024 * 1024 + 64);
+    // Now it should have created 2 buffers, 32 & 96 MB buffers.
+    assertEquals(2, sorter.buffers.size());
+    assertEquals(32 * 1024 * 1024 - 64, sorter.buffers.get(0).capacity());
+    assertEquals(96 * 1024 * 1024 + 64, sorter.buffers.get(1).capacity());
     closeSorter(sorter);
     verifyCounters(sorter, outputContext);
 
-    //TODO: Not sure if this would fail in build machines due to mem
-    //300 MB. Do not pre-allocate.
+    // TODO: Not sure if this would fail in build machines due to mem
+    // 300 MB. Do not pre-allocate.
     // Get 1 buffer with 62 MB. But grow to 2 buffers as data is written
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 300);
-    conf.setBoolean(TezRuntimeConfiguration
-        .TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
+    conf.setBoolean(
+        TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
     sorter = new PipelinedSorter(this.outputContext, conf, numOutputs, (300l << 20));
-    assertTrue(sorter.buffers.size() == 1);
-    assertTrue(sorter.buffers.get(0).capacity() == 32 * 1024 * 1024 - 64);
+    assertEquals(1, sorter.buffers.size());
+    assertEquals(32 * 1024 * 1024 - 64, sorter.buffers.get(0).capacity());
 
-    writeData(sorter, 50, 1024*1024, false); //50 1 MB KV to allocate 2nd buf
-    assertTrue(sorter.buffers.size() == 2);
-    assertTrue(sorter.buffers.get(0).capacity() == 32 * 1024 * 1024 - 64);
-    assertTrue(sorter.buffers.get(1).capacity() == 268 * 1024 * 1024 + 64);
+    writeData(sorter, 50, 1024 * 1024, false); // 50 1 MB KV to allocate 2nd buf
+    assertEquals(2, sorter.buffers.size());
+    assertEquals(32 * 1024 * 1024 - 64, sorter.buffers.get(0).capacity());
+    assertEquals(268 * 1024 * 1024 + 64, sorter.buffers.get(1).capacity());
 
-    //48 MB. Do not pre-allocate.
+    // 48 MB. Do not pre-allocate.
     // Get 32 MB buffer first invariably and proceed with the rest.
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 48);
-    conf.setBoolean(TezRuntimeConfiguration
-        .TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
-    sorter = new PipelinedSorter(this.outputContext, conf,
-        numOutputs, (48l << 20));
-    assertTrue("Expected 1 sort buffers. current len=" + sorter.buffers.size(),
-        sorter.buffers.size() == 1);
-    assertTrue(sorter.buffers.get(0).capacity() == 32 * 1024 * 1024 - 64);
-    writeData(sorter, 20, 1024*1024, false); //100 1 MB KV. Will spill
+    conf.setBoolean(
+        TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
+    sorter = new PipelinedSorter(this.outputContext, conf, numOutputs, (48l << 20));
+    assertEquals(1, sorter.buffers.size(),
+        "Expected 1 sort buffers. current len=" + sorter.buffers.size());
+    assertEquals(32 * 1024 * 1024 - 64, sorter.buffers.get(0).capacity());
+    writeData(sorter, 20, 1024 * 1024, false); // 100 1 MB KV. Will spill
 
-    //Now it should have created 2 buffers, 32 & 96 MB buffers.
-    assertTrue(sorter.buffers.size() == 2);
-    assertTrue(sorter.buffers.get(0).capacity() == 32 * 1024 * 1024 - 64);
-    assertTrue(sorter.buffers.get(1).capacity() == 16 * 1024 * 1024 + 64);
+    // Now it should have created 2 buffers, 32 & 96 MB buffers.
+    assertEquals(2, sorter.buffers.size());
+    assertEquals(32 * 1024 * 1024 - 64, sorter.buffers.get(0).capacity());
+    assertEquals(16 * 1024 * 1024 + 64, sorter.buffers.get(1).capacity());
     closeSorter(sorter);
   }
 
@@ -887,14 +888,24 @@ public class TestPipelinedSorter {
   }
 
   private void verifyOutputPermissions(String spillId) throws IOException {
-    String subpath = Constants.TEZ_RUNTIME_TASK_OUTPUT_DIR + "/" + spillId
-        + "/" + Constants.TEZ_RUNTIME_TASK_OUTPUT_FILENAME_STRING;
+    String subpath =
+        Constants.TEZ_RUNTIME_TASK_OUTPUT_DIR
+            + "/"
+            + spillId
+            + "/"
+            + Constants.TEZ_RUNTIME_TASK_OUTPUT_FILENAME_STRING;
     Path outputPath = dirAllocator.getLocalPathToRead(subpath, conf);
-    Path indexPath = dirAllocator.getLocalPathToRead(subpath + Constants.TEZ_RUNTIME_TASK_OUTPUT_INDEX_SUFFIX_STRING, conf);
-    Assert.assertEquals("Incorrect output permissions", (short)0640,
-        localFs.getFileStatus(outputPath).getPermission().toShort());
-    Assert.assertEquals("Incorrect index permissions", (short)0640,
-        localFs.getFileStatus(indexPath).getPermission().toShort());
+    Path indexPath =
+        dirAllocator.getLocalPathToRead(
+            subpath + Constants.TEZ_RUNTIME_TASK_OUTPUT_INDEX_SUFFIX_STRING, conf);
+    assertEquals(
+        (short) 0640,
+        localFs.getFileStatus(outputPath).getPermission().toShort(),
+        "Incorrect output permissions");
+    assertEquals(
+        (short) 0640,
+        localFs.getFileStatus(indexPath).getPermission().toShort(),
+        "Incorrect index permissions");
   }
 
   private void writeData(ExternalSorter sorter, int numKeys, int keyLen) throws IOException {
@@ -974,12 +985,12 @@ public class TestPipelinedSorter {
         reader.nextRawValue(valIn);
         readKey = keyDeserializer.deserialize(readKey);
         readValue = valDeserializer.deserialize(readValue);
-        Assert.assertTrue(key.equals(readKey));
-        Assert.assertTrue(val.equals(readValue));
+        assertEquals(key, readKey);
+        assertEquals(val, readValue);
         numRecordsRead++;
       }
     }
-    Assert.assertTrue(numRecordsRead == sortedDataMap.size());
+    assertEquals(numRecordsRead, sortedDataMap.size());
   }
 
   private static OutputContext createMockOutputContext(TezCounters counters, ApplicationId appId,

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestPipelinedSorter.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestPipelinedSorter.java
@@ -523,8 +523,7 @@ public class TestPipelinedSorter {
 
     for(int i = 0; i< sorter.bufferUsage.size(); i++) {
       int usage = sorter.bufferUsage.get(i);
-      assertTrue(usage >= avg, "Buffer index " + i + " is not used correctly. "
-              + " usage: " + usage + ", avg: " + avg);
+      assertTrue(usage >= avg, "Buffer index " + i + " is not used correctly. " + " usage: " + usage + ", avg: " + avg);
     }
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, false);
   }
@@ -726,8 +725,7 @@ public class TestPipelinedSorter {
         .TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, false);
     PipelinedSorter sorter = new PipelinedSorter(this.outputContext, conf,
         numOutputs, (128l << 20));
-    assertEquals(1, sorter.buffers.size(),
-        "Expected 1 sort buffers. current len=" + sorter.buffers.size());
+    assertEquals(1, sorter.buffers.size(), "Expected 1 sort buffers. current len=" + sorter.buffers.size());
 
     //128 MB. Pre-allocate. Get 2 buffer
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 128);
@@ -737,8 +735,7 @@ public class TestPipelinedSorter {
         .TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, false);
     sorter = new PipelinedSorter(this.outputContext, conf,
         numOutputs, (128l << 20));
-    assertEquals(2, sorter.buffers.size(),
-        "Expected 2 sort buffers. current len=" + sorter.buffers.size());
+    assertEquals(2, sorter.buffers.size(), "Expected 2 sort buffers. current len=" + sorter.buffers.size());
 
     //48 MB. Pre-allocate. But request for lesser block size (62). Get 2 buffer
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 48);
@@ -748,8 +745,7 @@ public class TestPipelinedSorter {
         .TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, false);
     sorter = new PipelinedSorter(this.outputContext, conf,
         numOutputs, (48l << 20));
-    assertEquals(1, sorter.buffers.size(),
-        "Expected 1 sort buffers. current len=" + sorter.buffers.size());
+    assertEquals(1, sorter.buffers.size(), "Expected 1 sort buffers. current len=" + sorter.buffers.size());
   }
 
   @Test
@@ -761,12 +757,9 @@ public class TestPipelinedSorter {
     // Get 32 MB buffer first and the another buffer with 96 on filling up
     // the 32 MB buffer.
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 128);
-    conf.setBoolean(
-        TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
-    PipelinedSorter sorter =
-        new PipelinedSorter(this.outputContext, conf, numOutputs, (128l << 20));
-    assertEquals(1, sorter.buffers.size(),
-        "Expected 1 sort buffers. current len=" + sorter.buffers.size());
+    conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
+    PipelinedSorter sorter = new PipelinedSorter(this.outputContext, conf, numOutputs, (128l << 20));
+    assertEquals(1, sorter.buffers.size(), "Expected 1 sort buffers. current len=" + sorter.buffers.size());
     assertEquals(32 * 1024 * 1024 - 64, sorter.buffers.get(0).capacity());
     writeData(sorter, 100, 1024 * 1024, false); // 100 1 MB KV. Will spill
 
@@ -781,8 +774,7 @@ public class TestPipelinedSorter {
     // 300 MB. Do not pre-allocate.
     // Get 1 buffer with 62 MB. But grow to 2 buffers as data is written
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 300);
-    conf.setBoolean(
-        TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
+    conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
     sorter = new PipelinedSorter(this.outputContext, conf, numOutputs, (300l << 20));
     assertEquals(1, sorter.buffers.size());
     assertEquals(32 * 1024 * 1024 - 64, sorter.buffers.get(0).capacity());
@@ -795,11 +787,9 @@ public class TestPipelinedSorter {
     // 48 MB. Do not pre-allocate.
     // Get 32 MB buffer first invariably and proceed with the rest.
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 48);
-    conf.setBoolean(
-        TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
+    conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_LAZY_ALLOCATE_MEMORY, true);
     sorter = new PipelinedSorter(this.outputContext, conf, numOutputs, (48l << 20));
-    assertEquals(1, sorter.buffers.size(),
-        "Expected 1 sort buffers. current len=" + sorter.buffers.size());
+    assertEquals(1, sorter.buffers.size(), "Expected 1 sort buffers. current len=" + sorter.buffers.size());
     assertEquals(32 * 1024 * 1024 - 64, sorter.buffers.get(0).capacity());
     writeData(sorter, 20, 1024 * 1024, false); // 100 1 MB KV. Will spill
 
@@ -889,22 +879,13 @@ public class TestPipelinedSorter {
 
   private void verifyOutputPermissions(String spillId) throws IOException {
     String subpath =
-        Constants.TEZ_RUNTIME_TASK_OUTPUT_DIR
-            + "/"
-            + spillId
-            + "/"
-            + Constants.TEZ_RUNTIME_TASK_OUTPUT_FILENAME_STRING;
+        Constants.TEZ_RUNTIME_TASK_OUTPUT_DIR + "/" + spillId + "/" + Constants.TEZ_RUNTIME_TASK_OUTPUT_FILENAME_STRING;
     Path outputPath = dirAllocator.getLocalPathToRead(subpath, conf);
     Path indexPath =
-        dirAllocator.getLocalPathToRead(
-            subpath + Constants.TEZ_RUNTIME_TASK_OUTPUT_INDEX_SUFFIX_STRING, conf);
-    assertEquals(
-        (short) 0640,
-        localFs.getFileStatus(outputPath).getPermission().toShort(),
+        dirAllocator.getLocalPathToRead(subpath + Constants.TEZ_RUNTIME_TASK_OUTPUT_INDEX_SUFFIX_STRING, conf);
+    assertEquals((short) 0640, localFs.getFileStatus(outputPath).getPermission().toShort(),
         "Incorrect output permissions");
-    assertEquals(
-        (short) 0640,
-        localFs.getFileStatus(indexPath).getPermission().toShort(),
+    assertEquals((short) 0640, localFs.getFileStatus(indexPath).getPermission().toShort(),
         "Incorrect index permissions");
   }
 

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestTezMerger.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestTezMerger.java
@@ -644,19 +644,19 @@ public class TestTezMerger {
     }
 
     //Verify if the number of distinct entries is the same in source and the test
-    assertEquals(dataMap.keySet().size(), VERIFICATION_DATA_SET.keySet().size(), "dataMap=" + dataMap.keySet().size() + ", verificationSet=" +
-            VERIFICATION_DATA_SET.keySet().size());
+    assertEquals(dataMap.keySet().size(), VERIFICATION_DATA_SET.keySet().size(),
+        "dataMap=" + dataMap.keySet().size() + ", verificationSet=" + VERIFICATION_DATA_SET.keySet().size());
 
     //Verify with source data
     for (Integer key : VERIFICATION_DATA_SET.keySet()) {
-      assertEquals((int) dataMap.get(key), VERIFICATION_DATA_SET.get(key).size(), "Data size for " + key + " not matching with source; dataSize:" + dataMap
-              .get(key) + ", source:" + VERIFICATION_DATA_SET.get(key).size());
+      assertEquals((int) dataMap.get(key), VERIFICATION_DATA_SET.get(key).size(),
+          "Data size for " + key + " not matching with source; dataSize:" + dataMap.get(key) + ", source:" +
+          VERIFICATION_DATA_SET.get(key).size());
     }
 
     //Verify if every key has the same number of repeated items in the source dataset as well
     for (Entry<Integer, Integer> entry : dataMap.entrySet()) {
-      assertEquals(VERIFICATION_DATA_SET.get(entry.getKey()).size(), (int) entry
-              .getValue(), entry.getKey() + "");
+      assertEquals(VERIFICATION_DATA_SET.get(entry.getKey()).size(), (int) entry.getValue(), entry.getKey() + "");
     }
 
     LOG.info("******************");

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestTezMerger.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/TestTezMerger.java
@@ -18,8 +18,8 @@
  */
 package org.apache.tez.runtime.library.common.sort.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -27,7 +27,9 @@ import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -53,6 +55,7 @@ import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.InMemoryRead
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.InMemoryWriter;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.MergeManager;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.TestMergeManager;
+import org.apache.tez.runtime.library.common.sort.impl.TezMerger.MergeQueue;
 
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.ListMultimap;
@@ -60,8 +63,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.TreeMultimap;
 
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,12 +106,13 @@ public class TestTezMerger {
     comparator = ConfigUtils.getIntermediateInputKeyComparator(DEFAULT_CONF);
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws Exception {
     localFs.delete(workDir, true);
   }
 
-  @Test(timeout = 80000)
+  @Test
+  @Timeout(value = 80000, unit = TimeUnit.MILLISECONDS)
   public void testMerge() throws Exception {
     /*
      * test with number of files, keys per file and mergefactor
@@ -171,10 +176,10 @@ public class TestTezMerger {
       String correctResult = expectedResult[i][1];
 
       if (records.isSameKey()) {
-        assertTrue("Expected " + correctResult, correctResult.equalsIgnoreCase(SAME_KEY));
+        assertTrue(correctResult.equalsIgnoreCase(SAME_KEY), "Expected " + correctResult);
         LOG.info("\tSame Key : key=" + k + ", val=" + v);
       } else {
-        assertTrue("Expected " + correctResult, correctResult.equalsIgnoreCase(DIFF_KEY));
+        assertTrue(correctResult.equalsIgnoreCase(DIFF_KEY), "Expected " + correctResult);
         LOG.info("key=" + k + ", val=" + v);
       }
 
@@ -182,7 +187,8 @@ public class TestTezMerger {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWithCustomComparator_WithEmptyStrings() throws Exception {
     List<Path> pathList = new LinkedList<>();
     List<String> data = Lists.newLinkedList();
@@ -232,7 +238,8 @@ public class TestTezMerger {
     data.clear();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWithCustomComparator_No_RLE() throws Exception {
     List<Path> pathList = new LinkedList<>();
     List<String> data = Lists.newLinkedList();
@@ -281,7 +288,8 @@ public class TestTezMerger {
     data.clear();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWithCustomComparator_RLE_acrossFiles() throws Exception {
     List<Path> pathList = new LinkedList<>();
     List<String> data = Lists.newLinkedList();
@@ -320,7 +328,8 @@ public class TestTezMerger {
 
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWithCustomComparator_mixedFiles() throws Exception {
     List<Path> pathList = new LinkedList<>();
     List<String> data = Lists.newLinkedList();
@@ -368,7 +377,8 @@ public class TestTezMerger {
     data.clear();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWithCustomComparator_RLE() throws Exception {
     List<Path> pathList = new LinkedList<>();
     List<String> data = Lists.newLinkedList();
@@ -406,7 +416,8 @@ public class TestTezMerger {
     data.clear();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWithCustomComparator_RLE2() throws Exception {
     List<Path> pathList = new LinkedList<>();
     List<String> data = Lists.newLinkedList();
@@ -454,7 +465,8 @@ public class TestTezMerger {
     data.clear();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWithCustomComparator() throws Exception {
     List<Path> pathList = new LinkedList<>();
     List<String> data = Lists.newLinkedList();
@@ -491,7 +503,8 @@ public class TestTezMerger {
     data.clear();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWithCustomComparator_RLE3() throws Exception {
     List<Path> pathList = new LinkedList<>();
     List<String> data = Lists.newLinkedList();
@@ -525,7 +538,8 @@ public class TestTezMerger {
     data.clear();
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testWithCustomComparator_allEmptyFiles() throws Exception {
     List<Path> pathList = new LinkedList<>();
     List<String> data = Lists.newLinkedList();
@@ -619,7 +633,7 @@ public class TestTezMerger {
         //More than one key should be present in the source data
         assertTrue(VERIFICATION_DATA_SET.get(k.get()).size() > 1);
         //Ensure this is same as the previous key we saw
-        assertEquals("previousKey=" + pk + ", current=" + k.get(), pk, k.get());
+        assertEquals(pk, k.get(), "previousKey=" + pk + ", current=" + k.get());
       } else {
         LOG.info("key=" + k.get() + ", val=" + v.get());
       }
@@ -630,20 +644,19 @@ public class TestTezMerger {
     }
 
     //Verify if the number of distinct entries is the same in source and the test
-    assertEquals("dataMap=" + dataMap.keySet().size() + ", verificationSet=" +
-            VERIFICATION_DATA_SET.keySet().size(), dataMap.keySet().size(), VERIFICATION_DATA_SET.keySet().size());
+    assertEquals(dataMap.keySet().size(), VERIFICATION_DATA_SET.keySet().size(), "dataMap=" + dataMap.keySet().size() + ", verificationSet=" +
+            VERIFICATION_DATA_SET.keySet().size());
 
     //Verify with source data
     for (Integer key : VERIFICATION_DATA_SET.keySet()) {
-      assertEquals("Data size for " + key + " not matching with source; dataSize:" + dataMap
-              .get(key) + ", source:" + VERIFICATION_DATA_SET.get(key).size(),
-              (int) dataMap.get(key), VERIFICATION_DATA_SET.get(key).size());
+      assertEquals((int) dataMap.get(key), VERIFICATION_DATA_SET.get(key).size(), "Data size for " + key + " not matching with source; dataSize:" + dataMap
+              .get(key) + ", source:" + VERIFICATION_DATA_SET.get(key).size());
     }
 
     //Verify if every key has the same number of repeated items in the source dataset as well
-    for (Map.Entry<Integer, Integer> entry : dataMap.entrySet()) {
-      assertEquals(entry.getKey() + "", VERIFICATION_DATA_SET.get(entry.getKey()).size(), (int) entry
-              .getValue());
+    for (Entry<Integer, Integer> entry : dataMap.entrySet()) {
+      assertEquals(VERIFICATION_DATA_SET.get(entry.getKey()).size(), (int) entry
+              .getValue(), entry.getKey() + "");
     }
 
     LOG.info("******************");
@@ -661,7 +674,8 @@ public class TestTezMerger {
     return pathList;
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testMergeSegments() throws Exception {
     List<TezMerger.Segment> segments = Lists.newLinkedList();
     segments.addAll(createInMemorySegments(10, 100));
@@ -685,7 +699,7 @@ public class TestTezMerger {
   private void mergeSegments(List<TezMerger.Segment> segmentList, int mergeFactor, boolean
       hasDiskSegments) throws Exception {
     //Merge datasets
-    TezMerger.MergeQueue mergeQueue = new TezMerger.MergeQueue(DEFAULT_CONF, localFs, segmentList,
+    MergeQueue mergeQueue = new MergeQueue(DEFAULT_CONF, localFs, segmentList,
         comparator, new Reporter(), false, false);
 
     TezRawKeyValueIterator records = mergeQueue.merge(
@@ -698,7 +712,7 @@ public class TestTezMerger {
 
     //ensure disk buffers are used
     int diskBufLen = mergeQueue.diskIFileValue.getLength();
-    assertTrue(diskBufLen + " disk buf length should be > 0", (hasDiskSegments == diskBufLen > 0));
+    assertTrue((hasDiskSegments == diskBufLen > 0), diskBufLen + " disk buf length should be > 0");
 
     VERIFICATION_DATA_SET.clear();
   }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/dflt/TestDefaultSorter.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/dflt/TestDefaultSorter.java
@@ -342,9 +342,10 @@ public class TestDefaultSorter {
           TezCommonUtils.decompressByteStringToByteArray(
               shufflePayload.getEmptyPartitions());
       BitSet emptyPartitionBitSet = TezUtilsInternal.fromByteArray(emptyPartitionsBytesString);
-      assertEquals(emptyPartitionBitSet.cardinality(), sorterWrapper.getEmptyPartitionsCount(), "Number of empty partitions did not match!");
+      assertEquals(emptyPartitionBitSet.cardinality(), sorterWrapper.getEmptyPartitionsCount(),
+          "Number of empty partitions did not match!");
     } else {
-      assertEquals(sorterWrapper.getEmptyPartitionsCount(), 0);
+      assertEquals(0, sorterWrapper.getEmptyPartitionsCount());
     }
     // Each non-empty partition adds 4 bytes for header, 2 bytes for EOF_MARKER, 4 bytes for checksum
     int expectedFileOutLength = sorterWrapper.getNonEmptyPartitionsCount() * 10;
@@ -354,8 +355,9 @@ public class TestDefaultSorter {
       // Each Record adds 1 byte for value length, 1 byte Text overhead (length), value.length bytes for value
       expectedFileOutLength += values[i].length() + 2;
     }
-    assertEquals(localFs.getFileStatus(sorter.getFinalOutputFile()).getLen(), expectedFileOutLength, "Unexpected Output File Size!");
-    assertEquals(sorter.getNumSpills(), 1);
+    assertEquals(localFs.getFileStatus(sorter.getFinalOutputFile()).getLen(), expectedFileOutLength,
+        "Unexpected Output File Size!");
+    assertEquals(1, sorter.getNumSpills());
     verifyCounters(sorter, context);
   }
 
@@ -450,7 +452,7 @@ public class TestDefaultSorter {
           if (sendEmptyPartitionDetails) {
             assertEquals(0, tezIndexRecord.getRawLength(), "Unexpected raw length for " + i + "th partition");
           } else {
-            assertEquals(tezIndexRecord.getRawLength(), 6, "");
+            assertEquals(6, tezIndexRecord.getRawLength(), "");
           }
         }
       }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/dflt/TestDefaultSorter.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/sort/impl/dflt/TestDefaultSorter.java
@@ -18,9 +18,11 @@
  */
 package org.apache.tez.runtime.library.common.sort.impl.dflt;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
@@ -36,6 +38,7 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -78,12 +81,12 @@ import org.apache.tez.util.StringInterner;
 
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -99,7 +102,7 @@ public class TestDefaultSorter {
   private Configuration conf;
   private LocalDirAllocator dirAllocator;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = new Configuration();
     conf.set(CommonConfigurationKeys.FS_PERMISSIONS_UMASK_KEY, "077");
@@ -120,18 +123,19 @@ public class TestDefaultSorter {
     dirAllocator = new LocalDirAllocator(TezRuntimeFrameworkConfigs.LOCAL_DIRS);
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() throws IOException {
     localFs.delete(workingDir, true);
   }
 
-  @After
+  @AfterEach
   public void reset() throws IOException {
     cleanup();
     localFs.mkdirs(workingDir);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSortSpillPercent() throws Exception {
     OutputContext context = createTezOutputContext();
 
@@ -154,7 +158,7 @@ public class TestDefaultSorter {
 
 
   @Test
-  @Ignore
+  @Disabled
   /**
    * Disabling this, as this would need 2047 MB sort mb for testing.
    * Set DefaultSorter.MAX_IO_SORT_MB = 20467 for running this.
@@ -193,7 +197,7 @@ public class TestDefaultSorter {
   }
 
   @Test
-  @Ignore
+  @Disabled
   /**
    * Disabling this, as this would need 2047 MB io.sort.mb for testing.
    * Provide > 2GB to JVM when running this test to avoid OOM in string generation.
@@ -229,30 +233,31 @@ public class TestDefaultSorter {
     }
   }
 
-
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSortMBLimits() throws Exception {
 
-    assertTrue("Expected " + DefaultSorter.MAX_IO_SORT_MB,
-        DefaultSorter.computeSortBufferSize(4096, "") == DefaultSorter.MAX_IO_SORT_MB);
-    assertTrue("Expected " + DefaultSorter.MAX_IO_SORT_MB,
-        DefaultSorter.computeSortBufferSize(2047, "") == DefaultSorter.MAX_IO_SORT_MB);
-    assertTrue("Expected 1024", DefaultSorter.computeSortBufferSize(1024, "") == 1024);
+    assertEquals(DefaultSorter.MAX_IO_SORT_MB, DefaultSorter.computeSortBufferSize(4096, ""),
+        "Expected " + DefaultSorter.MAX_IO_SORT_MB);
+    assertEquals(DefaultSorter.MAX_IO_SORT_MB, DefaultSorter.computeSortBufferSize(2047, ""),
+        "Expected " + DefaultSorter.MAX_IO_SORT_MB);
+    assertEquals(1024, DefaultSorter.computeSortBufferSize(1024, ""), "Expected 1024");
 
     try {
       DefaultSorter.computeSortBufferSize(0, "");
       fail("Should have thrown error for setting buffer size to 0");
-    } catch(RuntimeException re) {
+    } catch (RuntimeException re) {
     }
 
     try {
       DefaultSorter.computeSortBufferSize(-100, "");
       fail("Should have thrown error for setting buffer size to negative value");
-    } catch(RuntimeException re) {
+    } catch (RuntimeException re) {
     }
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   //Test TEZ-1977
   public void basicTest() throws IOException {
     OutputContext context = createTezOutputContext();
@@ -292,7 +297,8 @@ public class TestDefaultSorter {
     verifyOutputPermissions(context.getUniqueIdentifier());
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testEmptyCaseFileLengths() throws IOException {
     testEmptyCaseFileLengthsHelper(50, new String[] {"a", "b"}, new String[] {"1", "2"});
     testEmptyCaseFileLengthsHelper(50, new String[] {"a", "a"}, new String[] {"1", "2"});
@@ -311,7 +317,7 @@ public class TestDefaultSorter {
     String auxService = conf.get(TezConfiguration.TEZ_AM_SHUFFLE_AUXILIARY_SERVICE_ID, TezConfiguration.TEZ_AM_SHUFFLE_AUXILIARY_SERVICE_ID_DEFAULT);
     SorterWrapper sorterWrapper = new SorterWrapper(context, conf, numPartitions, handler.getMemoryAssigned());
     DefaultSorter sorter = sorterWrapper.getSorter();
-    assertEquals("Key and Values must have the same number of elements", keys.length, values.length);
+    assertEquals(keys.length, values.length, "Key and Values must have the same number of elements");
     BitSet keyRLEs = new BitSet(keys.length);
     for (int i = 0; i < keys.length; i++) {
       boolean isRLE = sorterWrapper.writeKeyValue(new Text(keys[i]), new Text(values[i]));
@@ -336,10 +342,9 @@ public class TestDefaultSorter {
           TezCommonUtils.decompressByteStringToByteArray(
               shufflePayload.getEmptyPartitions());
       BitSet emptyPartitionBitSet = TezUtilsInternal.fromByteArray(emptyPartitionsBytesString);
-      Assert.assertEquals("Number of empty partitions did not match!",
-          emptyPartitionBitSet.cardinality(), sorterWrapper.getEmptyPartitionsCount());
+      assertEquals(emptyPartitionBitSet.cardinality(), sorterWrapper.getEmptyPartitionsCount(), "Number of empty partitions did not match!");
     } else {
-      Assert.assertEquals(sorterWrapper.getEmptyPartitionsCount(), 0);
+      assertEquals(sorterWrapper.getEmptyPartitionsCount(), 0);
     }
     // Each non-empty partition adds 4 bytes for header, 2 bytes for EOF_MARKER, 4 bytes for checksum
     int expectedFileOutLength = sorterWrapper.getNonEmptyPartitionsCount() * 10;
@@ -349,7 +354,7 @@ public class TestDefaultSorter {
       // Each Record adds 1 byte for value length, 1 byte Text overhead (length), value.length bytes for value
       expectedFileOutLength += values[i].length() + 2;
     }
-    assertEquals("Unexpected Output File Size!", localFs.getFileStatus(sorter.getFinalOutputFile()).getLen(), expectedFileOutLength);
+    assertEquals(localFs.getFileStatus(sorter.getFinalOutputFile()).getLen(), expectedFileOutLength, "Unexpected Output File Size!");
     assertEquals(sorter.getNumSpills(), 1);
     verifyCounters(sorter, context);
   }
@@ -376,7 +381,8 @@ public class TestDefaultSorter {
     }
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   public void testWithEmptyDataWithFinalMergeDisabled() throws IOException {
     OutputContext context = createTezOutputContext();
 
@@ -427,9 +433,9 @@ public class TestDefaultSorter {
     }
     sorterWrapper.close();
     if (numKeys == 0) {
-      assertTrue(sorter.getNumSpills() == 1);
+      assertEquals(1, sorter.getNumSpills());
     } else {
-      assertTrue(sorter.getNumSpills() == numKeys);
+      assertEquals(sorter.getNumSpills(), numKeys);
     }
     verifyCounters(sorter, context);
     verifyOutputPermissions(context.getUniqueIdentifier());
@@ -442,9 +448,9 @@ public class TestDefaultSorter {
             continue;
           }
           if (sendEmptyPartitionDetails) {
-            Assert.assertEquals("Unexpected raw length for " + i + "th partition", 0, tezIndexRecord.getRawLength());
+            assertEquals(0, tezIndexRecord.getRawLength(), "Unexpected raw length for " + i + "th partition");
           } else {
-            Assert.assertEquals("", tezIndexRecord.getRawLength(), 6);
+            assertEquals(tezIndexRecord.getRawLength(), 6, "");
           }
         }
       }
@@ -457,9 +463,9 @@ public class TestDefaultSorter {
         continue;
       }
       if (sendEmptyPartitionDetails) {
-        Assert.assertEquals("Unexpected raw length for " + i + "th partition", 0, tezIndexRecord.getRawLength());
+        assertEquals(0, tezIndexRecord.getRawLength(), "Unexpected raw length for " + i + "th partition");
       } else {
-        Assert.assertEquals("Unexpected raw length for " + i + "th partition", 6, tezIndexRecord.getRawLength());
+        assertEquals(6, tezIndexRecord.getRawLength(), "Unexpected raw length for " + i + "th partition");
       }
     }
   }
@@ -482,27 +488,30 @@ public class TestDefaultSorter {
       sorterWrapper.writeKeyValue(keys[i], values[i]);
     }
     sorterWrapper.close();
-    assertTrue(sorter.getNumSpills() == 1);
+    assertEquals(1, sorter.getNumSpills());
     verifyCounters(sorter, context);
 
     if (withStats) {
-      assertTrue(sorter.getPartitionStats() != null);
+      assertNotNull(sorter.getPartitionStats());
     } else {
-      assertTrue(sorter.getPartitionStats() == null);
+      assertNull(sorter.getPartitionStats());
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testWithPartitionStats() throws IOException {
     testPartitionStats(true);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testWithoutPartitionStats() throws IOException {
     testPartitionStats(false);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   @SuppressWarnings("unchecked")
   public void testWithSingleSpillWithFinalMergeDisabled() throws IOException {
     OutputContext context = createTezOutputContext();
@@ -522,7 +531,7 @@ public class TestDefaultSorter {
       sorterWrapper.writeKeyValue(keys[i], values[i]);
     }
     sorterWrapper.close();
-    assertTrue(sorter.getNumSpills() == 1);
+    assertEquals(1, sorter.getNumSpills());
     ArgumentCaptor<List> eventCaptor = ArgumentCaptor.forClass(List.class);
     verify(context, times(1)).sendEvents(eventCaptor.capture());
     List<Event> events = eventCaptor.getValue();
@@ -539,7 +548,8 @@ public class TestDefaultSorter {
     verifyCounters(sorter, context);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   @SuppressWarnings("unchecked")
   public void testWithMultipleSpillsWithFinalMergeDisabled() throws IOException {
     OutputContext context = createTezOutputContext();
@@ -575,7 +585,7 @@ public class TestDefaultSorter {
         spillIndex++;
       }
     }
-    assertTrue(spillIndex == spillCount);
+    assertEquals(spillIndex, spillCount);
     verifyCounters(sorter, context);
   }
 
@@ -584,10 +594,8 @@ public class TestDefaultSorter {
         + "/" + Constants.TEZ_RUNTIME_TASK_OUTPUT_FILENAME_STRING;
     Path outputPath = dirAllocator.getLocalPathToRead(subpath, conf);
     Path indexPath = dirAllocator.getLocalPathToRead(subpath + Constants.TEZ_RUNTIME_TASK_OUTPUT_INDEX_SUFFIX_STRING, conf);
-    Assert.assertEquals("Incorrect output permissions", (short)0640,
-        localFs.getFileStatus(outputPath).getPermission().toShort());
-    Assert.assertEquals("Incorrect index permissions", (short)0640,
-        localFs.getFileStatus(indexPath).getPermission().toShort());
+    assertEquals((short)0640, localFs.getFileStatus(outputPath).getPermission().toShort(), "Incorrect output permissions");
+    assertEquals((short)0640, localFs.getFileStatus(indexPath).getPermission().toShort(), "Incorrect index permissions");
   }
 
   private void verifyCounters(DefaultSorter sorter, OutputContext context) {
@@ -597,19 +605,19 @@ public class TestDefaultSorter {
     TezCounter additionalSpillBytesRead = context.getCounters().findCounter(TaskCounter.ADDITIONAL_SPILLS_BYTES_READ);
 
     if (sorter.isFinalMergeEnabled()) {
-      assertTrue(additionalSpills.getValue() == (sorter.getNumSpills() - 1));
+      assertEquals(additionalSpills.getValue(), (sorter.getNumSpills() - 1));
       //Number of files served by shuffle-handler
-      assertTrue(1 == numShuffleChunks.getValue());
+      assertEquals(1, numShuffleChunks.getValue());
       if (sorter.getNumSpills() > 1) {
         assertTrue(additionalSpillBytesRead.getValue() > 0);
         assertTrue(additionalSpillBytesWritten.getValue() > 0);
       }
     } else {
-      assertTrue(0 == additionalSpills.getValue());
+      assertEquals(0, additionalSpills.getValue());
       //Number of files served by shuffle-handler
-      assertTrue(sorter.getNumSpills() == numShuffleChunks.getValue());
-      assertTrue(additionalSpillBytesRead.getValue() == 0);
-      assertTrue(additionalSpillBytesWritten.getValue() == 0);
+      assertEquals(sorter.getNumSpills(), numShuffleChunks.getValue());
+      assertEquals(0, additionalSpillBytesRead.getValue());
+      assertEquals(0, additionalSpillBytesWritten.getValue());
     }
 
     TezCounter finalOutputBytes = context.getCounters().findCounter(TaskCounter.OUTPUT_BYTES_PHYSICAL);

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/writers/TestUnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/writers/TestUnorderedPartitionedKVWriter.java
@@ -105,8 +105,9 @@ import com.google.protobuf.ByteString;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.*;
-import org.junit.jupiter.params.provider.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -137,18 +138,12 @@ public class TestUnorderedPartitionedKVWriter {
 
   @SuppressWarnings("deprecation")
   public static Stream<Arguments> data() {
-    return Stream.of(
-        Arguments.of(false, ReportPartitionStats.DISABLED),
-        Arguments.of(false, ReportPartitionStats.ENABLED),
-        Arguments.of(false, ReportPartitionStats.NONE),
-        Arguments.of(false, ReportPartitionStats.MEMORY_OPTIMIZED),
-        Arguments.of(false, ReportPartitionStats.PRECISE),
-        Arguments.of(true, ReportPartitionStats.DISABLED),
-        Arguments.of(true, ReportPartitionStats.ENABLED),
-        Arguments.of(true, ReportPartitionStats.NONE),
-        Arguments.of(true, ReportPartitionStats.MEMORY_OPTIMIZED),
-        Arguments.of(true, ReportPartitionStats.PRECISE)
-    );
+    return Stream.of(Arguments.of(false, ReportPartitionStats.DISABLED),
+        Arguments.of(false, ReportPartitionStats.ENABLED), Arguments.of(false, ReportPartitionStats.NONE),
+        Arguments.of(false, ReportPartitionStats.MEMORY_OPTIMIZED), Arguments.of(false, ReportPartitionStats.PRECISE),
+        Arguments.of(true, ReportPartitionStats.DISABLED), Arguments.of(true, ReportPartitionStats.ENABLED),
+        Arguments.of(true, ReportPartitionStats.NONE), Arguments.of(true, ReportPartitionStats.MEMORY_OPTIMIZED),
+        Arguments.of(true, ReportPartitionStats.PRECISE));
   }
 
   @BeforeAll
@@ -256,7 +251,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testNoSpill(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testNoSpill(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTest(10, 10, null, shouldCompress, -1, 0);
   }
@@ -264,7 +260,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testSingleSpill(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testSingleSpill(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTest(50, 10, null, shouldCompress, -1, 0);
   }
@@ -272,7 +269,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testMultipleSpills(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testMultipleSpills(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTest(200, 10, null, shouldCompress, -1, 0);
   }
@@ -280,7 +278,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testMultipleSpillsWithSmallBuffer(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testMultipleSpillsWithSmallBuffer(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     // numBuffers is much higher than available threads.
     baseTest(200, 10, null, shouldCompress, 512, 0, 9600, false);
@@ -289,7 +288,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testMergeBuffersAndSpill(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testMergeBuffersAndSpill(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTest(200, 10, null, shouldCompress, 2048, 10);
   }
@@ -297,7 +297,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testNoRecords(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testNoRecords(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTest(0, 10, null, shouldCompress, -1, 0);
   }
@@ -305,7 +306,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testNoRecords_SinglePartition(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testNoRecords_SinglePartition(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     // skipBuffers
     baseTest(0, 1, null, shouldCompress, -1, 0, 2048, false);
@@ -316,7 +318,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testSkippedPartitions(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testSkippedPartitions(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTest(200, 10, Sets.newHashSet(2, 5), shouldCompress, -1, 0);
   }
@@ -324,7 +327,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testNoSpill_SinglePartition(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testNoSpill_SinglePartition(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTest(10, 1, null, shouldCompress, -1, 0);
   }
@@ -332,7 +336,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testSpill_SinglePartition(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testSpill_SinglePartition(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTest(1000, 1, null, shouldCompress, -1, 0, 2048, true);
   }
@@ -340,7 +345,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testRandomText(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testRandomText(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     textTest(100, 10, 2048, 0, 0, 0, false, true);
   }
@@ -348,7 +354,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testLargeKeys(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testLargeKeys(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 10, 0, 0, false, true);
   }
@@ -356,7 +363,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testLargevalues(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testLargevalues(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 0, 10, 0, false, true);
   }
@@ -364,7 +372,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testLargeKvPairs(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testLargeKvPairs(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 0, 0, 10, false, true);
   }
@@ -372,7 +381,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testTextMixedRecords(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testTextMixedRecords(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     textTest(100, 10, 2048, 10, 10, 10, false, true);
   }
@@ -380,7 +390,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000000, unit = TimeUnit.MILLISECONDS)
-  public void testRandomTextWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testRandomTextWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     textTest(100, 10, 2048, 0, 0, 0, false, false);
   }
@@ -388,7 +399,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testLargeKeysWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testLargeKeysWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 10, 0, 0, false, false);
   }
@@ -396,7 +408,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testLargevaluesWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testLargevaluesWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 0, 10, 0, false, false);
   }
@@ -404,7 +417,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testLargeKvPairsWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testLargeKvPairsWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 0, 0, 10, false, false);
   }
@@ -412,7 +426,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testTextMixedRecordsWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testTextMixedRecordsWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     textTest(100, 10, 2048, 10, 10, 10, false, false);
   }
@@ -551,7 +566,7 @@ public class TestUnorderedPartitionedKVWriter {
     // Validate the events
     assertEquals(2, events.size());
 
-    assertInstanceOf(VertexManagerEvent.class, events.get(0));
+    assertInstanceOf(VertexManagerEvent.class, events.getFirst());
     VertexManagerEvent vme = (VertexManagerEvent) events.get(0);
     verifyPartitionStats(vme, partitionsWithData);
 
@@ -680,7 +695,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testNoSpill_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testNoSpill_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTestWithPipelinedTransfer(10, 10, null, shouldCompress);
   }
@@ -688,7 +704,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testSingleSpill_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testSingleSpill_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTestWithPipelinedTransfer(50, 10, null, shouldCompress);
   }
@@ -696,7 +713,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testMultipleSpills_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testMultipleSpills_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTestWithPipelinedTransfer(200, 10, null, shouldCompress);
   }
@@ -704,7 +722,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testNoRecords_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testNoRecords_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTestWithPipelinedTransfer(0, 10, null, shouldCompress);
   }
@@ -712,7 +731,9 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testNoRecords_SinglePartition_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testNoRecords_SinglePartition_WithPipelinedShuffle(boolean shouldCompress,
+                                                                 ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     // skipBuffers
     baseTestWithPipelinedTransfer(0, 1, null, shouldCompress);
@@ -721,7 +742,9 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testSkippedPartitions_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testSkippedPartitions_WithPipelinedShuffle(boolean shouldCompress,
+                                                         ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTestWithPipelinedTransfer(200, 10, Sets.newHashSet(2, 5), shouldCompress);
   }
@@ -729,7 +752,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testLargeKvPairs_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testLargeKvPairs_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 10, 20, 50, true, false);
   }
@@ -808,7 +832,7 @@ public class TestUnorderedPartitionedKVWriter {
       List<Event> events = eventCaptor.getAllValues().get(i);
       if (i < numOfCapturedEvents - 1) {
         assertEquals(1, events.size());
-        assertInstanceOf(CompositeDataMovementEvent.class, events.get(0));
+        assertInstanceOf(CompositeDataMovementEvent.class, events.getFirst());
       } else {
         assertEquals(2, events.size());
         assertInstanceOf(VertexManagerEvent.class, events.get(0));
@@ -861,15 +885,15 @@ public class TestUnorderedPartitionedKVWriter {
     long additionalSpillBytesRead = additionalSpillBytesReadCounter.getValue();
 
     //No additional spill bytes written when final merge is disabled.
-    assertEquals(additionalSpillBytesWritten, 0);
+    assertEquals(0, additionalSpillBytesWritten);
 
     //No additional spills when final merge is disabled.
     assertEquals(additionalSpillBytesWritten, additionalSpillBytesRead);
 
     //No additional spills when final merge is disabled.
-    assertEquals(numAdditionalSpillsCounter.getValue(), 0);
+    assertEquals(0, numAdditionalSpillsCounter.getValue());
 
-    assertTrue(lastEvents.size() > 0);
+    assertFalse(lastEvents.isEmpty());
     //Get the last event
     int index = lastEvents.size() - 1;
     assertInstanceOf(CompositeDataMovementEvent.class, lastEvents.get(index));
@@ -904,10 +928,14 @@ public class TestUnorderedPartitionedKVWriter {
   }
 
   private void checkPermissions(Path outputFile, Path indexFile) throws IOException {
-    assertEquals(FsAction.READ_WRITE, localFs.getFileStatus(outputFile).getPermission().getUserAction(), "Incorrect output permissions (user)");
-    assertEquals(FsAction.READ, localFs.getFileStatus(outputFile).getPermission().getGroupAction(), "Incorrect output permissions (group)");
-    assertEquals(FsAction.READ_WRITE, localFs.getFileStatus(indexFile).getPermission().getUserAction(), "Incorrect index permissions (user)");
-    assertEquals(FsAction.READ, localFs.getFileStatus(indexFile).getPermission().getGroupAction(), "Incorrect index permissions (group)");
+    assertEquals(FsAction.READ_WRITE, localFs.getFileStatus(outputFile).getPermission().getUserAction(),
+        "Incorrect output permissions (user)");
+    assertEquals(FsAction.READ, localFs.getFileStatus(outputFile).getPermission().getGroupAction(),
+        "Incorrect output permissions (group)");
+    assertEquals(FsAction.READ_WRITE, localFs.getFileStatus(indexFile).getPermission().getUserAction(),
+        "Incorrect index permissions (user)");
+    assertEquals(FsAction.READ, localFs.getFileStatus(indexFile).getPermission().getGroupAction(),
+        "Incorrect index permissions (group)");
   }
 
   private void verifyEmptyPartitions(DataMovementEventPayloadProto eventProto,
@@ -946,7 +974,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testNoSpill_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testNoSpill_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(10, 10, null, shouldCompress);
   }
@@ -954,7 +983,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testSingleSpill_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testSingleSpill_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(50, 10, null, shouldCompress);
   }
@@ -962,7 +992,9 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testSinglePartition_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testSinglePartition_WithFinalMergeDisabled(boolean shouldCompress,
+                                                         ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(0, 1, null, shouldCompress);
   }
@@ -970,7 +1002,9 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testMultipleSpills_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testMultipleSpills_WithFinalMergeDisabled(boolean shouldCompress,
+                                                        ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(200, 10, null, shouldCompress);
   }
@@ -978,7 +1012,8 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testNoRecords_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testNoRecords_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(0, 10, null, shouldCompress);
   }
@@ -986,7 +1021,9 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testNoRecords_SinglePartition_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testNoRecords_SinglePartition_WithFinalMergeDisabled(boolean shouldCompress,
+                                                                   ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(0, 1, null, shouldCompress);
   }
@@ -994,7 +1031,9 @@ public class TestUnorderedPartitionedKVWriter {
   @ParameterizedTest(name = "test[{0}, {1}]")
   @MethodSource("data")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testSkippedPartitions_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+  public void testSkippedPartitions_WithFinalMergeDisabled(boolean shouldCompress,
+                                                           ReportPartitionStats reportPartitionStats)
+      throws IOException, InterruptedException {
     setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(200, 10, Sets.newHashSet(2, 5), shouldCompress);
   }
@@ -1114,8 +1153,8 @@ public class TestUnorderedPartitionedKVWriter {
     if (numRecordsWritten > 0) {
       assertTrue(fileOutputBytes > 0);
       if (!shouldCompress) {
-        assertTrue(fileOutputBytes > outputRecordBytesCounter.getValue(), "fileOutputBytes=" + fileOutputBytes + ", outputRecordBytes="
-                +outputRecordBytesCounter.getValue());
+        assertTrue(fileOutputBytes > outputRecordBytesCounter.getValue(),
+            "fileOutputBytes=" + fileOutputBytes + ", outputRecordBytes=" + outputRecordBytesCounter.getValue());
       }
     } else {
       assertEquals(0, fileOutputBytes);
@@ -1126,15 +1165,15 @@ public class TestUnorderedPartitionedKVWriter {
     long additionalSpillBytesRead = additionalSpillBytesReadCounter.getValue();
 
     //No additional spill bytes written when final merge is disabled.
-    assertEquals(additionalSpillBytesWritten, 0);
+    assertEquals(0, additionalSpillBytesWritten);
 
     //No additional spills when final merge is disabled.
     assertEquals(additionalSpillBytesWritten, additionalSpillBytesRead);
 
     //No additional spills when final merge is disabled.
-    assertEquals(numAdditionalSpillsCounter.getValue(), 0);
+    assertEquals(0, numAdditionalSpillsCounter.getValue());
 
-    assertTrue(lastEvents.size() > 0);
+    assertFalse(lastEvents.isEmpty());
     //Get the last event
     int index = lastEvents.size() - 1;
     assertInstanceOf(CompositeDataMovementEvent.class, lastEvents.get(index));
@@ -1356,7 +1395,7 @@ public class TestUnorderedPartitionedKVWriter {
     BitSet emptyPartitionBits = null;
     // Verify the events returned
     assertEquals(2, events.size());
-    assertInstanceOf(VertexManagerEvent.class, events.get(0));
+    assertInstanceOf(VertexManagerEvent.class, events.getFirst());
     VertexManagerEvent vme = (VertexManagerEvent) events.get(0);
     verifyPartitionStats(vme, partitionsWithData);
     assertInstanceOf(CompositeDataMovementEvent.class, events.get(1));
@@ -1402,14 +1441,18 @@ public class TestUnorderedPartitionedKVWriter {
       return;
     }
 
-    boolean isInMem= eventProto.getData().hasData();
+    boolean isInMem = eventProto.getData().hasData();
     assertTrue(localFs.exists(outputFilePath));
-    assertEquals(FsAction.READ_WRITE, localFs.getFileStatus(outputFilePath).getPermission().getUserAction(), "Incorrect output permissions (user)");
-    assertEquals(FsAction.READ, localFs.getFileStatus(outputFilePath).getPermission().getGroupAction(), "Incorrect output permissions (group)");
-    if( !isInMem ) {
+    assertEquals(FsAction.READ_WRITE, localFs.getFileStatus(outputFilePath).getPermission().getUserAction(),
+        "Incorrect output permissions (user)");
+    assertEquals(FsAction.READ, localFs.getFileStatus(outputFilePath).getPermission().getGroupAction(),
+        "Incorrect output permissions (group)");
+    if (!isInMem) {
       assertTrue(localFs.exists(spillFilePath));
-      assertEquals(FsAction.READ_WRITE, localFs.getFileStatus(spillFilePath).getPermission().getUserAction(), "Incorrect index permissions (user)");
-      assertEquals(FsAction.READ, localFs.getFileStatus(spillFilePath).getPermission().getGroupAction(), "Incorrect index permissions (group)");
+      assertEquals(FsAction.READ_WRITE, localFs.getFileStatus(spillFilePath).getPermission().getUserAction(),
+          "Incorrect index permissions (user)");
+      assertEquals(FsAction.READ, localFs.getFileStatus(spillFilePath).getPermission().getGroupAction(),
+          "Incorrect index permissions (group)");
 
       // verify no intermediate spill files have been left around
       synchronized (kvWriter.spillInfoList) {
@@ -1425,14 +1468,13 @@ public class TestUnorderedPartitionedKVWriter {
     IntWritable keyDeser = new IntWritable();
     LongWritable valDeser = new LongWritable();
     for (int i = 0; i < numOutputs; i++) {
-      Reader reader = null;
+      Reader reader;
       InputStream inStream;
       if (isInMem) {
         // Read from in memory payload
         int dataLoadSize = eventProto.getData().getData().size();
         inStream = new ByteArrayInputStream(eventProto.getData().getData().toByteArray());
-        reader = new Reader(inStream, dataLoadSize, codec, null,
-                null, false, 0, -1);
+        reader = new Reader(inStream, dataLoadSize, codec, null, null, false, 0, -1);
       } else {
         TezSpillRecord spillRecord = new TezSpillRecord(spillFilePath, conf);
         TezIndexRecord indexRecord = spillRecord.getIndex(i);
@@ -1444,8 +1486,7 @@ public class TestUnorderedPartitionedKVWriter {
         FSDataInputStream tmpStream = FileSystem.getLocal(conf).open(outputFilePath);
         tmpStream.seek(indexRecord.getStartOffset());
         inStream = tmpStream;
-        reader = new Reader(tmpStream, indexRecord.getPartLength(), codec, null,
-                null, false, 0, -1);
+        reader = new Reader(tmpStream, indexRecord.getPartLength(), codec, null, null, false, 0, -1);
       }
 
       while (reader.nextRawKey(keyBuffer)) {

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/writers/TestUnorderedPartitionedKVWriter.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/common/writers/TestUnorderedPartitionedKVWriter.java
@@ -18,10 +18,12 @@
  */
 package org.apache.tez.runtime.library.common.writers;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.atLeast;
@@ -39,9 +41,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 import java.util.BitSet;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -49,8 +49,10 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
@@ -83,6 +85,7 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration.ReportPartitionStats;
 import org.apache.tez.runtime.library.common.Constants;
 import org.apache.tez.runtime.library.common.sort.impl.IFile;
+import org.apache.tez.runtime.library.common.sort.impl.IFile.Reader;
 import org.apache.tez.runtime.library.common.sort.impl.TezIndexRecord;
 import org.apache.tez.runtime.library.common.sort.impl.TezSpillRecord;
 import org.apache.tez.runtime.library.common.task.local.output.TezTaskOutput;
@@ -99,11 +102,11 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -111,7 +114,6 @@ import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@RunWith(value = Parameterized.class)
 public class TestUnorderedPartitionedKVWriter {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestUnorderedPartitionedKVWriter.class);
@@ -128,45 +130,46 @@ public class TestUnorderedPartitionedKVWriter {
   private ReportPartitionStats reportPartitionStats;
   private Configuration defaultConf = new Configuration();
 
-  public TestUnorderedPartitionedKVWriter(boolean shouldCompress,
-      ReportPartitionStats reportPartitionStats) {
+  public void setupInit(boolean shouldCompress, ReportPartitionStats reportPartitionStats) {
     this.shouldCompress = shouldCompress;
     this.reportPartitionStats = reportPartitionStats;
   }
 
   @SuppressWarnings("deprecation")
-  @Parameterized.Parameters(name = "test[{0}, {1}]")
-  public static Collection<Object[]> data() {
-    Object[][] data = new Object[][] {
-        { false, ReportPartitionStats.DISABLED },
-        { false, ReportPartitionStats.ENABLED },
-        { false, ReportPartitionStats.NONE },
-        { false, ReportPartitionStats.MEMORY_OPTIMIZED },
-        { false, ReportPartitionStats.PRECISE },
-        { true, ReportPartitionStats.DISABLED },
-        { true, ReportPartitionStats.ENABLED },
-        { true, ReportPartitionStats.NONE },
-        { true, ReportPartitionStats.MEMORY_OPTIMIZED },
-        { true, ReportPartitionStats.PRECISE }};
-    return Arrays.asList(data);
+  public static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(false, ReportPartitionStats.DISABLED),
+        Arguments.of(false, ReportPartitionStats.ENABLED),
+        Arguments.of(false, ReportPartitionStats.NONE),
+        Arguments.of(false, ReportPartitionStats.MEMORY_OPTIMIZED),
+        Arguments.of(false, ReportPartitionStats.PRECISE),
+        Arguments.of(true, ReportPartitionStats.DISABLED),
+        Arguments.of(true, ReportPartitionStats.ENABLED),
+        Arguments.of(true, ReportPartitionStats.NONE),
+        Arguments.of(true, ReportPartitionStats.MEMORY_OPTIMIZED),
+        Arguments.of(true, ReportPartitionStats.PRECISE)
+    );
   }
 
-  @Before
-  public void setup() throws IOException {
+  @BeforeAll
+  public static void setup() throws IOException {
     LOG.info("Setup. Using test dir: " + TEST_ROOT_DIR);
     localFs = FileSystem.getLocal(new Configuration());
     localFs.delete(TEST_ROOT_DIR, true);
     localFs.mkdirs(TEST_ROOT_DIR);
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws IOException {
     LOG.info("CleanUp");
     localFs.delete(TEST_ROOT_DIR, true);
   }
 
-  @Test(timeout = 10000)
-  public void testBufferSizing() throws IOException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testBufferSizing(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException {
+    setupInit(shouldCompress, reportPartitionStats);
     ApplicationId appId = ApplicationId.newInstance(10000000, 1);
     TezCounters counters = new TezCounters();
     String uniqueId = UUID.randomUUID().toString();
@@ -250,107 +253,167 @@ public class TestUnorderedPartitionedKVWriter {
     assertEquals(1, kvWriter.spillLimit);
   }
 
-  @Test(timeout = 10000)
-  public void testNoSpill() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testNoSpill(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTest(10, 10, null, shouldCompress, -1, 0);
   }
 
-  @Test(timeout = 10000)
-  public void testSingleSpill() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testSingleSpill(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTest(50, 10, null, shouldCompress, -1, 0);
   }
 
-  @Test(timeout = 10000)
-  public void testMultipleSpills() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testMultipleSpills(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTest(200, 10, null, shouldCompress, -1, 0);
   }
 
-  @Test(timeout = 10000)
-  public void testMultipleSpillsWithSmallBuffer() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testMultipleSpillsWithSmallBuffer(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     // numBuffers is much higher than available threads.
     baseTest(200, 10, null, shouldCompress, 512, 0, 9600, false);
   }
 
-  @Test(timeout = 10000)
-  public void testMergeBuffersAndSpill() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testMergeBuffersAndSpill(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTest(200, 10, null, shouldCompress, 2048, 10);
   }
 
-  @Test(timeout = 10000)
-  public void testNoRecords() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testNoRecords(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTest(0, 10, null, shouldCompress, -1, 0);
   }
 
-  @Test(timeout = 10000)
-  public void testNoRecords_SinglePartition() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testNoRecords_SinglePartition(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     // skipBuffers
     baseTest(0, 1, null, shouldCompress, -1, 0, 2048, false);
     // Check with data via events
     baseTest(0, 1, null, shouldCompress, -1, 0, 2048, true);
   }
 
-  @Test(timeout = 10000)
-  public void testSkippedPartitions() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testSkippedPartitions(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTest(200, 10, Sets.newHashSet(2, 5), shouldCompress, -1, 0);
   }
 
-  @Test(timeout = 10000)
-  public void testNoSpill_SinglePartition() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testNoSpill_SinglePartition(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTest(10, 1, null, shouldCompress, -1, 0);
   }
 
-  @Test(timeout = 10000)
-  public void testSpill_SinglePartition() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testSpill_SinglePartition(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTest(1000, 1, null, shouldCompress, -1, 0, 2048, true);
   }
 
-  @Test(timeout = 10000)
-  public void testRandomText() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testRandomText(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     textTest(100, 10, 2048, 0, 0, 0, false, true);
   }
 
-  @Test(timeout = 10000)
-  public void testLargeKeys() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testLargeKeys(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 10, 0, 0, false, true);
   }
 
-  @Test(timeout = 10000)
-  public void testLargevalues() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testLargevalues(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 0, 10, 0, false, true);
   }
 
-  @Test(timeout = 10000)
-  public void testLargeKvPairs() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testLargeKvPairs(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 0, 0, 10, false, true);
   }
 
-  @Test(timeout = 10000)
-  public void testTextMixedRecords() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testTextMixedRecords(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     textTest(100, 10, 2048, 10, 10, 10, false, true);
   }
 
-  @Test(timeout = 10000000)
-  public void testRandomTextWithoutFinalMerge() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000000, unit = TimeUnit.MILLISECONDS)
+  public void testRandomTextWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     textTest(100, 10, 2048, 0, 0, 0, false, false);
   }
 
-  @Test(timeout = 10000)
-  public void testLargeKeysWithoutFinalMerge() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testLargeKeysWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 10, 0, 0, false, false);
   }
 
-  @Test(timeout = 10000)
-  public void testLargevaluesWithoutFinalMerge() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testLargevaluesWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 0, 10, 0, false, false);
   }
 
-  @Test(timeout = 10000)
-  public void testLargeKvPairsWithoutFinalMerge() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testLargeKvPairsWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 0, 0, 10, false, false);
   }
 
-  @Test(timeout = 10000)
-  public void testTextMixedRecordsWithoutFinalMerge() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testTextMixedRecordsWithoutFinalMerge(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     textTest(100, 10, 2048, 10, 10, 10, false, false);
   }
 
@@ -488,11 +551,11 @@ public class TestUnorderedPartitionedKVWriter {
     // Validate the events
     assertEquals(2, events.size());
 
-    assertTrue(events.get(0) instanceof VertexManagerEvent);
+    assertInstanceOf(VertexManagerEvent.class, events.get(0));
     VertexManagerEvent vme = (VertexManagerEvent) events.get(0);
     verifyPartitionStats(vme, partitionsWithData);
 
-    assertTrue(events.get(1) instanceof CompositeDataMovementEvent);
+    assertInstanceOf(CompositeDataMovementEvent.class, events.get(1));
     CompositeDataMovementEvent cdme = (CompositeDataMovementEvent) events.get(1);
     assertEquals(0, cdme.getSourceIndexStart());
     assertEquals(numPartitions, cdme.getCount());
@@ -610,43 +673,64 @@ public class TestUnorderedPartitionedKVWriter {
     for (int i = 0; i < stats.length; i++) {
       // The stats should be greater than zero if and only if
       // the partition has data
-      assertTrue(expectedPartitionsWithData.get(i) == (stats[i] > 0));
+      assertEquals(expectedPartitionsWithData.get(i), (stats[i] > 0));
     }
   }
 
-  @Test(timeout = 10000)
-  public void testNoSpill_WithPipelinedShuffle() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testNoSpill_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTestWithPipelinedTransfer(10, 10, null, shouldCompress);
   }
 
-  @Test(timeout = 10000)
-  public void testSingleSpill_WithPipelinedShuffle() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testSingleSpill_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTestWithPipelinedTransfer(50, 10, null, shouldCompress);
   }
 
-  @Test(timeout = 10000)
-  public void testMultipleSpills_WithPipelinedShuffle() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testMultipleSpills_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTestWithPipelinedTransfer(200, 10, null, shouldCompress);
   }
 
-  @Test(timeout = 10000)
-  public void testNoRecords_WithPipelinedShuffle() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testNoRecords_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTestWithPipelinedTransfer(0, 10, null, shouldCompress);
   }
 
-  @Test(timeout = 10000)
-  public void testNoRecords_SinglePartition_WithPipelinedShuffle() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testNoRecords_SinglePartition_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     // skipBuffers
     baseTestWithPipelinedTransfer(0, 1, null, shouldCompress);
   }
 
-  @Test(timeout = 10000)
-  public void testSkippedPartitions_WithPipelinedShuffle() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testSkippedPartitions_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTestWithPipelinedTransfer(200, 10, Sets.newHashSet(2, 5), shouldCompress);
   }
 
-  @Test(timeout = 10000)
-  public void testLargeKvPairs_WithPipelinedShuffle() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testLargeKvPairs_WithPipelinedShuffle(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     textTest(0, 10, 2048, 10, 20, 50, true, false);
   }
 
@@ -710,11 +794,11 @@ public class TestUnorderedPartitionedKVWriter {
     List<Event> lastEvents = kvWriter.close();
 
     if (numPartitions == 1) {
-      assertEquals(false, kvWriter.skipBuffers);
+      assertFalse(kvWriter.skipBuffers);
     }
 
     //no events are sent to kvWriter upon close with pipelining
-    assertTrue(lastEvents.size() == 0);
+    assertEquals(0, lastEvents.size());
     verify(outputContext, atLeast(numExpectedSpills)).sendEvents(eventCaptor.capture());
     int numOfCapturedEvents = eventCaptor.getAllValues().size();
     lastEvents = eventCaptor.getAllValues().get(numOfCapturedEvents - 1);
@@ -723,12 +807,12 @@ public class TestUnorderedPartitionedKVWriter {
     for (int i=0; i<numOfCapturedEvents; i++) {
       List<Event> events = eventCaptor.getAllValues().get(i);
       if (i < numOfCapturedEvents - 1) {
-        assertTrue(events.size() == 1);
-        assertTrue(events.get(0) instanceof CompositeDataMovementEvent);
+        assertEquals(1, events.size());
+        assertInstanceOf(CompositeDataMovementEvent.class, events.get(0));
       } else {
-        assertTrue(events.size() == 2);
-        assertTrue(events.get(0) instanceof VertexManagerEvent);
-        assertTrue(events.get(1) instanceof CompositeDataMovementEvent);
+        assertEquals(2, events.size());
+        assertInstanceOf(VertexManagerEvent.class, events.get(0));
+        assertInstanceOf(CompositeDataMovementEvent.class, events.get(1));
       }
     }
     verifyPartitionStats(VMEvent, partitionsWithData);
@@ -780,7 +864,7 @@ public class TestUnorderedPartitionedKVWriter {
     assertEquals(additionalSpillBytesWritten, 0);
 
     //No additional spills when final merge is disabled.
-    assertTrue(additionalSpillBytesWritten == additionalSpillBytesRead);
+    assertEquals(additionalSpillBytesWritten, additionalSpillBytesRead);
 
     //No additional spills when final merge is disabled.
     assertEquals(numAdditionalSpillsCounter.getValue(), 0);
@@ -788,7 +872,7 @@ public class TestUnorderedPartitionedKVWriter {
     assertTrue(lastEvents.size() > 0);
     //Get the last event
     int index = lastEvents.size() - 1;
-    assertTrue(lastEvents.get(index) instanceof CompositeDataMovementEvent);
+    assertInstanceOf(CompositeDataMovementEvent.class, lastEvents.get(index));
     CompositeDataMovementEvent cdme =
         (CompositeDataMovementEvent)lastEvents.get(index);
     assertEquals(0, cdme.getSourceIndexStart());
@@ -820,14 +904,10 @@ public class TestUnorderedPartitionedKVWriter {
   }
 
   private void checkPermissions(Path outputFile, Path indexFile) throws IOException {
-    assertEquals("Incorrect output permissions (user)", FsAction.READ_WRITE,
-        localFs.getFileStatus(outputFile).getPermission().getUserAction());
-    assertEquals("Incorrect output permissions (group)", FsAction.READ,
-        localFs.getFileStatus(outputFile).getPermission().getGroupAction());
-    assertEquals("Incorrect index permissions (user)", FsAction.READ_WRITE,
-        localFs.getFileStatus(indexFile).getPermission().getUserAction());
-    assertEquals("Incorrect index permissions (group)", FsAction.READ,
-        localFs.getFileStatus(indexFile).getPermission().getGroupAction());
+    assertEquals(FsAction.READ_WRITE, localFs.getFileStatus(outputFile).getPermission().getUserAction(), "Incorrect output permissions (user)");
+    assertEquals(FsAction.READ, localFs.getFileStatus(outputFile).getPermission().getGroupAction(), "Incorrect output permissions (group)");
+    assertEquals(FsAction.READ_WRITE, localFs.getFileStatus(indexFile).getPermission().getUserAction(), "Incorrect index permissions (user)");
+    assertEquals(FsAction.READ, localFs.getFileStatus(indexFile).getPermission().getGroupAction(), "Incorrect index permissions (group)");
   }
 
   private void verifyEmptyPartitions(DataMovementEventPayloadProto eventProto,
@@ -863,38 +943,59 @@ public class TestUnorderedPartitionedKVWriter {
     }
   }
 
-  @Test(timeout = 10000)
-  public void testNoSpill_WithFinalMergeDisabled() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testNoSpill_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(10, 10, null, shouldCompress);
   }
 
-  @Test(timeout = 10000)
-  public void testSingleSpill_WithFinalMergeDisabled() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testSingleSpill_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(50, 10, null, shouldCompress);
   }
 
-  @Test(timeout = 10000)
-  public void testSinglePartition_WithFinalMergeDisabled() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testSinglePartition_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(0, 1, null, shouldCompress);
   }
 
-  @Test(timeout = 10000)
-  public void testMultipleSpills_WithFinalMergeDisabled() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testMultipleSpills_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(200, 10, null, shouldCompress);
   }
 
-  @Test(timeout = 10000)
-  public void testNoRecords_WithFinalMergeDisabled() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testNoRecords_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(0, 10, null, shouldCompress);
   }
 
-  @Test(timeout = 10000)
-  public void testNoRecords_SinglePartition_WithFinalMergeDisabled() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testNoRecords_SinglePartition_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(0, 1, null, shouldCompress);
   }
 
-  @Test(timeout = 10000)
-  public void testSkippedPartitions_WithFinalMergeDisabled() throws IOException, InterruptedException {
+  @ParameterizedTest(name = "test[{0}, {1}]")
+  @MethodSource("data")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testSkippedPartitions_WithFinalMergeDisabled(boolean shouldCompress, ReportPartitionStats reportPartitionStats) throws IOException, InterruptedException {
+    setupInit(shouldCompress, reportPartitionStats);
     baseTestWithFinalMergeDisabled(200, 10, Sets.newHashSet(2, 5), shouldCompress);
   }
 
@@ -957,7 +1058,7 @@ public class TestUnorderedPartitionedKVWriter {
     List<Event> lastEvents = kvWriter.close();
 
     if (numPartitions == 1) {
-      assertEquals(true, kvWriter.skipBuffers);
+      assertTrue(kvWriter.skipBuffers);
     }
 
     // max events sent are spills + one VM event. If there are no spills, atleast empty
@@ -1013,9 +1114,8 @@ public class TestUnorderedPartitionedKVWriter {
     if (numRecordsWritten > 0) {
       assertTrue(fileOutputBytes > 0);
       if (!shouldCompress) {
-        assertTrue("fileOutputBytes=" + fileOutputBytes + ", outputRecordBytes="
-                +outputRecordBytesCounter.getValue(),
-            fileOutputBytes > outputRecordBytesCounter.getValue());
+        assertTrue(fileOutputBytes > outputRecordBytesCounter.getValue(), "fileOutputBytes=" + fileOutputBytes + ", outputRecordBytes="
+                +outputRecordBytesCounter.getValue());
       }
     } else {
       assertEquals(0, fileOutputBytes);
@@ -1029,7 +1129,7 @@ public class TestUnorderedPartitionedKVWriter {
     assertEquals(additionalSpillBytesWritten, 0);
 
     //No additional spills when final merge is disabled.
-    assertTrue(additionalSpillBytesWritten == additionalSpillBytesRead);
+    assertEquals(additionalSpillBytesWritten, additionalSpillBytesRead);
 
     //No additional spills when final merge is disabled.
     assertEquals(numAdditionalSpillsCounter.getValue(), 0);
@@ -1037,7 +1137,7 @@ public class TestUnorderedPartitionedKVWriter {
     assertTrue(lastEvents.size() > 0);
     //Get the last event
     int index = lastEvents.size() - 1;
-    assertTrue(lastEvents.get(index) instanceof CompositeDataMovementEvent);
+    assertInstanceOf(CompositeDataMovementEvent.class, lastEvents.get(index));
     CompositeDataMovementEvent cdme =
         (CompositeDataMovementEvent)lastEvents.get(index);
     assertEquals(0, cdme.getSourceIndexStart());
@@ -1062,14 +1162,14 @@ public class TestUnorderedPartitionedKVWriter {
       cdme = (CompositeDataMovementEvent)event;
       eventProto = DataMovementEventPayloadProto.parseFrom(ByteString.copyFrom(cdme.getUserPayload()));
 
-      assertEquals(false, eventProto.getPipelined());
+      assertFalse(eventProto.getPipelined());
       if (eventProto.hasPathComponent()) {
         //for final merge disabled cases, it should have _spillId
         Matcher matcher = mergePathComponentPattern.matcher(eventProto.getPathComponent());
-        assertTrue("spill id should be present in path component " + eventProto.getPathComponent(), matcher.matches());
+        assertTrue(matcher.matches(), "spill id should be present in path component " + eventProto.getPathComponent());
         assertEquals(2, matcher.groupCount());
         assertEquals(uniqueId, matcher.group(1));
-        assertTrue("spill id should be present in path component", matcher.group(2) != null);
+        assertNotNull(matcher.group(2), "spill id should be present in path component");
         Path outputPath = new Path(outputContext.getWorkDirs()[0],
             "output/" + eventProto.getPathComponent() + "/" + Constants.TEZ_RUNTIME_TASK_OUTPUT_FILENAME_STRING);
         Path indexPath = outputPath.suffix(Constants.TEZ_RUNTIME_TASK_OUTPUT_INDEX_SUFFIX_STRING);
@@ -1077,7 +1177,7 @@ public class TestUnorderedPartitionedKVWriter {
       } else {
         assertEquals(0, eventProto.getSpillId());
         if (outputRecordsCounter.getValue() > 0) {
-          assertEquals(true, eventProto.getLastEvent());
+          assertTrue(eventProto.getLastEvent());
         } else {
           byte[] emptyPartitions = TezCommonUtils.decompressByteStringToByteArray(eventProto
               .getEmptyPartitions());
@@ -1172,12 +1272,12 @@ public class TestUnorderedPartitionedKVWriter {
     List<Event> events = kvWriter.close();
 
     if (numPartitions == 1) {
-      assertEquals(true, kvWriter.skipBuffers);
+      assertTrue(kvWriter.skipBuffers);
 
       // VM & DME events
       assertEquals(2, events.size());
       Event event1 = events.get(1);
-      assertTrue(event1 instanceof CompositeDataMovementEvent);
+      assertInstanceOf(CompositeDataMovementEvent.class, event1);
       CompositeDataMovementEvent dme = (CompositeDataMovementEvent) event1;
       ByteBuffer bb = dme.getUserPayload();
       ShuffleUserPayloads.DataMovementEventPayloadProto shufflePayload =
@@ -1256,10 +1356,10 @@ public class TestUnorderedPartitionedKVWriter {
     BitSet emptyPartitionBits = null;
     // Verify the events returned
     assertEquals(2, events.size());
-    assertTrue(events.get(0) instanceof VertexManagerEvent);
+    assertInstanceOf(VertexManagerEvent.class, events.get(0));
     VertexManagerEvent vme = (VertexManagerEvent) events.get(0);
     verifyPartitionStats(vme, partitionsWithData);
-    assertTrue(events.get(1) instanceof CompositeDataMovementEvent);
+    assertInstanceOf(CompositeDataMovementEvent.class, events.get(1));
     CompositeDataMovementEvent cdme = (CompositeDataMovementEvent) events.get(1);
     assertEquals(0, cdme.getSourceIndexStart());
     assertEquals(numOutputs, cdme.getCount());
@@ -1304,22 +1404,17 @@ public class TestUnorderedPartitionedKVWriter {
 
     boolean isInMem= eventProto.getData().hasData();
     assertTrue(localFs.exists(outputFilePath));
-    assertEquals("Incorrect output permissions (user)", FsAction.READ_WRITE,
-            localFs.getFileStatus(outputFilePath).getPermission().getUserAction());
-    assertEquals("Incorrect output permissions (group)", FsAction.READ,
-            localFs.getFileStatus(outputFilePath).getPermission().getGroupAction());
+    assertEquals(FsAction.READ_WRITE, localFs.getFileStatus(outputFilePath).getPermission().getUserAction(), "Incorrect output permissions (user)");
+    assertEquals(FsAction.READ, localFs.getFileStatus(outputFilePath).getPermission().getGroupAction(), "Incorrect output permissions (group)");
     if( !isInMem ) {
       assertTrue(localFs.exists(spillFilePath));
-      assertEquals("Incorrect index permissions (user)", FsAction.READ_WRITE,
-              localFs.getFileStatus(spillFilePath).getPermission().getUserAction());
-      assertEquals("Incorrect index permissions (group)", FsAction.READ,
-              localFs.getFileStatus(spillFilePath).getPermission().getGroupAction());
+      assertEquals(FsAction.READ_WRITE, localFs.getFileStatus(spillFilePath).getPermission().getUserAction(), "Incorrect index permissions (user)");
+      assertEquals(FsAction.READ, localFs.getFileStatus(spillFilePath).getPermission().getGroupAction(), "Incorrect index permissions (group)");
 
       // verify no intermediate spill files have been left around
       synchronized (kvWriter.spillInfoList) {
         for (SpillInfo spill : kvWriter.spillInfoList) {
-          assertFalse("lingering intermediate spill file " + spill.outPath,
-                  localFs.exists(spill.outPath));
+          assertFalse(localFs.exists(spill.outPath), "lingering intermediate spill file " + spill.outPath);
         }
       }
     }
@@ -1330,26 +1425,26 @@ public class TestUnorderedPartitionedKVWriter {
     IntWritable keyDeser = new IntWritable();
     LongWritable valDeser = new LongWritable();
     for (int i = 0; i < numOutputs; i++) {
-      IFile.Reader reader = null;
+      Reader reader = null;
       InputStream inStream;
       if (isInMem) {
         // Read from in memory payload
         int dataLoadSize = eventProto.getData().getData().size();
         inStream = new ByteArrayInputStream(eventProto.getData().getData().toByteArray());
-        reader = new IFile.Reader(inStream, dataLoadSize, codec, null,
+        reader = new Reader(inStream, dataLoadSize, codec, null,
                 null, false, 0, -1);
       } else {
         TezSpillRecord spillRecord = new TezSpillRecord(spillFilePath, conf);
         TezIndexRecord indexRecord = spillRecord.getIndex(i);
         if (skippedPartitions != null && skippedPartitions.contains(i)) {
-          assertFalse("The Index Record for partition " + i + " should not have any data", indexRecord.hasData());
+          assertFalse(indexRecord.hasData(), "The Index Record for partition " + i + " should not have any data");
           continue;
         }
 
         FSDataInputStream tmpStream = FileSystem.getLocal(conf).open(outputFilePath);
         tmpStream.seek(indexRecord.getStartOffset());
         inStream = tmpStream;
-        reader = new IFile.Reader(tmpStream, indexRecord.getPartLength(), codec, null,
+        reader = new Reader(tmpStream, indexRecord.getPartLength(), codec, null,
                 null, false, 0, -1);
       }
 

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestOrderedGroupedMergedKVInputConfig.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestOrderedGroupedMergedKVInputConfig.java
@@ -18,24 +18,28 @@
  */
 package org.apache.tez.runtime.library.conf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 
 import com.google.common.collect.Maps;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestOrderedGroupedMergedKVInputConfig {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNullParams() {
     try {
       OrderedGroupedKVInputConfig.newBuilder(null, "VALUE");
@@ -52,7 +56,8 @@ public class TestOrderedGroupedMergedKVInputConfig {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSetters() {
     Configuration fromConf = new Configuration(false);
     fromConf.set("test.conf.key.1", "confkey1");
@@ -110,7 +115,7 @@ public class TestOrderedGroupedMergedKVInputConfig {
     assertEquals("VALUE", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
     assertEquals("CustomCodec",
         conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertEquals(true, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
         false));
     assertEquals(0.11f, conf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 0.0f), 0.001f);
     assertEquals(0.22f, conf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MERGE_PERCENT, 0.0f), 0.001f);
@@ -127,11 +132,11 @@ public class TestOrderedGroupedMergedKVInputConfig {
         .TEZ_RUNTIME_SHUFFLE_MAX_ALLOWED_FAILED_FETCH_ATTEMPT_FRACTION, 0.00f), 0.001f);
     assertEquals(0.6f, conf.getFloat(TezRuntimeConfiguration
         .TEZ_RUNTIME_SHUFFLE_MIN_REQUIRED_PROGRESS_FRACTION, 0.6f), 0.001f);
-    assertEquals(false, conf.getBoolean(TezRuntimeConfiguration
+    assertFalse(conf.getBoolean(TezRuntimeConfiguration
         .TEZ_RUNTIME_SHUFFLE_FAILED_CHECK_SINCE_LAST_COMPLETION, true));
 
     // Verify additional configs
-    assertEquals(false, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertFalse(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
     assertEquals(1111, conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES_DEFAULT));
@@ -146,7 +151,8 @@ public class TestOrderedGroupedMergedKVInputConfig {
     assertEquals("unfiltered1", conf.get("test.conf.unfiltered.1"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDefaultConfigsUsed() {
     OrderedGroupedKVInputConfig.Builder builder =
         OrderedGroupedKVInputConfig.newBuilder("KEY", "VALUE");
@@ -157,7 +163,7 @@ public class TestOrderedGroupedMergedKVInputConfig {
 
     Configuration conf = rebuilt.conf;
 
-    assertEquals(true, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
 
     // Default property present.
@@ -169,7 +175,8 @@ public class TestOrderedGroupedMergedKVInputConfig {
     assertEquals("VALUE", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCombinerConfigs() {
     Map<String, String> combinerConf = Maps.newHashMap();
     combinerConf.put("combiner.test.key", "COMBINERKEY");

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestOrderedPartitionedKVEdgeConfig.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestOrderedPartitionedKVEdgeConfig.java
@@ -237,16 +237,12 @@ public class TestOrderedPartitionedKVEdgeConfig {
     Configuration inputConf = rebuiltInput.conf;
 
     assertEquals("KEY", outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_CLASS, ""));
-    assertEquals("VALUE",
-        outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
+    assertEquals("VALUE", outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
     assertEquals("PARTITIONER", outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS, ""));
     assertEquals(1111, outputConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 0));
-    assertEquals("CustomCodec",
-        outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertTrue(outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
-        false));
-    assertEquals("KEY_COMPARATOR",
-        outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_COMPARATOR_CLASS));
+    assertEquals("CustomCodec", outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
+    assertTrue(outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS, false));
+    assertEquals("KEY_COMPARATOR", outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_COMPARATOR_CLASS));
     assertEquals("comparatorValue", outputConf.get("comparator.test.key"));
     assertNull(outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT));
     assertNull(outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MERGE_PERCENT));
@@ -257,21 +253,17 @@ public class TestOrderedPartitionedKVEdgeConfig {
     assertEquals("KEY_COMPARATOR", inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_COMPARATOR_CLASS));
     assertEquals("comparatorValue", inputConf.get("comparator.test.key"));
     assertEquals("KEY", inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_CLASS, ""));
-    assertEquals("VALUE",
-        inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
-    assertEquals("CustomCodec",
-        inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertTrue(inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
-        false));
+    assertEquals("VALUE", inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
+    assertEquals("CustomCodec", inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
+    assertTrue(inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS, false));
 
-    assertEquals(0.11f,
-        inputConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 0.0f), 0.001f);
-    assertEquals(0.22f, inputConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MERGE_PERCENT, 0.0f),
+    assertEquals(0.11f, inputConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 0.0f),
         0.001f);
+    assertEquals(0.22f, inputConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MERGE_PERCENT, 0.0f), 0.001f);
     assertEquals(0.33f, inputConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_INPUT_POST_MERGE_BUFFER_PERCENT, 0.0f),
         0.001f);
-    assertEquals(0.44f,
-        inputConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 0.00f), 0.001f);
+    assertEquals(0.44f, inputConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 0.00f),
+        0.001f);
     assertNull(inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB));
 
   }
@@ -297,39 +289,29 @@ public class TestOrderedPartitionedKVEdgeConfig {
     Configuration inputConf = rebuiltInput.conf;
 
     assertEquals("KEY", outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_CLASS, ""));
-    assertEquals("VALUE",
-        outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
+    assertEquals("VALUE", outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
     assertEquals("PARTITIONER", outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS, ""));
-    assertEquals("CustomCodec",
-        outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertTrue(outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
-        false));
+    assertEquals("CustomCodec", outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
+    assertTrue(outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS, false));
     assertNull(outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT));
     //verify comparator and serialization class
-    assertEquals("SomeComparator1",
-        outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_COMPARATOR_CLASS));
-    assertTrue(outputConf.get(CommonConfigurationKeys.IO_SERIALIZATIONS_KEY).trim().startsWith
-        ("serClass2,serClass1"));
+    assertEquals("SomeComparator1", outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_COMPARATOR_CLASS));
+    assertTrue(outputConf.get(CommonConfigurationKeys.IO_SERIALIZATIONS_KEY).trim().startsWith("serClass2,serClass1"));
 
 
     //verify comparator and serialization class
     assertEquals("SomeComparator1", inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_COMPARATOR_CLASS));
-    assertTrue(inputConf.get(CommonConfigurationKeys.IO_SERIALIZATIONS_KEY).trim().startsWith
-        ("serClass2,serClass1"));
+    assertTrue(inputConf.get(CommonConfigurationKeys.IO_SERIALIZATIONS_KEY).trim().startsWith("serClass2,serClass1"));
 
     assertEquals("KEY", inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_CLASS, ""));
-    assertEquals("VALUE",
-        inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
-    assertEquals("CustomCodec",
-        inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertTrue(inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
-        false));
+    assertEquals("VALUE", inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
+    assertEquals("CustomCodec", inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
+    assertTrue(inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS, false));
   }
 
   private void checkHistoryText(String historyText) {
     assertNotNull(historyText);
-    assertTrue(historyText.contains(
-        TezRuntimeConfiguration.TEZ_RUNTIME_CONVERT_USER_PAYLOAD_TO_HISTORY_TEXT));
+    assertTrue(historyText.contains(TezRuntimeConfiguration.TEZ_RUNTIME_CONVERT_USER_PAYLOAD_TO_HISTORY_TEXT));
   }
 
   @Test
@@ -355,6 +337,4 @@ public class TestOrderedPartitionedKVEdgeConfig {
     checkHistoryText(edgeProperty.getEdgeDestination().getHistoryText());
     checkHistoryText(edgeProperty.getEdgeSource().getHistoryText());
   }
-
-
 }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestOrderedPartitionedKVEdgeConfig.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestOrderedPartitionedKVEdgeConfig.java
@@ -18,15 +18,16 @@
  */
 package org.apache.tez.runtime.library.conf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
@@ -37,11 +38,13 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration.ReportPartitio
 
 import com.google.common.collect.Maps;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestOrderedPartitionedKVEdgeConfig {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNullParams() {
     try {
       OrderedPartitionedKVEdgeConfig.newBuilder(null, "VALUE", "PARTITIONER");
@@ -65,7 +68,8 @@ public class TestOrderedPartitionedKVEdgeConfig {
     }
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testDefaultConfigsUsed() {
     OrderedPartitionedKVEdgeConfig.Builder builder = OrderedPartitionedKVEdgeConfig
         .newBuilder("KEY", "VALUE", "PARTITIONER");
@@ -79,19 +83,20 @@ public class TestOrderedPartitionedKVEdgeConfig {
     rebuiltInput.fromUserPayload(configuration.getInputPayload());
 
     Configuration outputConf = rebuiltOutput.conf;
-    assertEquals(true, outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertTrue(outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
     assertEquals("TestCodec",
         outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
 
     Configuration inputConf = rebuiltInput.conf;
-    assertEquals(true, inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertTrue(inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
     assertEquals("TestCodec",
         inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testSpecificIOConfs() {
     // Ensures that Output and Input confs are not mixed.
     OrderedPartitionedKVEdgeConfig.Builder builder = OrderedPartitionedKVEdgeConfig
@@ -114,7 +119,8 @@ public class TestOrderedPartitionedKVEdgeConfig {
         inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, "DEFAULT"));
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void tetCommonConf() {
 
     Configuration fromConf = new Configuration(false);
@@ -184,7 +190,7 @@ public class TestOrderedPartitionedKVEdgeConfig {
         ReportPartitionStats.fromString(outputConf.get(
         TezRuntimeConfiguration.TEZ_RUNTIME_REPORT_PARTITION_STATS,
         TezRuntimeConfiguration.TEZ_RUNTIME_REPORT_PARTITION_STATS_DEFAULT));
-    assertEquals(true, partitionStats.isEnabled());
+    assertTrue(partitionStats.isEnabled());
 
 
     assertEquals(3, inputConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_FACTOR, 0));
@@ -206,7 +212,8 @@ public class TestOrderedPartitionedKVEdgeConfig {
     assertEquals("unfiltered1", inputConf.get("test.conf.unfiltered.1"));
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testSetters() {
     Map<String, String> comparatorConf = Maps.newHashMap();
     comparatorConf.put("comparator.test.key", "comparatorValue");
@@ -236,9 +243,8 @@ public class TestOrderedPartitionedKVEdgeConfig {
     assertEquals(1111, outputConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 0));
     assertEquals("CustomCodec",
         outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertEquals(true,
-        outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
-            false));
+    assertTrue(outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
+        false));
     assertEquals("KEY_COMPARATOR",
         outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_COMPARATOR_CLASS));
     assertEquals("comparatorValue", outputConf.get("comparator.test.key"));
@@ -255,9 +261,8 @@ public class TestOrderedPartitionedKVEdgeConfig {
         inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
     assertEquals("CustomCodec",
         inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertEquals(true,
-        inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
-            false));
+    assertTrue(inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
+        false));
 
     assertEquals(0.11f,
         inputConf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 0.0f), 0.001f);
@@ -271,7 +276,8 @@ public class TestOrderedPartitionedKVEdgeConfig {
 
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testSerialization() {
     OrderedPartitionedKVEdgeConfig.Builder builder = OrderedPartitionedKVEdgeConfig
         .newBuilder("KEY", "VALUE", "PARTITIONER")
@@ -296,9 +302,8 @@ public class TestOrderedPartitionedKVEdgeConfig {
     assertEquals("PARTITIONER", outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS, ""));
     assertEquals("CustomCodec",
         outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertEquals(true,
-        outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
-            false));
+    assertTrue(outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
+        false));
     assertNull(outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT));
     //verify comparator and serialization class
     assertEquals("SomeComparator1",
@@ -317,9 +322,8 @@ public class TestOrderedPartitionedKVEdgeConfig {
         inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
     assertEquals("CustomCodec",
         inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertEquals(true,
-        inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
-            false));
+    assertTrue(inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
+        false));
   }
 
   private void checkHistoryText(String historyText) {
@@ -328,7 +332,8 @@ public class TestOrderedPartitionedKVEdgeConfig {
         TezRuntimeConfiguration.TEZ_RUNTIME_CONVERT_USER_PAYLOAD_TO_HISTORY_TEXT));
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testHistoryText() {
     OrderedPartitionedKVEdgeConfig.Builder builder =
         OrderedPartitionedKVEdgeConfig.newBuilder("KEY", "VALUE", "PARTITIONER");

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestOrderedPartitionedKVOutputConfig.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestOrderedPartitionedKVOutputConfig.java
@@ -18,24 +18,28 @@
  */
 package org.apache.tez.runtime.library.conf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 
 import com.google.common.collect.Maps;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestOrderedPartitionedKVOutputConfig {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNullParams() {
     try {
       OrderedPartitionedKVOutputConfig.newBuilder(
@@ -62,7 +66,8 @@ public class TestOrderedPartitionedKVOutputConfig {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSetters() {
     Configuration fromConf = new Configuration(false);
     fromConf.set("test.conf.key.1", "confkey1");
@@ -101,12 +106,12 @@ public class TestOrderedPartitionedKVOutputConfig {
     assertEquals("PARTITIONER", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS, ""));
     assertEquals("CustomCodec",
         conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertEquals(true, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
         false));
     assertEquals("KEY_COMPARATOR", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_COMPARATOR_CLASS));
 
     // Verify additional configs
-    assertEquals(false, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertFalse(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
     assertEquals(1111, conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES_DEFAULT));
@@ -122,7 +127,8 @@ public class TestOrderedPartitionedKVOutputConfig {
     assertEquals("unfiltered1", conf.get("test.conf.unfiltered.1"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDefaultConfigsUsed() {
     OrderedPartitionedKVOutputConfig.Builder builder =
         OrderedPartitionedKVOutputConfig.newBuilder("KEY", "VALUE", "PARTITIONER", null);
@@ -133,7 +139,7 @@ public class TestOrderedPartitionedKVOutputConfig {
 
     Configuration conf = rebuilt.conf;
 
-    assertEquals(true, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
 
     // Property present
@@ -146,7 +152,8 @@ public class TestOrderedPartitionedKVOutputConfig {
     assertEquals("PARTITIONER", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS, ""));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPartitionerConfigs() {
     Map<String, String> partitionerConf = Maps.newHashMap();
     partitionerConf.put("partitioner.test.key", "PARTITIONERKEY");
@@ -170,7 +177,8 @@ public class TestOrderedPartitionedKVOutputConfig {
     assertEquals("PARTITIONERKEY", conf.get("partitioner.test.key"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testCombinerConfigs() {
     Map<String, String> combinerConf = Maps.newHashMap();
     combinerConf.put("combiner.test.key", "COMBINERKEY");

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestUnorderedKVEdgeConfig.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestUnorderedKVEdgeConfig.java
@@ -18,15 +18,17 @@
  */
 package org.apache.tez.runtime.library.conf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
@@ -34,11 +36,13 @@ import org.apache.tez.dag.api.EdgeManagerPluginDescriptor;
 import org.apache.tez.dag.api.EdgeProperty;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestUnorderedKVEdgeConfig {
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testNullParams() {
     try {
       UnorderedKVEdgeConfig.newBuilder(null, "VALUE");
@@ -55,7 +59,8 @@ public class TestUnorderedKVEdgeConfig {
     }
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testDefaultConfigsUsed() {
     UnorderedKVEdgeConfig.Builder builder =
         UnorderedKVEdgeConfig.newBuilder("KEY", "VALUE");
@@ -72,7 +77,7 @@ public class TestUnorderedKVEdgeConfig {
     rebuiltInput.fromUserPayload(configuration.getInputPayload());
 
     Configuration outputConf = rebuiltOutput.conf;
-    assertEquals(true, outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertTrue(outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
     assertEquals("TestCodec",
         outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
@@ -80,7 +85,7 @@ public class TestUnorderedKVEdgeConfig {
         ("SerClass2,SerClass1"));
 
     Configuration inputConf = rebuiltInput.conf;
-    assertEquals(true, inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertTrue(inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
     assertEquals("TestCodec",
         inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
@@ -88,7 +93,8 @@ public class TestUnorderedKVEdgeConfig {
         ("SerClass2,SerClass1"));
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testSpecificIOConfs() {
     // Ensures that Output and Input confs are not mixed.
     UnorderedKVEdgeConfig.Builder builder =
@@ -112,7 +118,8 @@ public class TestUnorderedKVEdgeConfig {
         inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, "DEFAULT"));
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void tetCommonConf() {
 
     Configuration fromConf = new Configuration(false);
@@ -151,7 +158,7 @@ public class TestUnorderedKVEdgeConfig {
     Configuration outputConf = rebuiltOutput.conf;
     Configuration inputConf = rebuiltInput.conf;
 
-    assertEquals(false, outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD, true));
+    assertFalse(outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD, true));
     assertEquals(1111, outputConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES, 0));
     assertEquals(3333, outputConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_FILE_BUFFER_SIZE, 0));
     assertNull(outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT));
@@ -163,7 +170,7 @@ public class TestUnorderedKVEdgeConfig {
 
     assertEquals("unfiltered1", outputConf.get("test.conf.unfiltered.1"));
 
-    assertEquals(false, inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD, true));
+    assertFalse(inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD, true));
     assertEquals(1111, inputConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES, 0));
     assertEquals(3333, inputConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_FILE_BUFFER_SIZE, 0));
     assertEquals(0.11f,
@@ -185,7 +192,8 @@ public class TestUnorderedKVEdgeConfig {
         TezRuntimeConfiguration.TEZ_RUNTIME_CONVERT_USER_PAYLOAD_TO_HISTORY_TEXT));
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testHistoryText() {
     UnorderedKVEdgeConfig.Builder builder = UnorderedKVEdgeConfig.newBuilder("KEY", "VALUE");
     Configuration fromConf = new Configuration(false);

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestUnorderedKVInputConfig.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestUnorderedKVInputConfig.java
@@ -18,23 +18,27 @@
  */
 package org.apache.tez.runtime.library.conf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.dag.api.UserPayload;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestUnorderedKVInputConfig {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNullParams() {
     try {
       UnorderedKVInputConfig.newBuilder(null, "VALUE");
@@ -51,7 +55,8 @@ public class TestUnorderedKVInputConfig {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSetters() {
     Configuration fromConf = new Configuration(false);
     fromConf.set("test.conf.key.1", "confkey1");
@@ -90,14 +95,14 @@ public class TestUnorderedKVInputConfig {
     assertEquals("VALUE", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
     assertEquals("CustomCodec",
         conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertEquals(true, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
         false));
     assertEquals(0.11f, conf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MEMORY_LIMIT_PERCENT, 0.0f), 0.001f);
     assertEquals(0.22f, conf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_MERGE_PERCENT, 0.0f), 0.001f);
     assertEquals(0.33f, conf.getFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 0.00f), 0.001f);
 
     // Verify additional configs
-    assertEquals(false, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertFalse(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
     assertEquals(1111, conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES_DEFAULT));
@@ -113,7 +118,8 @@ public class TestUnorderedKVInputConfig {
     assertEquals("unfiltered1", conf.get("test.conf.unfiltered.1"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDefaultConfigsUsed() {
     UnorderedKVInputConfig.Builder builder =
         UnorderedKVInputConfig.newBuilder("KEY", "VALUE");
@@ -124,7 +130,7 @@ public class TestUnorderedKVInputConfig {
 
     Configuration conf = rebuilt.conf;
 
-    assertEquals(true, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
 
     // Default property present.

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestUnorderedKVOutputConfig.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestUnorderedKVOutputConfig.java
@@ -18,22 +18,26 @@
  */
 package org.apache.tez.runtime.library.conf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestUnorderedKVOutputConfig {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNullParams() {
     try {
       UnorderedKVOutputConfig.newBuilder(
@@ -52,7 +56,8 @@ public class TestUnorderedKVOutputConfig {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSetters() {
     Configuration fromConf = new Configuration(false);
     fromConf.set("test.conf.key.1", "confkey1");
@@ -88,11 +93,11 @@ public class TestUnorderedKVOutputConfig {
     assertEquals("VALUE", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
     assertEquals("CustomCodec",
         conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertEquals(true, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
         false));
 
     // Verify additional configs
-    assertEquals(false, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertFalse(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
     assertEquals(1111, conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES_DEFAULT));
@@ -106,7 +111,8 @@ public class TestUnorderedKVOutputConfig {
     assertEquals("unfiltered1", conf.get("test.conf.unfiltered.1"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDefaultConfigsUsed() {
     UnorderedKVOutputConfig.Builder builder =
         UnorderedKVOutputConfig
@@ -119,7 +125,7 @@ public class TestUnorderedKVOutputConfig {
 
     Configuration conf = rebuilt.conf;
 
-    assertEquals(true, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
 
     // Default property present.

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestUnorderedPartitionedKVEdgeConfig.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestUnorderedPartitionedKVEdgeConfig.java
@@ -18,15 +18,17 @@
  */
 package org.apache.tez.runtime.library.conf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
@@ -34,11 +36,13 @@ import org.apache.tez.dag.api.EdgeManagerPluginDescriptor;
 import org.apache.tez.dag.api.EdgeProperty;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestUnorderedPartitionedKVEdgeConfig {
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testNullParams() {
     try {
       UnorderedPartitionedKVEdgeConfig.newBuilder(null, "VALUE", "PARTITIONER");
@@ -62,7 +66,8 @@ public class TestUnorderedPartitionedKVEdgeConfig {
     }
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testDefaultConfigsUsed() {
     UnorderedPartitionedKVEdgeConfig.Builder builder =
         UnorderedPartitionedKVEdgeConfig.newBuilder("KEY", "VALUE", "PARTITIONER");
@@ -79,7 +84,7 @@ public class TestUnorderedPartitionedKVEdgeConfig {
     rebuiltInput.fromUserPayload(configuration.getInputPayload());
 
     Configuration outputConf = rebuiltOutput.conf;
-    assertEquals(true, outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertTrue(outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
     assertEquals("TestCodec",
         outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
@@ -87,7 +92,7 @@ public class TestUnorderedPartitionedKVEdgeConfig {
         ("SerClass2,SerClass1"));
 
     Configuration inputConf = rebuiltInput.conf;
-    assertEquals(true, inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertTrue(inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
     assertEquals("TestCodec",
         inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
@@ -95,7 +100,8 @@ public class TestUnorderedPartitionedKVEdgeConfig {
         ("SerClass2,SerClass1"));
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testSpecificIOConfs() {
     // Ensures that Output and Input confs are not mixed.
     UnorderedPartitionedKVEdgeConfig.Builder builder =
@@ -119,7 +125,8 @@ public class TestUnorderedPartitionedKVEdgeConfig {
         inputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, "DEFAULT"));
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void tetCommonConf() {
 
     Configuration fromConf = new Configuration(false);
@@ -160,7 +167,7 @@ public class TestUnorderedPartitionedKVEdgeConfig {
     Configuration outputConf = rebuiltOutput.conf;
     Configuration inputConf = rebuiltInput.conf;
 
-    assertEquals(false, outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD, true));
+    assertFalse(outputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD, true));
     assertEquals(1111, outputConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES, 0));
     assertEquals(3333, outputConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_FILE_BUFFER_SIZE, 0));
     assertNull(outputConf.get(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT));
@@ -176,7 +183,7 @@ public class TestUnorderedPartitionedKVEdgeConfig {
 
     assertEquals("unfiltered1", outputConf.get("test.conf.unfiltered.1"));
 
-    assertEquals(false, inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD, true));
+    assertFalse(inputConf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD, true));
     assertEquals(1111, inputConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES, 0));
     assertEquals(3333, inputConf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_FILE_BUFFER_SIZE, 0));
     assertEquals(0.11f,
@@ -200,7 +207,8 @@ public class TestUnorderedPartitionedKVEdgeConfig {
         TezRuntimeConfiguration.TEZ_RUNTIME_CONVERT_USER_PAYLOAD_TO_HISTORY_TEXT));
   }
 
-  @Test (timeout=2000)
+  @Test
+  @Timeout(value = 2000, unit = TimeUnit.MILLISECONDS)
   public void testHistoryText() {
     UnorderedPartitionedKVEdgeConfig.Builder builder =
         UnorderedPartitionedKVEdgeConfig.newBuilder("KEY", "VALUE", "PARTITIONER");

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestUnorderedPartitionedKVOutputConfig.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestUnorderedPartitionedKVOutputConfig.java
@@ -113,33 +113,25 @@ public class TestUnorderedPartitionedKVOutputConfig {
     Configuration conf = rebuilt.conf;
 
     // Verify programmatic API usage
-    assertTrue(conf.getBoolean(TezRuntimeConfiguration
-        .TEZ_RUNTIME_PIPELINED_SHUFFLE_ENABLED, false));
-    assertFalse(conf.getBoolean(TezRuntimeConfiguration
-        .TEZ_RUNTIME_ENABLE_FINAL_MERGE_IN_OUTPUT, true));
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SHUFFLE_ENABLED, false));
+    assertFalse(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_ENABLE_FINAL_MERGE_IN_OUTPUT, true));
     assertEquals(1111, conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_OUTPUT_BUFFER_SIZE_MB, 0));
     assertEquals("KEY", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_CLASS, ""));
     assertEquals("VALUE", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
     assertEquals("PARTITIONER", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS, ""));
-    assertEquals("CustomCodec",
-        conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
-        false));
+    assertEquals("CustomCodec", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS, false));
 
     // Verify additional configs
     assertFalse(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
     assertEquals(1111, conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES_DEFAULT));
-    assertEquals(2222,
-        conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_OUTPUT_MAX_PER_BUFFER_SIZE_BYTES, 0));
-    assertTrue(
-        conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_EMPTY_PARTITION_INFO_VIA_EVENTS_ENABLED,
-            false));
-    assertEquals(5120,
-            conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_TRANSFER_DATA_VIA_EVENTS_MAX_SIZE, 512));
-    assertFalse(conf.getBoolean(
-        TezRuntimeConfiguration.TEZ_RUNTIME_TRANSFER_DATA_VIA_EVENTS_SUPPORT_IN_MEM_FILE, true));
+    assertEquals(2222, conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_OUTPUT_MAX_PER_BUFFER_SIZE_BYTES, 0));
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_EMPTY_PARTITION_INFO_VIA_EVENTS_ENABLED, false));
+    assertEquals(5120, conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_TRANSFER_DATA_VIA_EVENTS_MAX_SIZE, 512));
+    assertFalse(
+        conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_TRANSFER_DATA_VIA_EVENTS_SUPPORT_IN_MEM_FILE, true));
     assertEquals("io", conf.get("io.shouldExist"));
     assertEquals("file", conf.get("file.shouldExist"));
     assertEquals("fs", conf.get("fs.shouldExist"));
@@ -170,15 +162,13 @@ public class TestUnorderedPartitionedKVOutputConfig {
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
 
     // Default property present.
-    assertEquals("TestCodec",
-        conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
+    assertEquals("TestCodec", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
 
     // Verify whatever was configured
     assertEquals("KEY", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_CLASS, ""));
     assertEquals("VALUE", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_VALUE_CLASS, ""));
     assertEquals("PARTITIONER", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS, ""));
-    assertTrue(conf.get(CommonConfigurationKeys.IO_SERIALIZATIONS_KEY).startsWith("SerClass2," +
-        "SerClass1"));
+    assertTrue(conf.get(CommonConfigurationKeys.IO_SERIALIZATIONS_KEY).startsWith("SerClass2," + "SerClass1"));
     //for unordered paritioned kv output, comparator is not populated
     assertNull(conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_COMPARATOR_CLASS));
   }
@@ -203,8 +193,7 @@ public class TestUnorderedPartitionedKVOutputConfig {
     Configuration conf = rebuilt.conf;
 
     // Default Output property should not be overridden based on partitioner config
-    assertEquals("TestCodec",
-        conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
+    assertEquals("TestCodec", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
 
     assertEquals("PARTITIONERKEY", conf.get("partitioner.test.key"));
   }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestUnorderedPartitionedKVOutputConfig.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/conf/TestUnorderedPartitionedKVOutputConfig.java
@@ -18,13 +18,15 @@
  */
 package org.apache.tez.runtime.library.conf;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
@@ -32,11 +34,13 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 
 import com.google.common.collect.Maps;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestUnorderedPartitionedKVOutputConfig {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNullParams() {
     try {
       UnorderedPartitionedKVOutputConfig.newBuilder(
@@ -63,7 +67,8 @@ public class TestUnorderedPartitionedKVOutputConfig {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSetters() {
     Configuration fromConf = new Configuration(false);
     fromConf.set("test.conf.key.1", "confkey1");
@@ -108,9 +113,9 @@ public class TestUnorderedPartitionedKVOutputConfig {
     Configuration conf = rebuilt.conf;
 
     // Verify programmatic API usage
-    assertEquals(true, conf.getBoolean(TezRuntimeConfiguration
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration
         .TEZ_RUNTIME_PIPELINED_SHUFFLE_ENABLED, false));
-    assertEquals(false, conf.getBoolean(TezRuntimeConfiguration
+    assertFalse(conf.getBoolean(TezRuntimeConfiguration
         .TEZ_RUNTIME_ENABLE_FINAL_MERGE_IN_OUTPUT, true));
     assertEquals(1111, conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_OUTPUT_BUFFER_SIZE_MB, 0));
     assertEquals("KEY", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_CLASS, ""));
@@ -118,22 +123,23 @@ public class TestUnorderedPartitionedKVOutputConfig {
     assertEquals("PARTITIONER", conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_PARTITIONER_CLASS, ""));
     assertEquals("CustomCodec",
         conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS_CODEC, ""));
-    assertEquals(true, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_COMPRESS,
         false));
 
     // Verify additional configs
-    assertEquals(false, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertFalse(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
     assertEquals(1111, conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_BYTES_DEFAULT));
     assertEquals(2222,
         conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_OUTPUT_MAX_PER_BUFFER_SIZE_BYTES, 0));
-    assertEquals(true,
-            conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_EMPTY_PARTITION_INFO_VIA_EVENTS_ENABLED, false));
+    assertTrue(
+        conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_EMPTY_PARTITION_INFO_VIA_EVENTS_ENABLED,
+            false));
     assertEquals(5120,
             conf.getInt(TezRuntimeConfiguration.TEZ_RUNTIME_TRANSFER_DATA_VIA_EVENTS_MAX_SIZE, 512));
-    assertEquals(false,
-        conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_TRANSFER_DATA_VIA_EVENTS_SUPPORT_IN_MEM_FILE, true));
+    assertFalse(conf.getBoolean(
+        TezRuntimeConfiguration.TEZ_RUNTIME_TRANSFER_DATA_VIA_EVENTS_SUPPORT_IN_MEM_FILE, true));
     assertEquals("io", conf.get("io.shouldExist"));
     assertEquals("file", conf.get("file.shouldExist"));
     assertEquals("fs", conf.get("fs.shouldExist"));
@@ -144,7 +150,8 @@ public class TestUnorderedPartitionedKVOutputConfig {
     assertEquals("unfiltered1", conf.get("test.conf.unfiltered.1"));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testDefaultConfigsUsed() {
     UnorderedPartitionedKVOutputConfig.Builder builder =
         UnorderedPartitionedKVOutputConfig
@@ -159,7 +166,7 @@ public class TestUnorderedPartitionedKVOutputConfig {
 
     Configuration conf = rebuilt.conf;
 
-    assertEquals(true, conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
+    assertTrue(conf.getBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD,
         TezRuntimeConfiguration.TEZ_RUNTIME_IFILE_READAHEAD_DEFAULT));
 
     // Default property present.
@@ -176,7 +183,8 @@ public class TestUnorderedPartitionedKVOutputConfig {
     assertNull(conf.get(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_COMPARATOR_CLASS));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPartitionerConfigs() {
     Map<String, String> partitionerConf = Maps.newHashMap();
     partitionerConf.put("partitioner.test.key", "PARTITIONERKEY");

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/input/TestOrderedGroupedKVInput.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/input/TestOrderedGroupedKVInput.java
@@ -18,7 +18,9 @@
  */
 package org.apache.tez.runtime.library.input;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -26,6 +28,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.tez.common.TezUtils;
@@ -38,14 +41,15 @@ import org.apache.tez.runtime.library.api.IOInterruptedException;
 import org.apache.tez.runtime.library.common.MemoryUpdateCallbackHandler;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.Shuffle;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 public class TestOrderedGroupedKVInput {
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testInterruptWhileAwaitingInput() throws IOException, TezException {
 
     InputContext inputContext = createMockInputContext();
@@ -56,9 +60,9 @@ public class TestOrderedGroupedKVInput {
 
     try {
       kvInput.getReader();
-      Assert.fail("getReader should not return since underlying inputs are not ready");
+      fail("getReader should not return since underlying inputs are not ready");
     } catch (IOException e) {
-      Assert.assertTrue(e instanceof IOInterruptedException);
+      assertInstanceOf(IOInterruptedException.class, e);
     }
 
   }
@@ -116,7 +120,7 @@ public class TestOrderedGroupedKVInput {
               (MemoryUpdateCallbackHandler) args[1];
           memUpdateCallbackHandler.memoryAssigned(200 * 1024 * 1024);
         } else {
-          Assert.fail();
+          fail();
         }
         return null;
       }
@@ -137,9 +141,9 @@ public class TestOrderedGroupedKVInput {
       try {
         doThrow(new InterruptedException()).when(shuffle).waitForInput();
       } catch (InterruptedException e) {
-        Assert.fail();
+        fail();
       } catch (TezException e) {
-        Assert.fail();
+        fail();
       }
       return shuffle;
     }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/input/TestSortedGroupedMergedInput.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/input/TestSortedGroupedMergedInput.java
@@ -18,9 +18,10 @@
  */
 package org.apache.tez.runtime.library.input;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -29,6 +30,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.io.RawComparator;
 import org.apache.tez.runtime.api.Event;
@@ -38,7 +40,8 @@ import org.apache.tez.runtime.api.Reader;
 import org.apache.tez.runtime.library.api.KeyValueReader;
 import org.apache.tez.runtime.library.api.KeyValuesReader;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class TestSortedGroupedMergedInput {
 
@@ -46,7 +49,8 @@ public class TestSortedGroupedMergedInput {
     return mock(MergedInputContext.class);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSimple() throws Exception {
     SortedTestKeyValuesReader kvsReader1 = new SortedTestKeyValuesReader(new int[] { 1, 2, 3 },
         new int[][] { { 1, 1 }, { 2, 2 }, { 3, 3 } });
@@ -98,7 +102,8 @@ public class TestSortedGroupedMergedInput {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSkippedKey() throws Exception {
 
 
@@ -144,7 +149,8 @@ public class TestSortedGroupedMergedInput {
     getNextFromFinishedReader(kvsReader);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testPartialValuesSkip() throws Exception {
 
     SortedTestKeyValuesReader kvsReader1 = new SortedTestKeyValuesReader(new int[] { 1, 2, 3 },
@@ -191,7 +197,8 @@ public class TestSortedGroupedMergedInput {
     getNextFromFinishedReader(kvsReader);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testOrdering() throws Exception {
 
     SortedTestKeyValuesReader kvsReader1 = new SortedTestKeyValuesReader(new int[] { 2, 4 },
@@ -243,7 +250,8 @@ public class TestSortedGroupedMergedInput {
     getNextFromFinishedReader(kvsReader);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSkippedKey2() throws Exception {
 
     SortedTestKeyValuesReader kvsReader1 = new SortedTestKeyValuesReader(new int[] { 2, 4 },
@@ -299,7 +307,8 @@ public class TestSortedGroupedMergedInput {
   }
 
   // Reads all values for a key, but doesn't trigger the last hasNext() call.
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSkippedKey3() throws Exception {
 
     SortedTestKeyValuesReader kvsReader1 = new SortedTestKeyValuesReader(new int[] { 1, 2, 3, 4 },
@@ -346,7 +355,8 @@ public class TestSortedGroupedMergedInput {
     getNextFromFinishedReader(kvsReader);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testEmptySources() throws Exception {
 
     SortedTestKeyValuesReader kvsReader1 = new SortedTestKeyValuesReader(new int[] {},
@@ -370,11 +380,12 @@ public class TestSortedGroupedMergedInput {
     OrderedGroupedMergedKVInput input = new OrderedGroupedMergedKVInput(createMergedInputContext(), sInputs);
 
     KeyValuesReader kvsReader = input.getReader();
-    assertTrue(kvsReader.next() == false);
+    assertFalse(kvsReader.next());
     getNextFromFinishedReader(kvsReader);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleConcatenatedMergedKeyValueInput() throws Exception {
 
     DummyInput sInput1 = new DummyInput(10);
@@ -395,13 +406,14 @@ public class TestSortedGroupedMergedInput {
       Integer key = (Integer) kvReader.getCurrentKey();
       Integer value = (Integer) kvReader.getCurrentValue();
     }
-    assertTrue(keyCount == 30);
+    assertEquals(30, keyCount);
     verify(mockContext, times(4)).notifyProgress(); // one for each reader change and one to exit
 
     getNextFromFinishedReader(kvReader);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleConcatenatedMergedKeyValuesInput() throws Exception {
     SortedTestKeyValuesReader kvsReader1 = new SortedTestKeyValuesReader(new int[] { 1, 2, 3 },
         new int[][] { { 1, 1 }, { 2, 2 }, { 3, 3 } });

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOnFileSortedOutput.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOnFileSortedOutput.java
@@ -67,8 +67,9 @@ import com.google.protobuf.ByteString;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.*;
-import org.junit.jupiter.params.provider.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -98,9 +99,8 @@ public class TestOnFileSortedOutput {
   private int emptyPartitionIdx;
   private ReportPartitionStats reportPartitionStats;
 
-  public void setupInit(boolean sendEmptyPartitionViaEvent,
-      SorterImpl sorterImpl, int sorterThreads, int emptyPartitionIdx,
-      ReportPartitionStats reportPartitionStats) throws Exception {
+  public void setupInit(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads,
+                        int emptyPartitionIdx, ReportPartitionStats reportPartitionStats) throws Exception {
     this.sendEmptyPartitionViaEvent = sendEmptyPartitionViaEvent;
     this.emptyPartitionIdx = emptyPartitionIdx;
     this.sorterImpl = sorterImpl;
@@ -152,8 +152,7 @@ public class TestOnFileSortedOutput {
         Arguments.of(false, SorterImpl.PIPELINED, 2, 0, ReportPartitionStats.ENABLED),
         Arguments.of(true, SorterImpl.PIPELINED, 2, -1, ReportPartitionStats.ENABLED),
         Arguments.of(true, SorterImpl.PIPELINED, 2, 0, ReportPartitionStats.ENABLED),
-        Arguments.of(true, SorterImpl.PIPELINED, 2, 0, ReportPartitionStats.PRECISE)
-    );
+        Arguments.of(true, SorterImpl.PIPELINED, 2, 0, ReportPartitionStats.PRECISE));
   }
 
   private void startSortedOutput(int partitions) throws Exception {
@@ -188,7 +187,8 @@ public class TestOnFileSortedOutput {
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
   @MethodSource("getParameters")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testPipelinedShuffle(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+  public void testPipelinedShuffle(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads,
+                                   int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
     setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     _testPipelinedShuffle(SorterImpl.PIPELINED.name());
   }
@@ -196,7 +196,9 @@ public class TestOnFileSortedOutput {
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
   @MethodSource("getParameters")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testPipelinedShuffleWithFinalMerge(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+  public void testPipelinedShuffleWithFinalMerge(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl,
+                                                 int sorterThreads, int emptyPartitionId,
+                                                 ReportPartitionStats reportPartitionStats) throws Exception {
     setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 3);
     conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_SORTER_CLASS, SorterImpl.PIPELINED.name());
@@ -217,7 +219,9 @@ public class TestOnFileSortedOutput {
 
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
   @MethodSource("getParameters")
-  public void testPipelinedSettingsWithDefaultSorter(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+  public void testPipelinedSettingsWithDefaultSorter(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl,
+                                                     int sorterThreads, int emptyPartitionId,
+                                                     ReportPartitionStats reportPartitionStats) throws Exception {
     setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 3);
     //negative. with default sorter
@@ -244,7 +248,8 @@ public class TestOnFileSortedOutput {
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
   @MethodSource("getParameters")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testSortBufferSize(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception{
+  public void testSortBufferSize(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads,
+                                 int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
     setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     OutputContext context = createTezOutputContext();
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 2048);
@@ -274,7 +279,8 @@ public class TestOnFileSortedOutput {
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
   @MethodSource("getParameters")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void baseTest(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+  public void baseTest(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads,
+                       int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
     setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     startSortedOutput(partitions);
 
@@ -316,7 +322,9 @@ public class TestOnFileSortedOutput {
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
   @MethodSource("getParameters")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testWithSomeEmptyPartition(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+  public void testWithSomeEmptyPartition(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads,
+                                         int emptyPartitionId, ReportPartitionStats reportPartitionStats)
+      throws Exception {
     setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     //ensure atleast 2 partitions are available
     partitions = Math.max(2, partitions);
@@ -347,7 +355,8 @@ public class TestOnFileSortedOutput {
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
   @MethodSource("getParameters")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testAllEmptyPartition(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+  public void testAllEmptyPartition(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads,
+                                    int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
     setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     startSortedOutput(partitions);
 
@@ -425,7 +434,8 @@ public class TestOnFileSortedOutput {
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
   @MethodSource("getParameters")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testInvalidSorter(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+  public void testInvalidSorter(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads,
+                                int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
     setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     try {
       _testPipelinedShuffle("Foo");
@@ -438,7 +448,9 @@ public class TestOnFileSortedOutput {
   @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
   @MethodSource("getParameters")
   @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
-  public void testLowerCaseNamedSorter(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+  public void testLowerCaseNamedSorter(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads,
+                                       int emptyPartitionId, ReportPartitionStats reportPartitionStats)
+      throws Exception {
     setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     _testPipelinedShuffle("Pipelined");
   }

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOnFileSortedOutput.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOnFileSortedOutput.java
@@ -18,10 +18,10 @@
  */
 package org.apache.tez.runtime.library.output;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.doAnswer;
@@ -31,12 +31,12 @@ import static org.mockito.Mockito.mock;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -65,17 +65,14 @@ import org.apache.tez.runtime.library.shuffle.impl.ShuffleUserPayloads;
 
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
-@RunWith(Parameterized.class)
 public class TestOnFileSortedOutput {
   private static final Random rnd = new Random();
   private static final String UniqueID = "UUID";
@@ -101,17 +98,9 @@ public class TestOnFileSortedOutput {
   private int emptyPartitionIdx;
   private ReportPartitionStats reportPartitionStats;
 
-  /**
-   * Constructor
-   *
-   * @param sendEmptyPartitionViaEvent
-   * @param sorterImpl Which sorter impl ( pipeline/legacy )
-   * @param sorterThreads number of threads needed for sorter (required only for pipelined sorter)
-   * @param emptyPartitionIdx for which data should not be generated
-   */
-  public TestOnFileSortedOutput(boolean sendEmptyPartitionViaEvent,
+  public void setupInit(boolean sendEmptyPartitionViaEvent,
       SorterImpl sorterImpl, int sorterThreads, int emptyPartitionIdx,
-      ReportPartitionStats reportPartitionStats) throws IOException {
+      ReportPartitionStats reportPartitionStats) throws Exception {
     this.sendEmptyPartitionViaEvent = sendEmptyPartitionViaEvent;
     this.emptyPartitionIdx = emptyPartitionIdx;
     this.sorterImpl = sorterImpl;
@@ -123,10 +112,7 @@ public class TestOnFileSortedOutput {
     String localDirs = workingDir.toString();
     conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS, localDirs);
     fs = FileSystem.getLocal(conf);
-  }
 
-  @Before
-  public void setup() throws Exception {
     conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_SORTER_CLASS, sorterImpl.name());
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_PIPELINED_SORTER_SORT_THREADS, sorterThreads);
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 5);
@@ -146,40 +132,28 @@ public class TestOnFileSortedOutput {
     this.partitions = Math.max(1, rnd.nextInt(10));
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws IOException {
     fs.delete(workingDir, true);
   }
 
   @SuppressWarnings("deprecation")
-  @Parameterized.Parameters(name = "test[{0}, {1}, {2}, {3}, {4}]")
-  public static Collection<Object[]> getParameters() {
-    Collection<Object[]> parameters = new ArrayList<Object[]>();
-    //empty_partition_via_events_enabled, noOfSortThreads,
-    // partitionToBeEmpty, reportPartitionStats
-    parameters.add(new Object[] { false, SorterImpl.LEGACY, 1, -1,
-        ReportPartitionStats.ENABLED });
-    parameters.add(new Object[] { false, SorterImpl.LEGACY, 1, 0,
-        ReportPartitionStats.ENABLED  });
-    parameters.add(new Object[] { true, SorterImpl.LEGACY, 1, -1,
-        ReportPartitionStats.ENABLED  });
-    parameters.add(new Object[] { true, SorterImpl.LEGACY, 1, 0,
-        ReportPartitionStats.ENABLED  });
-    parameters.add(new Object[] { true, SorterImpl.LEGACY, 1, 0,
-        ReportPartitionStats.PRECISE  });
+  public static Stream<Arguments> getParameters() {
+    return Stream.of(
+        //empty_partition_via_events_enabled, noOfSortThreads, partitionToBeEmpty, reportPartitionStats
+        Arguments.of(false, SorterImpl.LEGACY, 1, -1, ReportPartitionStats.ENABLED),
+        Arguments.of(false, SorterImpl.LEGACY, 1, 0, ReportPartitionStats.ENABLED),
+        Arguments.of(true, SorterImpl.LEGACY, 1, -1, ReportPartitionStats.ENABLED),
+        Arguments.of(true, SorterImpl.LEGACY, 1, 0, ReportPartitionStats.ENABLED),
+        Arguments.of(true, SorterImpl.LEGACY, 1, 0, ReportPartitionStats.PRECISE),
 
-    //Pipelined sorter
-    parameters.add(new Object[] { false, SorterImpl.PIPELINED, 2, -1,
-        ReportPartitionStats.ENABLED  });
-    parameters.add(new Object[] { false, SorterImpl.PIPELINED, 2, 0,
-        ReportPartitionStats.ENABLED  });
-    parameters.add(new Object[] { true, SorterImpl.PIPELINED, 2, -1,
-        ReportPartitionStats.ENABLED  });
-    parameters.add(new Object[] { true, SorterImpl.PIPELINED, 2, 0,
-        ReportPartitionStats.ENABLED  });
-    parameters.add(new Object[] { true, SorterImpl.PIPELINED, 2, 0,
-        ReportPartitionStats.PRECISE  });
-    return parameters;
+        //Pipelined sorter
+        Arguments.of(false, SorterImpl.PIPELINED, 2, -1, ReportPartitionStats.ENABLED),
+        Arguments.of(false, SorterImpl.PIPELINED, 2, 0, ReportPartitionStats.ENABLED),
+        Arguments.of(true, SorterImpl.PIPELINED, 2, -1, ReportPartitionStats.ENABLED),
+        Arguments.of(true, SorterImpl.PIPELINED, 2, 0, ReportPartitionStats.ENABLED),
+        Arguments.of(true, SorterImpl.PIPELINED, 2, 0, ReportPartitionStats.PRECISE)
+    );
   }
 
   private void startSortedOutput(int partitions) throws Exception {
@@ -211,13 +185,19 @@ public class TestOnFileSortedOutput {
     assertTrue(sortedOutput.pipelinedShuffle);
   }
 
-  @Test (timeout = 5000)
-  public void testPipelinedShuffle() throws Exception {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testPipelinedShuffle(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+    setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     _testPipelinedShuffle(SorterImpl.PIPELINED.name());
   }
 
-  @Test (timeout = 5000)
-  public void testPipelinedShuffleWithFinalMerge() throws Exception {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testPipelinedShuffleWithFinalMerge(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+    setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 3);
     conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_SORTER_CLASS, SorterImpl.PIPELINED.name());
 
@@ -235,8 +215,10 @@ public class TestOnFileSortedOutput {
     assertTrue(sortedOutput.pipelinedShuffle);
   }
 
-  @Test
-  public void testPipelinedSettingsWithDefaultSorter() throws Exception {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
+  @MethodSource("getParameters")
+  public void testPipelinedSettingsWithDefaultSorter(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+    setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 3);
     //negative. with default sorter
     conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_SORTER_CLASS, SorterImpl.LEGACY.name());
@@ -259,8 +241,11 @@ public class TestOnFileSortedOutput {
 
   }
 
-  @Test (timeout = 5000)
-  public void testSortBufferSize() throws Exception{
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testSortBufferSize(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception{
+    setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     OutputContext context = createTezOutputContext();
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 2048);
     UserPayload payLoad = TezUtils.createUserPayloadFromConf(conf);
@@ -286,8 +271,11 @@ public class TestOnFileSortedOutput {
     }
   }
 
-  @Test(timeout = 5000)
-  public void baseTest() throws Exception {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void baseTest(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+    setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     startSortedOutput(partitions);
 
     //Write random set of keys
@@ -325,8 +313,11 @@ public class TestOnFileSortedOutput {
     assertEquals(UniqueID, payload.getPathComponent());
   }
 
-  @Test(timeout = 5000)
-  public void testWithSomeEmptyPartition() throws Exception {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testWithSomeEmptyPartition(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+    setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     //ensure atleast 2 partitions are available
     partitions = Math.max(2, partitions);
     startSortedOutput(partitions);
@@ -353,8 +344,11 @@ public class TestOnFileSortedOutput {
     assertEquals(UniqueID, payload.getPathComponent());
   }
 
-  @Test(timeout = 5000)
-  public void testAllEmptyPartition() throws Exception {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testAllEmptyPartition(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+    setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     startSortedOutput(partitions);
 
     //Close output without writing any data to it.
@@ -428,18 +422,24 @@ public class TestOnFileSortedOutput {
     return context;
   }
 
-  @Test(timeout=5000)
-  public void testInvalidSorter() throws Exception {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testInvalidSorter(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+    setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     try {
       _testPipelinedShuffle("Foo");
-      Assert.fail("Expected start to fail due to invalid sorter");
+      fail("Expected start to fail due to invalid sorter");
     } catch (IllegalArgumentException e) {
       // Expected
     }
   }
 
-  @Test(timeout=5000)
-  public void testLowerCaseNamedSorter() throws Exception {
+  @ParameterizedTest(name = "test[{0}, {1}, {2}, {3}, {4}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testLowerCaseNamedSorter(boolean sendEmptyPartitionViaEvent, SorterImpl sorterImpl, int sorterThreads, int emptyPartitionId, ReportPartitionStats reportPartitionStats) throws Exception {
+    setupInit(sendEmptyPartitionViaEvent, sorterImpl, sorterThreads, emptyPartitionId, reportPartitionStats);
     _testPipelinedShuffle("Pipelined");
   }
 

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOnFileUnorderedKVOutput.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOnFileUnorderedKVOutput.java
@@ -18,9 +18,9 @@
  */
 package org.apache.tez.runtime.library.output;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.atLeast;
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -75,10 +76,10 @@ import org.apache.tez.runtime.library.testutils.KVDataGen.KVPair;
 
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -110,17 +111,18 @@ public class TestOnFileUnorderedKVOutput {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     localFs.mkdirs(workDir);
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     localFs.delete(workDir, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testGeneratedDataMovementEvent() throws Exception {
     Configuration conf = new Configuration();
     conf.set(TezRuntimeConfiguration.TEZ_RUNTIME_KEY_CLASS, Text.class.getName());
@@ -148,7 +150,7 @@ public class TestOnFileUnorderedKVOutput {
     assertTrue(events != null && events.size() == 2);
     CompositeDataMovementEvent dmEvent = (CompositeDataMovementEvent)events.get(1);
 
-    assertEquals("Invalid source index", 0, dmEvent.getSourceIndexStart());
+    assertEquals(0, dmEvent.getSourceIndexStart(), "Invalid source index");
 
     DataMovementEventPayloadProto shufflePayload = DataMovementEventPayloadProto
         .parseFrom(ByteString.copyFrom(dmEvent.getUserPayload()));
@@ -180,7 +182,8 @@ public class TestOnFileUnorderedKVOutput {
     assertEquals("base-value", mergedConf.get("base-key"));
   }
 
-  @Test(timeout = 30000)
+  @Test
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
   @SuppressWarnings("unchecked")
   public void testWithPipelinedShuffle() throws Exception {
     Configuration conf = new Configuration();
@@ -217,7 +220,7 @@ public class TestOnFileUnorderedKVOutput {
 
 
     CompositeDataMovementEvent dmEvent = (CompositeDataMovementEvent)events.get(1);
-    assertEquals("Invalid source index", 0, dmEvent.getSourceIndexStart());
+    assertEquals(0, dmEvent.getSourceIndexStart(), "Invalid source index");
 
     DataMovementEventPayloadProto shufflePayload = DataMovementEventPayloadProto
         .parseFrom(ByteString.copyFrom(dmEvent.getUserPayload()));
@@ -271,7 +274,7 @@ public class TestOnFileUnorderedKVOutput {
     verify(runtimeTask, times(1)).addAndGetTezCounter(destinationVertexName);
     verify(runtimeTask, times(1)).getTaskStatistics();
     // verify output stats object got created
-    Assert.assertTrue(task.getTaskStatistics().getIOStatistics().containsKey(destinationVertexName));
+    assertTrue(task.getTaskStatistics().getIOStatistics().containsKey(destinationVertexName));
     OutputContext outputContext = spy(realOutputContext);
     doAnswer(new Answer() {
       @Override public Object answer(InvocationOnMock invocation) throws Throwable {

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOrderedPartitionedKVOutput2.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestOrderedPartitionedKVOutput2.java
@@ -18,13 +18,15 @@
  */
 package org.apache.tez.runtime.library.output;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -43,9 +45,10 @@ import org.apache.tez.runtime.library.shuffle.impl.ShuffleUserPayloads;
 
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 // Tests which don't require parameterization
 public class TestOrderedPartitionedKVOutput2 {
@@ -53,7 +56,7 @@ public class TestOrderedPartitionedKVOutput2 {
   private FileSystem localFs;
   private Path workingDir;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = new Configuration();
     localFs = FileSystem.getLocal(conf);
@@ -68,12 +71,13 @@ public class TestOrderedPartitionedKVOutput2 {
     conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS, workingDir.toString());
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws IOException {
     localFs.delete(workingDir, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNonStartedOutput() throws IOException {
     OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, conf, workingDir);
     int numPartitions = 10;
@@ -82,9 +86,9 @@ public class TestOrderedPartitionedKVOutput2 {
     List<Event> events = output.close();
     assertEquals(2, events.size());
     Event event1 = events.get(0);
-    assertTrue(event1 instanceof VertexManagerEvent);
+    assertInstanceOf(VertexManagerEvent.class, event1);
     Event event2 = events.get(1);
-    assertTrue(event2 instanceof CompositeDataMovementEvent);
+    assertInstanceOf(CompositeDataMovementEvent.class, event2);
     CompositeDataMovementEvent cdme = (CompositeDataMovementEvent) event2;
     ByteBuffer bb = cdme.getUserPayload();
     ShuffleUserPayloads.DataMovementEventPayloadProto shufflePayload =
@@ -100,7 +104,8 @@ public class TestOrderedPartitionedKVOutput2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConfigMerge() throws IOException {
     Configuration localConf = new Configuration(conf);
     localConf.set("config-from-local", "config-from-local-value");
@@ -115,7 +120,8 @@ public class TestOrderedPartitionedKVOutput2 {
     assertEquals("config-from-payload-value", configAfterMerge.get("config-from-payload"));
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testClose() throws Exception {
     OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, conf, workingDir);
     int numPartitions = 10;

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestUnorderedKVOutput2.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestUnorderedKVOutput2.java
@@ -18,15 +18,17 @@
  */
 package org.apache.tez.runtime.library.output;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -44,9 +46,10 @@ import org.apache.tez.runtime.library.shuffle.impl.ShuffleUserPayloads;
 
 import com.google.protobuf.ByteString;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 // Tests which don't require parameterization
 public class TestUnorderedKVOutput2 {
@@ -54,7 +57,7 @@ public class TestUnorderedKVOutput2 {
   private FileSystem localFs;
   private Path workingDir;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = new Configuration();
     localFs = FileSystem.getLocal(conf);
@@ -69,12 +72,13 @@ public class TestUnorderedKVOutput2 {
     conf.setStrings(TezRuntimeFrameworkConfigs.LOCAL_DIRS, workingDir.toString());
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws IOException {
     localFs.delete(workingDir, true);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNonStartedOutput() throws Exception {
     OutputContext outputContext = OutputTestHelpers.createOutputContext();
     int numPartitions = 1;
@@ -83,7 +87,7 @@ public class TestUnorderedKVOutput2 {
     List<Event> events = output.close();
     assertEquals(1, events.size());
     Event event1 = events.get(0);
-    assertTrue(event1 instanceof DataMovementEvent);
+    assertInstanceOf(DataMovementEvent.class, event1);
     DataMovementEvent dme = (DataMovementEvent) event1;
     ByteBuffer bb = dme.getUserPayload();
     ShuffleUserPayloads.DataMovementEventPayloadProto shufflePayload =
@@ -99,7 +103,8 @@ public class TestUnorderedKVOutput2 {
     }
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testConfigMerge() throws Exception {
     Configuration localConf = new Configuration(conf);
     localConf.set("config-from-local", "config-from-local-value");
@@ -114,7 +119,8 @@ public class TestUnorderedKVOutput2 {
     assertEquals("config-from-payload-value", configAfterMerge.get("config-from-payload"));
   }
 
-  @Test(timeout = 10000)
+  @Test
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
   public void testClose() throws Exception {
     OutputContext outputContext = OutputTestHelpers.createOutputContext(conf, conf, workingDir);
     int numPartitions = 1;

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestUnorderedPartitionedKVOutput2.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/output/TestUnorderedPartitionedKVOutput2.java
@@ -18,12 +18,14 @@
  */
 package org.apache.tez.runtime.library.output;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -36,13 +38,15 @@ import org.apache.tez.runtime.library.shuffle.impl.ShuffleUserPayloads;
 
 import com.google.protobuf.ByteString;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 // Tests which don't require parameterization
 public class TestUnorderedPartitionedKVOutput2 {
 
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
   public void testNonStartedOutput() throws Exception {
     OutputContext outputContext = OutputTestHelpers.createOutputContext();
     int numPartitions = 1;
@@ -52,7 +56,7 @@ public class TestUnorderedPartitionedKVOutput2 {
     List<Event> events = output.close();
     assertEquals(1, events.size());
     Event event1 = events.get(0);
-    assertTrue(event1 instanceof CompositeDataMovementEvent);
+    assertInstanceOf(CompositeDataMovementEvent.class, event1);
     CompositeDataMovementEvent dme = (CompositeDataMovementEvent) event1;
     ByteBuffer bb = dme.getUserPayload();
     ShuffleUserPayloads.DataMovementEventPayloadProto shufflePayload =

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/testutils/KVDataGen.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/testutils/KVDataGen.java
@@ -25,7 +25,6 @@ import java.util.Random;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.Text;
 
-
 public final class KVDataGen {
 
   static Random rnd = new Random();

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/testutils/KVDataGen.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/testutils/KVDataGen.java
@@ -25,6 +25,7 @@ import java.util.Random;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.Text;
 
+
 public final class KVDataGen {
 
   static Random rnd = new Random();

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/testutils/RandomTextGenerator.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/testutils/RandomTextGenerator.java
@@ -22,7 +22,6 @@ import java.util.Random;
 
 import org.apache.hadoop.io.Text;
 
-
 public final class RandomTextGenerator {
 
   static int minWordsInKey = 10;

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/testutils/RandomTextGenerator.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/testutils/RandomTextGenerator.java
@@ -22,6 +22,7 @@ import java.util.Random;
 
 import org.apache.hadoop.io.Text;
 
+
 public final class RandomTextGenerator {
 
   static int minWordsInKey = 10;

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/testutils/RuntimeTestUtils.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/testutils/RuntimeTestUtils.java
@@ -27,6 +27,7 @@ import java.io.InputStream;
 
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.ShuffleHeader;
 
+
 public final class RuntimeTestUtils {
 
   private RuntimeTestUtils() {

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/testutils/RuntimeTestUtils.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/testutils/RuntimeTestUtils.java
@@ -27,7 +27,6 @@ import java.io.InputStream;
 
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.ShuffleHeader;
 
-
 public final class RuntimeTestUtils {
 
   private RuntimeTestUtils() {

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/utils/TestCodecUtils.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/utils/TestCodecUtils.java
@@ -54,7 +54,6 @@ import org.apache.tez.runtime.library.common.sort.impl.IFileInputStream;
 
 import org.junit.jupiter.api.Test;
 
-
 public class TestCodecUtils {
 
   @Test
@@ -150,7 +149,8 @@ public class TestCodecUtils {
             CompressionOutputStream stream =
                 CodecUtils.createOutputStream(codec, mock(OutputStream.class), compressor);
 
-            assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT, getBufferSize(stream), "stream buffer size is incorrect");
+            assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT, getBufferSize(stream),
+                "stream buffer size is incorrect");
 
             CodecPool.returnCompressor(compressor);
           } catch (Exception e) {
@@ -167,7 +167,8 @@ public class TestCodecUtils {
             CompressionInputStream stream =
                 CodecUtils.createInputStream(codec, mock(InputStream.class), decompressor);
 
-            assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT, getBufferSize(stream), "stream buffer size is incorrect");
+            assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT, getBufferSize(stream),
+                "stream buffer size is incorrect");
 
             CodecPool.returnDecompressor(decompressor);
           } catch (Exception e) {
@@ -187,8 +188,7 @@ public class TestCodecUtils {
   public void testDefaultBufferSize() {
     Configuration conf = new Configuration(); // config with no buffersize set
 
-    assertEquals(CodecUtils.DEFAULT_BUFFER_SIZE,
-        CodecUtils.getDefaultBufferSize(conf, new DummyCompressionCodec()));
+    assertEquals(CodecUtils.DEFAULT_BUFFER_SIZE, CodecUtils.getDefaultBufferSize(conf, new DummyCompressionCodec()));
     assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT,
         CodecUtils.getDefaultBufferSize(conf, new DefaultCodec()));
     assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT,

--- a/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/utils/TestCodecUtils.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/runtime/library/utils/TestCodecUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.tez.runtime.library.utils;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -51,8 +52,8 @@ import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.DummyCompressionCodec;
 import org.apache.tez.runtime.library.common.sort.impl.IFileInputStream;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 public class TestCodecUtils {
 
@@ -85,8 +86,7 @@ public class TestCodecUtils {
               (DecompressorStream) CodecUtils.getDecompressedInputStreamWithBufferSize(codec,
                   mock(IFileInputStream.class), decompressor, modifiedBufferSize);
 
-          Assert.assertEquals("stream buffer size is incorrect", modifiedBufferSize,
-              getBufferSize(stream));
+          assertEquals(modifiedBufferSize, getBufferSize(stream), "stream buffer size is incorrect");
 
           CodecPool.returnDecompressor(decompressor);
         } catch (IOException e) {
@@ -133,8 +133,7 @@ public class TestCodecUtils {
                 (CompressionInputStream) CodecUtils.getDecompressedInputStreamWithBufferSize(codec,
                     mock(IFileInputStream.class), decompressor, modifiedBufferSize);
 
-            Assert.assertEquals("stream buffer size is incorrect", modifiedBufferSize,
-                getBufferSize(stream));
+            assertEquals(modifiedBufferSize, getBufferSize(stream), "stream buffer size is incorrect");
 
             CodecPool.returnDecompressor(decompressor);
           } catch (IOException e) {
@@ -151,8 +150,7 @@ public class TestCodecUtils {
             CompressionOutputStream stream =
                 CodecUtils.createOutputStream(codec, mock(OutputStream.class), compressor);
 
-            Assert.assertEquals("stream buffer size is incorrect",
-                CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT, getBufferSize(stream));
+            assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT, getBufferSize(stream), "stream buffer size is incorrect");
 
             CodecPool.returnCompressor(compressor);
           } catch (Exception e) {
@@ -169,8 +167,7 @@ public class TestCodecUtils {
             CompressionInputStream stream =
                 CodecUtils.createInputStream(codec, mock(InputStream.class), decompressor);
 
-            Assert.assertEquals("stream buffer size is incorrect",
-                CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT, getBufferSize(stream));
+            assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT, getBufferSize(stream), "stream buffer size is incorrect");
 
             CodecPool.returnDecompressor(decompressor);
           } catch (Exception e) {
@@ -190,19 +187,19 @@ public class TestCodecUtils {
   public void testDefaultBufferSize() {
     Configuration conf = new Configuration(); // config with no buffersize set
 
-    Assert.assertEquals(CodecUtils.DEFAULT_BUFFER_SIZE,
+    assertEquals(CodecUtils.DEFAULT_BUFFER_SIZE,
         CodecUtils.getDefaultBufferSize(conf, new DummyCompressionCodec()));
-    Assert.assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT,
+    assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT,
         CodecUtils.getDefaultBufferSize(conf, new DefaultCodec()));
-    Assert.assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT,
+    assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT,
         CodecUtils.getDefaultBufferSize(conf, new BZip2Codec()));
-    Assert.assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT,
+    assertEquals(CommonConfigurationKeysPublic.IO_FILE_BUFFER_SIZE_DEFAULT,
         CodecUtils.getDefaultBufferSize(conf, new GzipCodec()));
-    Assert.assertEquals(CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_DEFAULT,
+    assertEquals(CommonConfigurationKeys.IO_COMPRESSION_CODEC_SNAPPY_BUFFERSIZE_DEFAULT,
         CodecUtils.getDefaultBufferSize(conf, new SnappyCodec()));
-    Assert.assertEquals(CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_DEFAULT,
+    assertEquals(CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_DEFAULT,
         CodecUtils.getDefaultBufferSize(conf, new ZStandardCodec()));
-    Assert.assertEquals(CommonConfigurationKeys.IO_COMPRESSION_CODEC_LZ4_BUFFERSIZE_DEFAULT,
+    assertEquals(CommonConfigurationKeys.IO_COMPRESSION_CODEC_LZ4_BUFFERSIZE_DEFAULT,
         CodecUtils.getDefaultBufferSize(conf, new Lz4Codec()));
   }
 

--- a/tez-tests/pom.xml
+++ b/tez-tests/pom.xml
@@ -120,11 +120,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk18on</artifactId>
       <scope>test</scope>
@@ -136,8 +131,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
   </dependencies>
 

--- a/tez-tests/src/test/java/org/apache/tez/mapreduce/TestMRRJobs.java
+++ b/tez-tests/src/test/java/org/apache/tez/mapreduce/TestMRRJobs.java
@@ -18,8 +18,13 @@
  */
 package org.apache.tez.mapreduce;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.RandomTextWriterJob;
 import org.apache.hadoop.conf.Configuration;
@@ -32,6 +37,7 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.JobStatus.State;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
@@ -40,10 +46,10 @@ import org.apache.tez.mapreduce.examples.MRRSleepJob;
 import org.apache.tez.mapreduce.hadoop.MRJobConfig;
 import org.apache.tez.test.MiniTezCluster;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,7 +69,7 @@ public class TestMRRJobs {
   private static final String OUTPUT_ROOT_DIR = "/tmp" + Path.SEPARATOR +
       TestMRRJobs.class.getSimpleName();
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     try {
       conf.setInt(YarnConfiguration.RM_AM_MAX_ATTEMPTS, 1);
@@ -95,7 +101,7 @@ public class TestMRRJobs {
 
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (mrrTezCluster != null) {
       mrrTezCluster.stop();
@@ -107,7 +113,8 @@ public class TestMRRJobs {
     }
   }
 
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMRRSleepJob() throws IOException, InterruptedException,
       ClassNotFoundException {
     LOG.info("\n\n\nStarting testMRRSleepJob().");
@@ -132,22 +139,22 @@ public class TestMRRJobs {
     String trackingUrl = job.getTrackingURL();
     String jobId = job.getJobID().toString();
     boolean succeeded = job.waitForCompletion(true);
-    Assert.assertTrue(succeeded);
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
+    assertTrue(succeeded);
+    assertEquals(State.SUCCEEDED, job.getJobState());
     // There's one bug in YARN that there may be some suffix at the end of trackingURL (YARN-2246)
     // After TEZ-1961, the tracking will change from http://localhost:53419/proxy/application_1430963524753_0005
     // to http://localhost:53419/proxy/application_1430963524753_0005/ui/
     // So here use String#contains to verify.
-    Assert.assertTrue("Tracking URL was " + trackingUrl +
-                      " but didn't Match Job ID " + jobId ,
-          trackingUrl.contains(jobId.substring(jobId.indexOf("_"))));
+    assertTrue(trackingUrl.contains(jobId.substring(jobId.indexOf("_"))), "Tracking URL was " + trackingUrl +
+                      " but didn't Match Job ID " + jobId);
 
     // FIXME once counters and task progress can be obtained properly
     // TODO use dag client to test counters and task progress?
     // what about completed jobs?
   }
 
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testRandomWriter() throws IOException, InterruptedException,
       ClassNotFoundException {
 
@@ -171,11 +178,10 @@ public class TestMRRJobs {
     String trackingUrl = job.getTrackingURL();
     String jobId = job.getJobID().toString();
     boolean succeeded = job.waitForCompletion(true);
-    Assert.assertTrue(succeeded);
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
-    Assert.assertTrue("Tracking URL was " + trackingUrl +
-                      " but didn't Match Job ID " + jobId ,
-          trackingUrl.contains(jobId.substring(jobId.indexOf("_"))));
+    assertTrue(succeeded);
+    assertEquals(State.SUCCEEDED, job.getJobState());
+    assertTrue(trackingUrl.contains(jobId.substring(jobId.indexOf("_"))), "Tracking URL was " + trackingUrl +
+                      " but didn't Match Job ID " + jobId);
 
     // Make sure there are three files in the output-dir
 
@@ -190,12 +196,13 @@ public class TestMRRJobs {
         count++;
       }
     }
-    Assert.assertEquals("Number of part files is wrong!", 3, count);
+    assertEquals(3, count, "Number of part files is wrong!");
 
   }
 
 
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testFailingJob() throws IOException, InterruptedException,
       ClassNotFoundException {
 
@@ -222,14 +229,15 @@ public class TestMRRJobs {
 
     job.submit();
     boolean succeeded = job.waitForCompletion(true);
-    Assert.assertFalse(succeeded);
-    Assert.assertEquals(JobStatus.State.FAILED, job.getJobState());
+    assertFalse(succeeded);
+    assertEquals(JobStatus.State.FAILED, job.getJobState());
 
     // FIXME once counters and task progress can be obtained properly
     // TODO verify failed task diagnostics
   }
 
-  @Test (timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testFailingAttempt() throws IOException, InterruptedException,
       ClassNotFoundException {
 
@@ -256,21 +264,21 @@ public class TestMRRJobs {
 
     job.submit();
     boolean succeeded = job.waitForCompletion(true);
-    Assert.assertTrue(succeeded);
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
+    assertTrue(succeeded);
+    assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
 
     // FIXME once counters and task progress can be obtained properly
     // TODO verify failed task diagnostics
   }
 
-  @Test (timeout = 60000)
-  public void testMRRSleepJobWithCompression() throws IOException,
-      InterruptedException, ClassNotFoundException {
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
+  public void testMRRSleepJobWithCompression()
+      throws IOException, InterruptedException, ClassNotFoundException {
     LOG.info("\n\n\nStarting testMRRSleepJobWithCompression().");
 
     if (!(new File(MiniTezCluster.APPJAR)).exists()) {
-      LOG.info("MRAppJar " + MiniTezCluster.APPJAR
-               + " not found. Not running test.");
+      LOG.info("MRAppJar " + MiniTezCluster.APPJAR + " not found. Not running test.");
       return;
     }
 
@@ -279,26 +287,24 @@ public class TestMRRJobs {
     MRRSleepJob sleepJob = new MRRSleepJob();
     sleepJob.setConf(sleepConf);
 
-    Job job = sleepJob.createJob(1, 1, 2, 1, 1,
-        1, 1, 1, 1, 1);
+    Job job = sleepJob.createJob(1, 1, 2, 1, 1, 1, 1, 1, 1, 1);
 
     job.setJarByClass(MRRSleepJob.class);
     job.setMaxMapAttempts(1); // speed up failures
 
     // enable compression
     job.getConfiguration().setBoolean(MRJobConfig.MAP_OUTPUT_COMPRESS, true);
-    job.getConfiguration().set(MRJobConfig.MAP_OUTPUT_COMPRESS_CODEC,
-        DefaultCodec.class.getName());
+    job.getConfiguration().set(MRJobConfig.MAP_OUTPUT_COMPRESS_CODEC, DefaultCodec.class.getName());
 
     job.submit();
     String trackingUrl = job.getTrackingURL();
     String jobId = job.getJobID().toString();
     boolean succeeded = job.waitForCompletion(true);
-    Assert.assertTrue(succeeded);
-    Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
-    Assert.assertTrue("Tracking URL was " + trackingUrl +
-                      " but didn't Match Job ID " + jobId ,
-          trackingUrl.contains(jobId.substring(jobId.indexOf("_"))));
+    assertTrue(succeeded);
+    assertEquals(State.SUCCEEDED, job.getJobState());
+    assertTrue(
+        trackingUrl.contains(jobId.substring(jobId.indexOf("_"))),
+        "Tracking URL was " + trackingUrl + " but didn't Match Job ID " + jobId);
 
     // FIXME once counters and task progress can be obtained properly
     // TODO use dag client to test counters and task progress?
@@ -306,9 +312,9 @@ public class TestMRRJobs {
 
   }
 
-
   /*
-  //@Test (timeout = 60000)
+  //@Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMRRSleepJobWithSecurityOn() throws IOException,
       InterruptedException, ClassNotFoundException {
 
@@ -351,8 +357,8 @@ public class TestMRRJobs {
         String trackingUrl = job.getTrackingURL();
         String jobId = job.getJobID().toString();
         job.waitForCompletion(true);
-        Assert.assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
-        Assert.assertTrue("Tracking URL was " + trackingUrl +
+        assertEquals(JobStatus.State.SUCCEEDED, job.getJobState());
+        assertTrue("Tracking URL was " + trackingUrl +
                           " but didn't Match Job ID " + jobId ,
           trackingUrl.endsWith(jobId.substring(jobId.lastIndexOf("_")) + "/"));
         return null;

--- a/tez-tests/src/test/java/org/apache/tez/mapreduce/TestMRRJobs.java
+++ b/tez-tests/src/test/java/org/apache/tez/mapreduce/TestMRRJobs.java
@@ -145,8 +145,8 @@ public class TestMRRJobs {
     // After TEZ-1961, the tracking will change from http://localhost:53419/proxy/application_1430963524753_0005
     // to http://localhost:53419/proxy/application_1430963524753_0005/ui/
     // So here use String#contains to verify.
-    assertTrue(trackingUrl.contains(jobId.substring(jobId.indexOf("_"))), "Tracking URL was " + trackingUrl +
-                      " but didn't Match Job ID " + jobId);
+    assertTrue(trackingUrl.contains(jobId.substring(jobId.indexOf("_"))),
+        "Tracking URL was " + trackingUrl + " but didn't Match Job ID " + jobId);
 
     // FIXME once counters and task progress can be obtained properly
     // TODO use dag client to test counters and task progress?
@@ -180,8 +180,8 @@ public class TestMRRJobs {
     boolean succeeded = job.waitForCompletion(true);
     assertTrue(succeeded);
     assertEquals(State.SUCCEEDED, job.getJobState());
-    assertTrue(trackingUrl.contains(jobId.substring(jobId.indexOf("_"))), "Tracking URL was " + trackingUrl +
-                      " but didn't Match Job ID " + jobId);
+    assertTrue(trackingUrl.contains(jobId.substring(jobId.indexOf("_"))),
+        "Tracking URL was " + trackingUrl + " but didn't Match Job ID " + jobId);
 
     // Make sure there are three files in the output-dir
 
@@ -273,8 +273,7 @@ public class TestMRRJobs {
 
   @Test
   @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
-  public void testMRRSleepJobWithCompression()
-      throws IOException, InterruptedException, ClassNotFoundException {
+  public void testMRRSleepJobWithCompression() throws IOException, InterruptedException, ClassNotFoundException {
     LOG.info("\n\n\nStarting testMRRSleepJobWithCompression().");
 
     if (!(new File(MiniTezCluster.APPJAR)).exists()) {
@@ -302,8 +301,7 @@ public class TestMRRJobs {
     boolean succeeded = job.waitForCompletion(true);
     assertTrue(succeeded);
     assertEquals(State.SUCCEEDED, job.getJobState());
-    assertTrue(
-        trackingUrl.contains(jobId.substring(jobId.indexOf("_"))),
+    assertTrue(trackingUrl.contains(jobId.substring(jobId.indexOf("_"))),
         "Tracking URL was " + trackingUrl + " but didn't Match Job ID " + jobId);
 
     // FIXME once counters and task progress can be obtained properly

--- a/tez-tests/src/test/java/org/apache/tez/mapreduce/TestMRRJobsDAGApi.java
+++ b/tez-tests/src/test/java/org/apache/tez/mapreduce/TestMRRJobsDAGApi.java
@@ -18,9 +18,11 @@
  */
 package org.apache.tez.mapreduce;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
@@ -128,10 +131,10 @@ import org.apache.tez.test.MiniTezCluster;
 
 import com.google.common.collect.Sets;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -149,7 +152,7 @@ public class TestMRRJobsDAGApi {
   private static String TEST_ROOT_DIR = "target" + Path.SEPARATOR
       + TestMRRJobsDAGApi.class.getName() + "-tmpDir";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     try {
       conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEST_ROOT_DIR);
@@ -173,7 +176,7 @@ public class TestMRRJobsDAGApi {
 
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (mrrTezCluster != null) {
       mrrTezCluster.stop();
@@ -186,7 +189,8 @@ public class TestMRRJobsDAGApi {
     // TODO Add cleanup code.
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testSleepJob() throws TezException, IOException, InterruptedException {
     SleepProcessorConfig spConf = new SleepProcessorConfig(1);
 
@@ -213,8 +217,10 @@ public class TestMRRJobsDAGApi {
           + dagStatus.getState());
       Thread.sleep(500l);
       dagStatus = dagClient.getDAGStatus(null);
-      assertTrue("Memory used by AM is supposed to be 0 if not requested", dagStatus.getMemoryUsedByAM() == 0);
-      assertTrue("Memory used by tasks is supposed to be 0 if not requested", dagStatus.getMemoryUsedByTasks() == 0);
+      assertEquals(0, dagStatus.getMemoryUsedByAM(),
+          "Memory used by AM is supposed to be 0 if not requested");
+      assertEquals(0, dagStatus.getMemoryUsedByTasks(),
+          "Memory used by tasks is supposed to be 0 if not requested");
     }
     dagStatus = dagClient.getDAGStatus(Sets.newHashSet(StatusGetOpts.GET_COUNTERS, StatusGetOpts.GET_MEMORY_USAGE));
 
@@ -222,14 +228,15 @@ public class TestMRRJobsDAGApi {
     assertNotNull(dagStatus.getDAGCounters());
     assertNotNull(dagStatus.getDAGCounters().getGroup(FileSystemCounter.class.getName()));
     assertNotNull(dagStatus.getDAGCounters().findCounter(TaskCounter.GC_TIME_MILLIS));
-    assertTrue("Memory used by AM is supposed to be >0", dagStatus.getMemoryUsedByAM() > 0);
-    assertTrue("Memory used by tasks is supposed to be >0", dagStatus.getMemoryUsedByTasks() > 0);
+    assertTrue(dagStatus.getMemoryUsedByAM() > 0, "Memory used by AM is supposed to be >0");
+    assertTrue(dagStatus.getMemoryUsedByTasks() > 0, "Memory used by tasks is supposed to be >0");
 
     ExampleDriver.printDAGStatus(dagClient, new String[] { "SleepVertex" }, true, true);
     tezSession.stop();
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testNonDefaultFSStagingDir() throws Exception {
     SleepProcessorConfig spConf = new SleepProcessorConfig(1);
 
@@ -270,7 +277,8 @@ public class TestMRRJobsDAGApi {
   }
 
   // Submits a simple 5 stage sleep job using tez session. Then kills it.
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testHistoryLogging() throws IOException,
       InterruptedException, TezException, ClassNotFoundException, YarnException {
     SleepProcessorConfig spConf = new SleepProcessorConfig(1);
@@ -320,46 +328,50 @@ public class TestMRRJobsDAGApi {
         break;
       }
     }
-    Assert.assertNotNull(historyLogFileStatus);
-    Assert.assertTrue(historyLogFileStatus.getLen() > 0);
+    assertNotNull(historyLogFileStatus);
+    assertTrue(historyLogFileStatus.getLen() > 0);
     tezSession.stop();
   }
 
   // Submits a simple 5 stage sleep job using the DAG submit API instead of job
   // client.
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMRRSleepJobDagSubmit() throws IOException,
   InterruptedException, TezException, ClassNotFoundException, YarnException {
     State finalState = testMRRSleepJobDagSubmitCore(false, false, false, false);
 
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, finalState);
+    assertEquals(DAGStatus.State.SUCCEEDED, finalState);
     // TODO Add additional checks for tracking URL etc. - once it's exposed by
     // the DAG API.
   }
 
   // Submits a simple 5 stage sleep job using the DAG submit API. Then kills it.
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMRRSleepJobDagSubmitAndKill() throws IOException,
   InterruptedException, TezException, ClassNotFoundException, YarnException {
     State finalState = testMRRSleepJobDagSubmitCore(false, true, false, false);
 
-    Assert.assertEquals(DAGStatus.State.KILLED, finalState);
+    assertEquals(DAGStatus.State.KILLED, finalState);
     // TODO Add additional checks for tracking URL etc. - once it's exposed by
     // the DAG API.
   }
 
   // Submits a DAG to AM via RPC after AM has started
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMRRSleepJobViaSession() throws IOException,
   InterruptedException, TezException, ClassNotFoundException, YarnException {
     State finalState = testMRRSleepJobDagSubmitCore(true, false, false, false);
 
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, finalState);
+    assertEquals(DAGStatus.State.SUCCEEDED, finalState);
   }
 
   // Submit 2 jobs via RPC using a custom initializer. The second job is submitted with an
   // additional local resource, which is verified by the initializer.
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testAMRelocalization() throws Exception {
     Path relocPath = new Path("/tmp/relocalizationfilefound");
     if (remoteFs.exists(relocPath)) {
@@ -369,8 +381,8 @@ public class TestMRRJobsDAGApi {
 
     State finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, true, MRInputAMSplitGeneratorRelocalizationTest.class, null);
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    Assert.assertFalse(remoteFs.exists(new Path("/tmp/relocalizationfilefound")));
+    assertEquals(DAGStatus.State.SUCCEEDED, finalState);
+    assertFalse(remoteFs.exists(new Path("/tmp/relocalizationfilefound")));
 
     // Start the second job with some additional resources.
 
@@ -390,14 +402,14 @@ public class TestMRRJobsDAGApi {
     additionalResources.put("test.jar", createLrObjFromPath(relocFilePath));
     additionalResources.put("TezAppJar.jar", createLrObjFromPath(tezAppJarRemote));
 
-    Assert.assertEquals(TezAppMasterStatus.READY,
+    assertEquals(TezAppMasterStatus.READY,
         tezSession.getAppMasterStatus());
     finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, true, MRInputAMSplitGeneratorRelocalizationTest.class, additionalResources);
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    Assert.assertEquals(TezAppMasterStatus.READY,
+    assertEquals(DAGStatus.State.SUCCEEDED, finalState);
+    assertEquals(TezAppMasterStatus.READY,
         tezSession.getAppMasterStatus());
-    Assert.assertTrue(remoteFs.exists(new Path("/tmp/relocalizationfilefound")));
+    assertTrue(remoteFs.exists(new Path("/tmp/relocalizationfilefound")));
 
     stopAndVerifyYarnApp(tezSession);
   }
@@ -406,7 +418,7 @@ public class TestMRRJobsDAGApi {
       IOException, YarnException {
     ApplicationId appId = tezSession.getAppMasterApplicationId();
     tezSession.stop();
-    Assert.assertEquals(TezAppMasterStatus.SHUTDOWN,
+    assertEquals(TezAppMasterStatus.SHUTDOWN,
         tezSession.getAppMasterStatus());
 
     YarnClient yarnClient = YarnClient.createYarnClient();
@@ -426,14 +438,15 @@ public class TestMRRJobsDAGApi {
     }
 
     ApplicationReport appReport = yarnClient.getApplicationReport(appId);
-    Assert.assertEquals(YarnApplicationState.FINISHED,
+    assertEquals(YarnApplicationState.FINISHED,
         appReport.getYarnApplicationState());
-    Assert.assertEquals(FinalApplicationStatus.SUCCEEDED,
+    assertEquals(FinalApplicationStatus.SUCCEEDED,
         appReport.getFinalApplicationStatus());
   }
 
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testAMRelocalizationConflict() throws Exception {
     Path relocPath = new Path("/tmp/relocalizationfilefound");
     if (remoteFs.exists(relocPath)) {
@@ -444,8 +457,8 @@ public class TestMRRJobsDAGApi {
     TezClient tezSession = createTezSession();
     State finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, true, MRInputAMSplitGeneratorRelocalizationTest.class, null);
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    Assert.assertFalse(remoteFs.exists(relocPath));
+    assertEquals(DAGStatus.State.SUCCEEDED, finalState);
+    assertFalse(remoteFs.exists(relocPath));
 
     // Create a bogus TezAppJar directly to HDFS
     LOG.info("Creating jar for relocalization test");
@@ -460,7 +473,7 @@ public class TestMRRJobsDAGApi {
     try {
       testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, true, MRInputAMSplitGeneratorRelocalizationTest.class, additionalResources);
-      Assert.fail("should have failed");
+      fail("should have failed");
     } catch (Exception ex) {
       // expected
     }
@@ -482,12 +495,13 @@ public class TestMRRJobsDAGApi {
 
     TezClient tezSession = TezClient.create("testrelocalizationsession", tezConf, true);
     tezSession.start();
-    Assert.assertEquals(TezAppMasterStatus.INITIALIZING, tezSession.getAppMasterStatus());
+    assertEquals(TezAppMasterStatus.INITIALIZING, tezSession.getAppMasterStatus());
     return tezSession;
   }
 
   // Submits a DAG to AM via RPC after AM has started
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleMRRSleepJobViaSession() throws IOException,
   InterruptedException, TezException, ClassNotFoundException, YarnException {
     Path remoteStagingDir = remoteFs.makeQualified(new Path("/tmp", String
@@ -500,42 +514,45 @@ public class TestMRRJobsDAGApi {
 
     TezClient tezSession = TezClient.create("testsession", tezConf, true);
     tezSession.start();
-    Assert.assertEquals(TezAppMasterStatus.INITIALIZING,
+    assertEquals(TezAppMasterStatus.INITIALIZING,
         tezSession.getAppMasterStatus());
 
     State finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, false, null, null);
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    Assert.assertEquals(TezAppMasterStatus.READY,
+    assertEquals(DAGStatus.State.SUCCEEDED, finalState);
+    assertEquals(TezAppMasterStatus.READY,
         tezSession.getAppMasterStatus());
     finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, false, null, null);
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    Assert.assertEquals(TezAppMasterStatus.READY,
+    assertEquals(DAGStatus.State.SUCCEEDED, finalState);
+    assertEquals(TezAppMasterStatus.READY,
         tezSession.getAppMasterStatus());
 
     stopAndVerifyYarnApp(tezSession);
   }
 
   // Submits a simple 5 stage sleep job using tez session. Then kills it.
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMRRSleepJobDagSubmitAndKillViaRPC() throws IOException,
   InterruptedException, TezException, ClassNotFoundException, YarnException {
     State finalState = testMRRSleepJobDagSubmitCore(true, true, false, false);
 
-    Assert.assertEquals(DAGStatus.State.KILLED, finalState);
+    assertEquals(DAGStatus.State.KILLED, finalState);
     // TODO Add additional checks for tracking URL etc. - once it's exposed by
     // the DAG API.
   }
 
   // Create and close a tez session without submitting a job
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testTezSessionShutdown() throws IOException,
   InterruptedException, TezException, ClassNotFoundException, YarnException {
     testMRRSleepJobDagSubmitCore(true, false, true, false);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testAMSplitGeneration() throws IOException, InterruptedException,
       TezException, ClassNotFoundException, YarnException {
     testMRRSleepJobDagSubmitCore(true, false, false, true);
@@ -655,7 +672,7 @@ public class TestMRRJobsDAGApi {
         true);
     DataSinkDescriptor dataSinkDescriptor =
         MROutputLegacy.createConfigBuilder(stage3Conf, NullOutputFormat.class).build();
-    Assert.assertFalse(dataSinkDescriptor.getOutputDescriptor().getHistoryText().isEmpty());
+    assertFalse(dataSinkDescriptor.getOutputDescriptor().getHistoryText().isEmpty());
     stage3Vertex.addDataSink("MROutput", dataSinkDescriptor);
 
     // TODO env, resources
@@ -733,9 +750,9 @@ public class TestMRRJobsDAGApi {
             LOG.info("Application completed after sending session shutdown"
                 + ", yarnApplicationState=" + appState
                 + ", finalAppStatus=" + appReport.getFinalApplicationStatus());
-            Assert.assertEquals(YarnApplicationState.FINISHED,
+            assertEquals(YarnApplicationState.FINISHED,
                 appState);
-            Assert.assertEquals(FinalApplicationStatus.SUCCEEDED,
+            assertEquals(FinalApplicationStatus.SUCCEEDED,
                 appReport.getFinalApplicationStatus());
             break;
           }
@@ -752,7 +769,7 @@ public class TestMRRJobsDAGApi {
         tezSession.addAppMasterLocalFiles(additionalLocalResources);
       }
       dagClient = tezSession.submitDAG(dag);
-      Assert.assertEquals(TezAppMasterStatus.RUNNING,
+      assertEquals(TezAppMasterStatus.RUNNING,
           tezSession.getAppMasterStatus());
     }
     DAGStatus dagStatus = dagClient.getDAGStatus(null);
@@ -790,7 +807,8 @@ public class TestMRRJobsDAGApi {
         resourceSize, resourceModificationTime);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testVertexGroups() throws Exception {
     LOG.info("Running Group Test");
     Path inPath = new Path(TEST_ROOT_DIR, "in-groups");
@@ -812,7 +830,8 @@ public class TestMRRJobsDAGApi {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testBroadcastAndOneToOne() throws Exception {
     LOG.info("Running BroadcastAndOneToOne Test");
     BroadcastAndOneToOneExample job = new BroadcastAndOneToOneExample();

--- a/tez-tests/src/test/java/org/apache/tez/mapreduce/TestMRRJobsDAGApi.java
+++ b/tez-tests/src/test/java/org/apache/tez/mapreduce/TestMRRJobsDAGApi.java
@@ -217,10 +217,8 @@ public class TestMRRJobsDAGApi {
           + dagStatus.getState());
       Thread.sleep(500l);
       dagStatus = dagClient.getDAGStatus(null);
-      assertEquals(0, dagStatus.getMemoryUsedByAM(),
-          "Memory used by AM is supposed to be 0 if not requested");
-      assertEquals(0, dagStatus.getMemoryUsedByTasks(),
-          "Memory used by tasks is supposed to be 0 if not requested");
+      assertEquals(0, dagStatus.getMemoryUsedByAM(), "Memory used by AM is supposed to be 0 if not requested");
+      assertEquals(0, dagStatus.getMemoryUsedByTasks(), "Memory used by tasks is supposed to be 0 if not requested");
     }
     dagStatus = dagClient.getDAGStatus(Sets.newHashSet(StatusGetOpts.GET_COUNTERS, StatusGetOpts.GET_MEMORY_USAGE));
 
@@ -402,13 +400,11 @@ public class TestMRRJobsDAGApi {
     additionalResources.put("test.jar", createLrObjFromPath(relocFilePath));
     additionalResources.put("TezAppJar.jar", createLrObjFromPath(tezAppJarRemote));
 
-    assertEquals(TezAppMasterStatus.READY,
-        tezSession.getAppMasterStatus());
+    assertEquals(TezAppMasterStatus.READY, tezSession.getAppMasterStatus());
     finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, true, MRInputAMSplitGeneratorRelocalizationTest.class, additionalResources);
     assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    assertEquals(TezAppMasterStatus.READY,
-        tezSession.getAppMasterStatus());
+    assertEquals(TezAppMasterStatus.READY, tezSession.getAppMasterStatus());
     assertTrue(remoteFs.exists(new Path("/tmp/relocalizationfilefound")));
 
     stopAndVerifyYarnApp(tezSession);
@@ -418,8 +414,7 @@ public class TestMRRJobsDAGApi {
       IOException, YarnException {
     ApplicationId appId = tezSession.getAppMasterApplicationId();
     tezSession.stop();
-    assertEquals(TezAppMasterStatus.SHUTDOWN,
-        tezSession.getAppMasterStatus());
+    assertEquals(TezAppMasterStatus.SHUTDOWN, tezSession.getAppMasterStatus());
 
     YarnClient yarnClient = YarnClient.createYarnClient();
     yarnClient.init(mrrTezCluster.getConfig());
@@ -438,10 +433,8 @@ public class TestMRRJobsDAGApi {
     }
 
     ApplicationReport appReport = yarnClient.getApplicationReport(appId);
-    assertEquals(YarnApplicationState.FINISHED,
-        appReport.getYarnApplicationState());
-    assertEquals(FinalApplicationStatus.SUCCEEDED,
-        appReport.getFinalApplicationStatus());
+    assertEquals(YarnApplicationState.FINISHED, appReport.getYarnApplicationState());
+    assertEquals(FinalApplicationStatus.SUCCEEDED, appReport.getFinalApplicationStatus());
   }
 
 
@@ -514,19 +507,16 @@ public class TestMRRJobsDAGApi {
 
     TezClient tezSession = TezClient.create("testsession", tezConf, true);
     tezSession.start();
-    assertEquals(TezAppMasterStatus.INITIALIZING,
-        tezSession.getAppMasterStatus());
+    assertEquals(TezAppMasterStatus.INITIALIZING, tezSession.getAppMasterStatus());
 
     State finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, false, null, null);
     assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    assertEquals(TezAppMasterStatus.READY,
-        tezSession.getAppMasterStatus());
+    assertEquals(TezAppMasterStatus.READY, tezSession.getAppMasterStatus());
     finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, false, null, null);
     assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    assertEquals(TezAppMasterStatus.READY,
-        tezSession.getAppMasterStatus());
+    assertEquals(TezAppMasterStatus.READY, tezSession.getAppMasterStatus());
 
     stopAndVerifyYarnApp(tezSession);
   }
@@ -750,10 +740,8 @@ public class TestMRRJobsDAGApi {
             LOG.info("Application completed after sending session shutdown"
                 + ", yarnApplicationState=" + appState
                 + ", finalAppStatus=" + appReport.getFinalApplicationStatus());
-            assertEquals(YarnApplicationState.FINISHED,
-                appState);
-            assertEquals(FinalApplicationStatus.SUCCEEDED,
-                appReport.getFinalApplicationStatus());
+            assertEquals(YarnApplicationState.FINISHED, appState);
+            assertEquals(FinalApplicationStatus.SUCCEEDED, appReport.getFinalApplicationStatus());
             break;
           }
         }
@@ -769,8 +757,7 @@ public class TestMRRJobsDAGApi {
         tezSession.addAppMasterLocalFiles(additionalLocalResources);
       }
       dagClient = tezSession.submitDAG(dag);
-      assertEquals(TezAppMasterStatus.RUNNING,
-          tezSession.getAppMasterStatus());
+      assertEquals(TezAppMasterStatus.RUNNING, tezSession.getAppMasterStatus());
     }
     DAGStatus dagStatus = dagClient.getDAGStatus(null);
     while (!dagStatus.isCompleted()) {

--- a/tez-tests/src/test/java/org/apache/tez/test/FaultToleranceTestRunner.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/FaultToleranceTestRunner.java
@@ -32,7 +32,6 @@ import org.apache.tez.dag.api.DAG;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.client.DAGClient;
 import org.apache.tez.dag.api.client.DAGStatus;
-
 /**
  * Run a DAG on a cluster with the given configuration. Starts a TezSession
  * using default cluster configuration from installation. Then uses reflection

--- a/tez-tests/src/test/java/org/apache/tez/test/FaultToleranceTestRunner.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/FaultToleranceTestRunner.java
@@ -32,6 +32,7 @@ import org.apache.tez.dag.api.DAG;
 import org.apache.tez.dag.api.TezConfiguration;
 import org.apache.tez.dag.api.client.DAGClient;
 import org.apache.tez.dag.api.client.DAGStatus;
+
 /**
  * Run a DAG on a cluster with the given configuration. Starts a TezSession
  * using default cluster configuration from installation. Then uses reflection

--- a/tez-tests/src/test/java/org/apache/tez/test/SimpleTestDAG.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/SimpleTestDAG.java
@@ -30,7 +30,6 @@ import org.apache.tez.dag.api.EdgeProperty.SchedulingType;
 import org.apache.tez.dag.api.UserPayload;
 import org.apache.tez.dag.api.Vertex;
 
-
 /**
  * Simple Test DAG with 2 vertices using TestProcessor/TestInput/TestOutput.
  *

--- a/tez-tests/src/test/java/org/apache/tez/test/SimpleTestDAG.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/SimpleTestDAG.java
@@ -30,6 +30,7 @@ import org.apache.tez.dag.api.EdgeProperty.SchedulingType;
 import org.apache.tez.dag.api.UserPayload;
 import org.apache.tez.dag.api.Vertex;
 
+
 /**
  * Simple Test DAG with 2 vertices using TestProcessor/TestInput/TestOutput.
  *

--- a/tez-tests/src/test/java/org/apache/tez/test/SimpleTestDAG3Vertices.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/SimpleTestDAG3Vertices.java
@@ -30,7 +30,6 @@ import org.apache.tez.dag.api.EdgeProperty.SchedulingType;
 import org.apache.tez.dag.api.UserPayload;
 import org.apache.tez.dag.api.Vertex;
 
-
 /**
  * Simple Test DAG with 3 vertices using TestProcessor/TestInput/TestOutput.
  *

--- a/tez-tests/src/test/java/org/apache/tez/test/SimpleTestDAG3Vertices.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/SimpleTestDAG3Vertices.java
@@ -30,6 +30,7 @@ import org.apache.tez.dag.api.EdgeProperty.SchedulingType;
 import org.apache.tez.dag.api.UserPayload;
 import org.apache.tez.dag.api.Vertex;
 
+
 /**
  * Simple Test DAG with 3 vertices using TestProcessor/TestInput/TestOutput.
  *

--- a/tez-tests/src/test/java/org/apache/tez/test/TestAM.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestAM.java
@@ -150,7 +150,8 @@ public class TestAM {
     URL url = URI.create(webUIAddress).toURL();
     IntegerRanges portRange = conf.getRange(TezConfiguration.TEZ_AM_WEBSERVICE_PORT_RANGE,
         TezConfiguration.TEZ_AM_WEBSERVICE_PORT_RANGE_DEFAULT);
-    assertTrue(portRange.getRangeStart() <= url.getPort(), "WebUIService port should be in the defined range (got: " + url.getPort() + ")");
+    assertTrue(portRange.getRangeStart() <= url.getPort(),
+        "WebUIService port should be in the defined range (got: " + url.getPort() + ")");
 
     tezSession.stop();
   }

--- a/tez-tests/src/test/java/org/apache/tez/test/TestAM.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestAM.java
@@ -18,15 +18,16 @@
  */
 package org.apache.tez.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -48,9 +49,10 @@ import org.apache.tez.dag.api.client.DAGStatus;
 import org.apache.tez.runtime.library.processor.SleepProcessor;
 import org.apache.tez.runtime.library.processor.SleepProcessor.SleepProcessorConfig;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +68,7 @@ public class TestAM {
 
   private static final String TEST_ROOT_DIR = "target" + Path.SEPARATOR + TestAM.class.getName() + "-tmpDir";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     try {
       conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, TEST_ROOT_DIR);
@@ -93,7 +95,7 @@ public class TestAM {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (tezCluster != null) {
       tezCluster.stop();
@@ -106,7 +108,8 @@ public class TestAM {
     getProfiler().delete();
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testAMWebUIService() throws TezException, IOException, InterruptedException {
     SleepProcessorConfig spConf = new SleepProcessorConfig(1);
 
@@ -129,7 +132,7 @@ public class TestAM {
     }
 
     String webUIAddress = dagClient.getWebUIAddress();
-    assertNotNull("getWebUIAddress should return TezAM's web UI address", webUIAddress);
+    assertNotNull(webUIAddress, "getWebUIAddress should return TezAM's web UI address");
     LOG.info("TezAM webUI address: " + webUIAddress);
 
     checkAddress(webUIAddress + "/jmx");
@@ -147,8 +150,7 @@ public class TestAM {
     URL url = URI.create(webUIAddress).toURL();
     IntegerRanges portRange = conf.getRange(TezConfiguration.TEZ_AM_WEBSERVICE_PORT_RANGE,
         TezConfiguration.TEZ_AM_WEBSERVICE_PORT_RANGE_DEFAULT);
-    assertTrue("WebUIService port should be in the defined range (got: " + url.getPort() + ")",
-        portRange.getRangeStart() <= url.getPort());
+    assertTrue(portRange.getRangeStart() <= url.getPort(), "WebUIService port should be in the defined range (got: " + url.getPort() + ")");
 
     tezSession.stop();
   }
@@ -166,7 +168,7 @@ public class TestAM {
     } catch (Exception e) {
       LOG.error("Error while checking url: " + url, e);
     }
-    assertTrue(url + " should be available", success);
+    assertTrue(success, url + " should be available");
   }
 
   private static File getProfiler() {

--- a/tez-tests/src/test/java/org/apache/tez/test/TestAMRecovery.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestAMRecovery.java
@@ -18,13 +18,15 @@
  */
 package org.apache.tez.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -75,12 +77,12 @@ import org.apache.tez.runtime.library.processor.SimpleProcessor;
 
 import com.google.common.collect.Lists;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,7 +102,7 @@ public class TestAMRecovery {
   private static String FAIL_ON_PARTIAL_FINISHED = "FAIL_ON_PARTIAL_COMPLETED";
   private static String FAIL_ON_ATTEMPT = "FAIL_ON_ATTEMPT";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     LOG.info("Starting mini clusters");
     try {
@@ -124,7 +126,7 @@ public class TestAMRecovery {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws InterruptedException {
     if (tezSession != null) {
       try {
@@ -153,7 +155,7 @@ public class TestAMRecovery {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     LOG.info("Starting session");
     Path remoteStagingDir =
@@ -184,7 +186,7 @@ public class TestAMRecovery {
     tezSession.start();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws InterruptedException {
     if (tezSession != null) {
       try {
@@ -204,7 +206,8 @@ public class TestAMRecovery {
    *
    * @throws Exception
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testVertexPartiallyFinished_Broadcast() throws Exception {
     DAG dag =
         createDAG("VertexPartiallyFinished_Broadcast", ControlledImmediateStartVertexManager.class,
@@ -235,7 +238,8 @@ public class TestAMRecovery {
    *
    * @throws Exception
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testVertexCompletelyFinished_Broadcast() throws Exception {
     DAG dag =
         createDAG("VertexCompletelyFinished_Broadcast", ControlledImmediateStartVertexManager.class,
@@ -267,7 +271,8 @@ public class TestAMRecovery {
    *
    * @throws Exception
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testVertexPartialFinished_One2One() throws Exception {
     DAG dag =
         createDAG("VertexPartialFinished_One2One", ControlledInputReadyVertexManager.class,
@@ -299,7 +304,8 @@ public class TestAMRecovery {
    *
    * @throws Exception
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testVertexCompletelyFinished_One2One() throws Exception {
     DAG dag =
         createDAG("VertexCompletelyFinished_One2One", ControlledInputReadyVertexManager.class,
@@ -331,7 +337,8 @@ public class TestAMRecovery {
    *
    * @throws Exception
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testVertexPartiallyFinished_ScatterGather() throws Exception {
     DAG dag =
         createDAG("VertexPartiallyFinished_ScatterGather", ControlledShuffleVertexManager.class,
@@ -363,7 +370,8 @@ public class TestAMRecovery {
    *
    * @throws Exception
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testVertexCompletelyFinished_ScatterGather() throws Exception {
     DAG dag =
         createDAG("VertexCompletelyFinished_ScatterGather", ControlledShuffleVertexManager.class,
@@ -374,8 +382,8 @@ public class TestAMRecovery {
     TezCounter outputCounter = counters.findCounter(TestOutput.COUNTER_NAME, TestOutput.COUNTER_NAME);
     TezCounter inputCounter = counters.findCounter(TestInput.COUNTER_NAME, TestInput.COUNTER_NAME);
     // verify that processor, input and output counters, are all being collected
-    Assert.assertTrue(outputCounter.getValue() > 0);
-    Assert.assertTrue(inputCounter.getValue() > 0);
+    assertTrue(outputCounter.getValue() > 0);
+    assertTrue(inputCounter.getValue() > 0);
 
     List<HistoryEvent> historyEvents1 = readRecoveryLog(1);
     List<HistoryEvent> historyEvents2 = readRecoveryLog(2);
@@ -398,7 +406,8 @@ public class TestAMRecovery {
    *
    * @throws Exception
    */
-  @Test(timeout = 600000)
+  @Test
+  @Timeout(value = 600000, unit = TimeUnit.MILLISECONDS)
   public void testHighMaxAttempt() throws Exception {
     Random rand = new Random();
     tezConf.set(FAIL_ON_ATTEMPT, rand.nextInt(MAX_AM_ATTEMPT) + "");
@@ -416,7 +425,7 @@ public class TestAMRecovery {
     DAGStatus dagStatus =
         dagClient.waitForCompletionWithStatusUpdates(EnumSet
             .of(StatusGetOpts.GET_COUNTERS));
-    Assert.assertEquals(finalState, dagStatus.getState());
+    assertEquals(finalState, dagStatus.getState());
     return dagStatus.getDAGCounters();
   }
 

--- a/tez-tests/src/test/java/org/apache/tez/test/TestAMRecoveryAggregationBroadcast.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestAMRecoveryAggregationBroadcast.java
@@ -18,7 +18,7 @@
  */
 package org.apache.tez.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -85,12 +85,12 @@ import org.apache.tez.runtime.library.conf.OrderedPartitionedKVEdgeConfig;
 import org.apache.tez.runtime.library.conf.UnorderedKVEdgeConfig;
 import org.apache.tez.runtime.library.partitioner.HashPartitioner;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,7 +120,7 @@ public class TestAMRecoveryAggregationBroadcast {
   private TezConfiguration tezConf;
   private TezClient tezSession;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupAll() {
     try {
       dfsConf = new Configuration();
@@ -156,7 +156,7 @@ public class TestAMRecoveryAggregationBroadcast {
     writer.close();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAll() {
     if (tezCluster != null) {
       tezCluster.stop();
@@ -168,7 +168,7 @@ public class TestAMRecoveryAggregationBroadcast {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Path remoteStagingDir = remoteFs.makeQualified(new Path(TEST_ROOT_DIR, String
         .valueOf(new Random().nextInt(100000))));
@@ -187,7 +187,7 @@ public class TestAMRecoveryAggregationBroadcast {
     tezSession.start();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws InterruptedException {
     if (tezSession != null) {
       try {
@@ -200,7 +200,8 @@ public class TestAMRecoveryAggregationBroadcast {
     tezSession = null;
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testSucceed() throws Exception {
     DAG dag = createDAG("Succeed");
     TezCounters counters = runDAGAndVerify(dag, false);
@@ -215,7 +216,8 @@ public class TestAMRecoveryAggregationBroadcast {
     assertEquals(Collections.emptyList(), readRecoveryLog(2));
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testTableScanTemporalFailure() throws Exception {
     tezConf.setBoolean(TABLE_SCAN_SLEEP, true);
     DAG dag = createDAG("TableScanTemporalFailure");
@@ -235,7 +237,8 @@ public class TestAMRecoveryAggregationBroadcast {
     assertEquals(Collections.emptyList(), readRecoveryLog(3));
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testAggregationTemporalFailure() throws Exception {
     tezConf.setBoolean(AGGREGATION_SLEEP, true);
     DAG dag = createDAG("AggregationTemporalFailure");
@@ -255,7 +258,8 @@ public class TestAMRecoveryAggregationBroadcast {
     assertEquals(Collections.emptyList(), readRecoveryLog(3));
   }
 
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testMapJoinTemporalFailure() throws Exception {
     tezConf.setBoolean(MAP_JOIN_SLEEP, true);
     DAG dag = createDAG("MapJoinTemporalFailure");
@@ -350,13 +354,13 @@ public class TestAMRecoveryAggregationBroadcast {
     }
     DAGStatus dagStatus = dagClient.waitForCompletionWithStatusUpdates(EnumSet.of(StatusGetOpts.GET_COUNTERS));
     LOG.info("Diagnosis: " + dagStatus.getDiagnostics());
-    Assert.assertEquals(State.SUCCEEDED, dagStatus.getState());
+    assertEquals(State.SUCCEEDED, dagStatus.getState());
 
     FSDataInputStream in = remoteFs.open(new Path(OUT_PATH, "part-v002-o000-r-00000"));
     ByteBuffer buf = ByteBuffer.allocate(100);
     in.read(buf);
     buf.flip();
-    Assert.assertEquals(EXPECTED_OUTPUT, StandardCharsets.UTF_8.decode(buf).toString());
+    assertEquals(EXPECTED_OUTPUT, StandardCharsets.UTF_8.decode(buf).toString());
     return dagStatus.getDAGCounters();
   }
 

--- a/tez-tests/src/test/java/org/apache/tez/test/TestDAGRecovery.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestDAGRecovery.java
@@ -18,8 +18,11 @@
  */
 package org.apache.tez.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -43,12 +46,12 @@ import org.apache.tez.test.dag.MultiAttemptDAG.NoOpInput;
 import org.apache.tez.test.dag.MultiAttemptDAG.TestRootInputInitializer;
 import org.apache.tez.test.dag.SimpleVTestDAG;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,7 +68,7 @@ public class TestDAGRecovery {
   private static FileSystem remoteFs = null;
   private static TezConfiguration tezConf = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     LOG.info("Starting mini clusters");
     try {
@@ -88,7 +91,7 @@ public class TestDAGRecovery {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws InterruptedException {
     if (tezSession != null) {
       try {
@@ -116,7 +119,7 @@ public class TestDAGRecovery {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup()  throws Exception {
     LOG.info("Starting session");
     Path remoteStagingDir = remoteFs.makeQualified(new Path(TEST_ROOT_DIR, String
@@ -142,7 +145,7 @@ public class TestDAGRecovery {
     tezSession.start();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws InterruptedException {
     if (tezSession != null) {
       try {
@@ -168,10 +171,11 @@ public class TestDAGRecovery {
       dagStatus = dagClient.getDAGStatus(null);
     }
 
-    Assert.assertEquals(finalState, dagStatus.getState());
+    assertEquals(finalState, dagStatus.getState());
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testBasicRecovery() throws Exception {
     DAG dag = MultiAttemptDAG.createDAG("TestBasicRecovery", null);
     // add input to v1 to make sure that there will be init events for v1 (TEZ-1345)
@@ -183,7 +187,8 @@ public class TestDAGRecovery {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testDelayedInit() throws Exception {
     DAG dag = SimpleVTestDAG.createDAG("DelayedInitDAG", null);
     dag.getVertex("v1").addDataSource(

--- a/tez-tests/src/test/java/org/apache/tez/test/TestDAGRecovery2.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestDAGRecovery2.java
@@ -18,9 +18,12 @@
  */
 package org.apache.tez.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -41,12 +44,12 @@ import org.apache.tez.dag.api.client.DAGStatus.State;
 import org.apache.tez.test.dag.MultiAttemptDAG;
 import org.apache.tez.test.dag.SimpleVTestDAG;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +65,7 @@ public class TestDAGRecovery2 {
   private static TezClient tezSession = null;
   private static FileSystem remoteFs = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     LOG.info("Starting mini clusters");
     try {
@@ -85,7 +88,7 @@ public class TestDAGRecovery2 {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws InterruptedException {
     if (tezSession != null) {
       try {
@@ -127,7 +130,7 @@ public class TestDAGRecovery2 {
     return tezConf;
   }
 
-  @Before
+  @BeforeEach
   public void setup()  throws Exception {
     Path remoteStagingDir = remoteFs.makeQualified(new Path(TEST_ROOT_DIR, String
         .valueOf(new Random().nextInt(100000))));
@@ -139,7 +142,7 @@ public class TestDAGRecovery2 {
     tezSession.start();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws InterruptedException {
     if (tezSession != null) {
       try {
@@ -170,10 +173,11 @@ public class TestDAGRecovery2 {
       dagStatus = dagClient.getDAGStatus(null);
     }
 
-    Assert.assertEquals(finalState, dagStatus.getState());
+    assertEquals(finalState, dagStatus.getState());
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testFailingCommitter() throws Exception {
     DAG dag = SimpleVTestDAG.createDAG("FailingCommitterDAG", null);
     OutputDescriptor od =
@@ -187,7 +191,8 @@ public class TestDAGRecovery2 {
     runDAGAndVerify(dag, State.FAILED);
   }
 
-  @Test(timeout=120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testSessionDisableMultiAttempts() throws Exception {
     tezSession.stop();
     Path remoteStagingDir = remoteFs.makeQualified(new Path(TEST_ROOT_DIR, String

--- a/tez-tests/src/test/java/org/apache/tez/test/TestExceptionPropagation.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestExceptionPropagation.java
@@ -18,7 +18,8 @@
  */
 package org.apache.tez.test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -27,6 +28,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -90,7 +92,8 @@ import org.apache.tez.test.dag.MultiAttemptDAG.NoOpInput;
 
 import com.google.common.collect.Lists;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -216,7 +219,8 @@ public class TestExceptionPropagation {
    * @throws Exception
    *
    */
-  @Test(timeout = 600000)
+  @Test
+  @Timeout(value = 600000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionPropagationSession() throws Exception {
     try {
       startSessionClient();
@@ -245,7 +249,8 @@ public class TestExceptionPropagation {
    *
    * @throws Exception
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testExceptionPropagationNonSession() throws Exception {
     try {
       startMiniTezCluster();

--- a/tez-tests/src/test/java/org/apache/tez/test/TestFaultTolerance.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestFaultTolerance.java
@@ -18,9 +18,14 @@
  */
 package org.apache.tez.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -50,12 +55,12 @@ import org.apache.tez.test.dag.*;
 
 import com.google.common.base.Joiner;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +76,7 @@ public class TestFaultTolerance {
   private static TezClient tezSession = null;
   private static TezConfiguration tezConf;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     LOG.info("Starting mini clusters");
     FileSystem remoteFs = null;
@@ -109,7 +114,7 @@ public class TestFaultTolerance {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     LOG.info("Stopping mini clusters");
     if (tezSession != null) {
@@ -125,7 +130,7 @@ public class TestFaultTolerance {
     }
   }
 
-  @Before
+  @BeforeEach
   public void checkSessionStatus() {
     // TODO restart session if it crashed due to some test error
   }
@@ -152,20 +157,21 @@ public class TestFaultTolerance {
       dagStatus = dagClient.getDAGStatus(null);
     }
 
-    Assert.assertEquals(finalState, dagStatus.getState());
+    assertEquals(finalState, dagStatus.getState());
 
     if (checkFailedAttempts > 0) {
-      Assert.assertEquals(checkFailedAttempts,
+      assertEquals(checkFailedAttempts,
           dagStatus.getDAGProgress().getFailedTaskAttemptCount());
     }
 
     if (diagnostics != null) {
-      Assert.assertNotNull(dagStatus.getDiagnostics());
-      Assert.assertTrue(Joiner.on(":").join(dagStatus.getDiagnostics()).contains(diagnostics));
+      assertNotNull(dagStatus.getDiagnostics());
+      assertTrue(Joiner.on(":").join(dagStatus.getDiagnostics()).contains(diagnostics));
     }
   }
 
-  @Test (timeout=600000)
+  @Test
+  @Timeout(value = 600000, unit = TimeUnit.MILLISECONDS)
   public void testSessionStopped() throws Exception {
     Configuration testConf = new Configuration(false);
 
@@ -198,13 +204,15 @@ public class TestFaultTolerance {
     tezSession.start();
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testBasicSuccessScatterGather() throws Exception {
     DAG dag = SimpleTestDAG.createDAG("testBasicSuccessScatterGather", null);
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testBasicSuccessBroadcast() throws Exception {
     DAG dag = DAG.create("testBasicSuccessBroadcast");
     Vertex v1 =
@@ -220,7 +228,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testBasicTaskFailure() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setBoolean(TestProcessor.getVertexConfName(
@@ -245,7 +254,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED, 1);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testTaskMultipleFailures() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setBoolean(TestProcessor.getVertexConfName(
@@ -266,7 +276,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED, 4);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testTaskMultipleFailuresDAGFail() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setBoolean(TestProcessor.getVertexConfName(
@@ -280,7 +291,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.FAILED);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testBasicInputFailureWithExit() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setBoolean(TestInput.getVertexConfName(
@@ -308,7 +320,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testBasicInputFailureWithoutExit() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setBoolean(TestInput.getVertexConfName(
@@ -330,7 +343,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testBasicInputFailureWithoutExitDeadline() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setInt(SimpleTestDAG.TEZ_SIMPLE_DAG_NUM_TASKS, 3); // 1 error < 0.4 fail fraction
@@ -348,7 +362,8 @@ public class TestFaultTolerance {
   }
 
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleInputFailureWithoutExit() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setBoolean(TestInput.getVertexConfName(
@@ -375,7 +390,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMultiVersionInputFailureWithoutExit() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setBoolean(TestInput.getVertexConfName(
@@ -404,7 +420,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testTwoLevelsFailingDAGSuccess() throws Exception {
     Configuration testConf = new Configuration();
     DAG dag = new FailingDagBuilder(FailingDagBuilder.Levels.TWO)
@@ -412,7 +429,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testThreeLevelsFailingDAGSuccess() throws Exception {
     Configuration testConf = new Configuration();
     DAG dag = new FailingDagBuilder(FailingDagBuilder.Levels.THREE)
@@ -420,7 +438,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testSixLevelsFailingDAGSuccess() throws Exception {
     Configuration testConf = new Configuration();
     DAG dag = new FailingDagBuilder(FailingDagBuilder.Levels.SIX)
@@ -428,7 +447,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testThreeLevelsFailingDAG2VerticesHaveFailedAttemptsDAGSucceeds() throws Exception {
     Configuration testConf = new Configuration();
     //set maximum number of task attempts to 4
@@ -482,7 +502,8 @@ public class TestFaultTolerance {
    * The input version is now 2. The attempt will now succeed.
    * @throws Exception
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testInputFailureCausesRerunAttemptWithinMaxAttemptSuccess() throws Exception {
     Configuration testConf = new Configuration();
     //at v1, task 1 has attempt 0 failing. Attempt 1 succeeds. 1 attempt fails so far.
@@ -578,7 +599,8 @@ public class TestFaultTolerance {
    * AM vertex succeeded order is v1, v2, v1, v2, v3.
    * @throws Exception
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testCascadingInputFailureWithoutExitSuccess() throws Exception {
     Configuration testConf = new Configuration(false);
     setCascadingInputFailureConfig(testConf, false);
@@ -608,7 +630,8 @@ public class TestFaultTolerance {
    * AM vertex succeeded order is v1, v2, v3, v1, v2, v3.
    * @throws Exception
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testCascadingInputFailureWithExitSuccess() throws Exception {
     Configuration testConf = new Configuration(false);
     setCascadingInputFailureConfig(testConf, true);
@@ -635,7 +658,8 @@ public class TestFaultTolerance {
    *
    * @throws Exception
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testInputFailureCausesRerunOfTwoVerticesWithoutExit() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setBoolean(TestInput.getVertexConfName(
@@ -673,7 +697,8 @@ public class TestFaultTolerance {
    *
    * @throws Exception
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testAttemptOfDownstreamVertexConnectedWithTwoUpstreamVerticesFailure() throws Exception {
     Configuration testConf = new Configuration(false);
 
@@ -708,7 +733,8 @@ public class TestFaultTolerance {
    * Also covers multiple consumer vertices report failure against same producer task.
    * @throws Exception
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testInputFailureRerunCanSendOutputToTwoDownstreamVertices() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setBoolean(TestInput.getVertexConfName(
@@ -765,7 +791,8 @@ public class TestFaultTolerance {
    * DAG succeeds with v1 attempt2.
    * @throws Exception
    */
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testTwoTasksHaveInputFailuresSuccess() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setBoolean(TestInput.getVertexConfName(
@@ -796,7 +823,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Test (timeout=240000)
+  @Test
+  @Timeout(value = 240000, unit = TimeUnit.MILLISECONDS)
   public void testRandomFailingTasks() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setBoolean(TestProcessor.TEZ_FAILING_PROCESSOR_DO_RANDOM_FAIL, true);
@@ -806,8 +834,9 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Ignore
-  @Test (timeout=240000)
+  @Disabled
+  @Test
+  @Timeout(value = 240000, unit = TimeUnit.MILLISECONDS)
   public void testRandomFailingInputs() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setBoolean(TestInput.TEZ_FAILING_INPUT_DO_RANDOM_FAIL, true);
@@ -817,7 +846,8 @@ public class TestFaultTolerance {
     runDAGAndVerify(dag, DAGStatus.State.SUCCEEDED);
   }
 
-  @Test (timeout=240000)
+  @Test
+  @Timeout(value = 240000, unit = TimeUnit.MILLISECONDS)
   public void testNoProgress() throws Exception {
     Configuration testConf = new Configuration(false);
     testConf.setInt(SimpleTestDAG.TEZ_SIMPLE_DAG_NUM_TASKS, 1);

--- a/tez-tests/src/test/java/org/apache/tez/test/TestLocalMode.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestLocalMode.java
@@ -18,14 +18,16 @@
  */
 package org.apache.tez.test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -51,16 +53,15 @@ import org.apache.tez.runtime.api.ProcessorContext;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 import org.apache.tez.runtime.library.processor.SleepProcessor;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 
 /**
  * Tests for running Tez in local execution mode (without YARN).
  */
-@RunWith(Parameterized.class)
 public class TestLocalMode {
 
   /**
@@ -75,20 +76,16 @@ public class TestLocalMode {
   private static MiniDFSCluster dfsCluster;
   private static FileSystem remoteFs;
 
-  private final boolean useDfs;
-  private final boolean useLocalModeWithoutNetwork;
-
-  @Parameterized.Parameters(name = "useDFS:{0} useLocalModeWithoutNetwork:{1}")
-  public static Collection<Object[]> params() {
-    return Arrays.asList(new Object[][]{{false, false}, {true, false}, {false, true}, {true, true}});
+  public static Stream<Arguments> params() {
+    return Stream.of(
+        Arguments.of(false, false),
+        Arguments.of(true, false),
+        Arguments.of(false, true),
+        Arguments.of(true, true)
+    );
   }
 
-  public TestLocalMode(boolean useDfs, boolean useLocalModeWithoutNetwork) {
-    this.useDfs = useDfs;
-    this.useLocalModeWithoutNetwork = useLocalModeWithoutNetwork;
-  }
-
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     try {
       Configuration conf = new Configuration();
@@ -101,7 +98,7 @@ public class TestLocalMode {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws InterruptedException {
     if (dfsCluster != null) {
       try {
@@ -112,7 +109,7 @@ public class TestLocalMode {
     }
   }
 
-  private TezConfiguration createConf() {
+  private TezConfiguration createConf(boolean useDfs, boolean useLocalModeWithoutNetwork) {
     TezConfiguration conf = new TezConfiguration();
     conf.setBoolean(TezConfiguration.TEZ_LOCAL_MODE, true);
     conf.setBoolean(TezConfiguration.TEZ_LOCAL_MODE_WITHOUT_NETWORK, useLocalModeWithoutNetwork);
@@ -127,14 +124,16 @@ public class TestLocalMode {
     return conf;
   }
 
-  @Test(timeout = 30000)
-  public void testMultipleClientsWithSession() throws TezException, InterruptedException,
+  @ParameterizedTest(name = "useDFS:{0} useLocalModeWithoutNetwork:{1}")
+  @MethodSource("params")
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+  public void testMultipleClientsWithSession(boolean useDfs, boolean useLocalModeWithoutNetwork) throws TezException, InterruptedException,
       IOException {
-    TezConfiguration tezConf1 = createConf();
+    TezConfiguration tezConf1 = createConf(useDfs, useLocalModeWithoutNetwork);
     TezClient tezClient1 = TezClient.create("commonName", tezConf1, true);
     tezClient1.start();
 
-    DAG dag1 = createSimpleDAG("testMultipleClientsWithSession", SleepProcessor.class.getName());
+    DAG dag1 = createSimpleDAG("testMultipleClientsWithSession", SleepProcessor.class.getName(), useDfs, useLocalModeWithoutNetwork);
 
     DAGClient dagClient1 = tezClient1.submitDAG(dag1);
     dagClient1.waitForCompletion();
@@ -145,8 +144,8 @@ public class TestLocalMode {
     dagClient1.close();
     tezClient1.stop();
 
-    TezConfiguration tezConf2 = createConf();
-    DAG dag2 = createSimpleDAG("testMultipleClientsWithSession_2", SleepProcessor.class.getName());
+    TezConfiguration tezConf2 = createConf(useDfs, useLocalModeWithoutNetwork);
+    DAG dag2 = createSimpleDAG("testMultipleClientsWithSession_2", SleepProcessor.class.getName(), useDfs, useLocalModeWithoutNetwork);
     TezClient tezClient2 = TezClient.create("commonName", tezConf2, true);
     tezClient2.start();
     DAGClient dagClient2 = tezClient2.submitDAG(dag2);
@@ -154,19 +153,21 @@ public class TestLocalMode {
     assertEquals(DAGStatus.State.SUCCEEDED, dagClient2.getDAGStatus(null).getState());
     assertEquals(VertexStatus.State.SUCCEEDED,
         dagClient2.getVertexStatus(SleepProcessor.SLEEP_VERTEX_NAME, null).getState());
-    assertFalse(dagClient1.getExecutionContext().equals(dagClient2.getExecutionContext()));
+    assertNotEquals(dagClient1.getExecutionContext(), dagClient2.getExecutionContext());
     dagClient2.close();
     tezClient2.stop();
   }
 
-  @Test(timeout = 10000)
-  public void testMultipleClientsWithoutSession() throws TezException, InterruptedException,
+  @ParameterizedTest(name = "useDFS:{0} useLocalModeWithoutNetwork:{1}")
+  @MethodSource("params")
+  @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
+  public void testMultipleClientsWithoutSession(boolean useDfs, boolean useLocalModeWithoutNetwork) throws TezException, InterruptedException,
       IOException {
-    TezConfiguration tezConf1 = createConf();
+    TezConfiguration tezConf1 = createConf(useDfs, useLocalModeWithoutNetwork);
     TezClient tezClient1 = TezClient.create("commonName", tezConf1, false);
     tezClient1.start();
 
-    DAG dag1 = createSimpleDAG("testMultipleClientsWithoutSession", SleepProcessor.class.getName());
+    DAG dag1 = createSimpleDAG("testMultipleClientsWithoutSession", SleepProcessor.class.getName(), useDfs, useLocalModeWithoutNetwork);
 
     DAGClient dagClient1 = tezClient1.submitDAG(dag1);
     dagClient1.waitForCompletion();
@@ -177,8 +178,8 @@ public class TestLocalMode {
     tezClient1.stop();
 
 
-    TezConfiguration tezConf2 = createConf();
-    DAG dag2 = createSimpleDAG("testMultipleClientsWithoutSession_2", SleepProcessor.class.getName());
+    TezConfiguration tezConf2 = createConf(useDfs, useLocalModeWithoutNetwork);
+    DAG dag2 = createSimpleDAG("testMultipleClientsWithoutSession_2", SleepProcessor.class.getName(), useDfs, useLocalModeWithoutNetwork);
     TezClient tezClient2 = TezClient.create("commonName", tezConf2, false);
     tezClient2.start();
     DAGClient dagClient2 = tezClient2.submitDAG(dag2);
@@ -186,20 +187,22 @@ public class TestLocalMode {
     assertEquals(DAGStatus.State.SUCCEEDED, dagClient2.getDAGStatus(null).getState());
     assertEquals(VertexStatus.State.SUCCEEDED,
         dagClient2.getVertexStatus(SleepProcessor.SLEEP_VERTEX_NAME, null).getState());
-    assertFalse(dagClient1.getExecutionContext().equals(dagClient2.getExecutionContext()));
+    assertNotEquals(dagClient1.getExecutionContext(), dagClient2.getExecutionContext());
     dagClient2.close();
     tezClient2.stop();
   }
 
-  @Test(timeout = 20000)
-  public void testNoSysExitOnSuccessfulDAG() throws TezException, InterruptedException,
+  @ParameterizedTest(name = "useDFS:{0} useLocalModeWithoutNetwork:{1}")
+  @MethodSource("params")
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
+  public void testNoSysExitOnSuccessfulDAG(boolean useDfs, boolean useLocalModeWithoutNetwork) throws TezException, InterruptedException,
       IOException {
-    TezConfiguration tezConf1 = createConf();
+    TezConfiguration tezConf1 = createConf(useDfs, useLocalModeWithoutNetwork);
     // Run in non-session mode so that the AM terminates
     TezClient tezClient1 = TezClient.create("commonName", tezConf1, false);
     tezClient1.start();
 
-    DAG dag1 = createSimpleDAG("testNoSysExitOnSuccessfulDAG", SleepProcessor.class.getName());
+    DAG dag1 = createSimpleDAG("testNoSysExitOnSuccessfulDAG", SleepProcessor.class.getName(), useDfs, useLocalModeWithoutNetwork);
 
     DAGClient dagClient1 = tezClient1.submitDAG(dag1);
     dagClient1.waitForCompletion();
@@ -213,15 +216,17 @@ public class TestLocalMode {
     tezClient1.stop();
   }
 
-  @Test(timeout = 20000)
-  public void testNoSysExitOnFailingDAG() throws TezException, InterruptedException,
+  @ParameterizedTest(name = "useDFS:{0} useLocalModeWithoutNetwork:{1}")
+  @MethodSource("params")
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
+  public void testNoSysExitOnFailingDAG(boolean useDfs, boolean useLocalModeWithoutNetwork) throws TezException, InterruptedException,
       IOException {
-    TezConfiguration tezConf1 = createConf();
+    TezConfiguration tezConf1 = createConf(useDfs, useLocalModeWithoutNetwork);
     // Run in non-session mode so that the AM terminates
     TezClient tezClient1 = TezClient.create("commonName", tezConf1, false);
     tezClient1.start();
 
-    DAG dag1 = createSimpleDAG("testNoSysExitOnFailingDAG", FailingProcessor.class.getName());
+    DAG dag1 = createSimpleDAG("testNoSysExitOnFailingDAG", FailingProcessor.class.getName(), useDfs, useLocalModeWithoutNetwork);
 
     DAGClient dagClient1 = tezClient1.submitDAG(dag1);
     dagClient1.waitForCompletion();
@@ -261,24 +266,26 @@ public class TestLocalMode {
     }
   }
 
-  private DAG createSimpleDAG(String dagName, String processorName) {
-    DAG dag = DAG.create(generateDagName("DAG-" + dagName)).addVertex(
+  private DAG createSimpleDAG(String dagName, String processorName, boolean useDfs, boolean useLocalModeWithoutNetwork) {
+    DAG dag = DAG.create(generateDagName("DAG-" + dagName, useDfs, useLocalModeWithoutNetwork)).addVertex(
         Vertex.create(SleepProcessor.SLEEP_VERTEX_NAME, ProcessorDescriptor.create(processorName).setUserPayload(
             new SleepProcessor.SleepProcessorConfig(SLEEP_PROCESSOR_TIME_TO_SLEEP_MS).toUserPayload()), 1));
     return dag;
   }
-  private String generateDagName(String baseName) {
+  private String generateDagName(String baseName, boolean useDfs, boolean useLocalModeWithoutNetwork) {
     return baseName + (useDfs ? "_useDfs" : "") + (useLocalModeWithoutNetwork ? "_useLocalModeWithoutNetwork" : "");
   }
 
-  @Test(timeout=30000)
-  public void testMultiDAGsOnSession() throws IOException, TezException, InterruptedException {
+  @ParameterizedTest(name = "useDFS:{0} useLocalModeWithoutNetwork:{1}")
+  @MethodSource("params")
+  @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+  public void testMultiDAGsOnSession(boolean useDfs, boolean useLocalModeWithoutNetwork) throws IOException, TezException, InterruptedException {
     int dags = 2;//two dags will be submitted to session
     String[] inputPaths = new String[dags];
     String[] outputPaths =  new String[dags];
     DAGClient[] dagClients = new DAGClient[dags];
 
-    TezConfiguration tezConf = createConf();
+    TezConfiguration tezConf = createConf(useDfs, useLocalModeWithoutNetwork);
     TezClient tezClient = TezClient.create("testMultiDAGOnSession", tezConf, true);
     tezClient.start();
 
@@ -308,7 +315,8 @@ public class TestLocalMode {
         }
         //verify all dags sharing the same execution context
         if(i>0) {
-          assertTrue(dagClients[i-1].getExecutionContext().equals(dagClients[i].getExecutionContext()));
+          assertEquals(dagClients[i - 1].getExecutionContext(),
+              dagClients[i].getExecutionContext());
         }
       }
     } finally {

--- a/tez-tests/src/test/java/org/apache/tez/test/TestLocalMode.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestLocalMode.java
@@ -56,8 +56,9 @@ import org.apache.tez.runtime.library.processor.SleepProcessor;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.*;
-import org.junit.jupiter.params.provider.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for running Tez in local execution mode (without YARN).
@@ -77,12 +78,8 @@ public class TestLocalMode {
   private static FileSystem remoteFs;
 
   public static Stream<Arguments> params() {
-    return Stream.of(
-        Arguments.of(false, false),
-        Arguments.of(true, false),
-        Arguments.of(false, true),
-        Arguments.of(true, true)
-    );
+    return Stream.of(Arguments.of(false, false), Arguments.of(true, false), Arguments.of(false, true),
+        Arguments.of(true, true));
   }
 
   @BeforeAll
@@ -127,13 +124,14 @@ public class TestLocalMode {
   @ParameterizedTest(name = "useDFS:{0} useLocalModeWithoutNetwork:{1}")
   @MethodSource("params")
   @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
-  public void testMultipleClientsWithSession(boolean useDfs, boolean useLocalModeWithoutNetwork) throws TezException, InterruptedException,
-      IOException {
+  public void testMultipleClientsWithSession(boolean useDfs, boolean useLocalModeWithoutNetwork)
+      throws TezException, InterruptedException, IOException {
     TezConfiguration tezConf1 = createConf(useDfs, useLocalModeWithoutNetwork);
     TezClient tezClient1 = TezClient.create("commonName", tezConf1, true);
     tezClient1.start();
 
-    DAG dag1 = createSimpleDAG("testMultipleClientsWithSession", SleepProcessor.class.getName(), useDfs, useLocalModeWithoutNetwork);
+    DAG dag1 = createSimpleDAG("testMultipleClientsWithSession", SleepProcessor.class.getName(), useDfs,
+        useLocalModeWithoutNetwork);
 
     DAGClient dagClient1 = tezClient1.submitDAG(dag1);
     dagClient1.waitForCompletion();
@@ -145,7 +143,8 @@ public class TestLocalMode {
     tezClient1.stop();
 
     TezConfiguration tezConf2 = createConf(useDfs, useLocalModeWithoutNetwork);
-    DAG dag2 = createSimpleDAG("testMultipleClientsWithSession_2", SleepProcessor.class.getName(), useDfs, useLocalModeWithoutNetwork);
+    DAG dag2 = createSimpleDAG("testMultipleClientsWithSession_2", SleepProcessor.class.getName(), useDfs,
+        useLocalModeWithoutNetwork);
     TezClient tezClient2 = TezClient.create("commonName", tezConf2, true);
     tezClient2.start();
     DAGClient dagClient2 = tezClient2.submitDAG(dag2);
@@ -161,13 +160,14 @@ public class TestLocalMode {
   @ParameterizedTest(name = "useDFS:{0} useLocalModeWithoutNetwork:{1}")
   @MethodSource("params")
   @Timeout(value = 10000, unit = TimeUnit.MILLISECONDS)
-  public void testMultipleClientsWithoutSession(boolean useDfs, boolean useLocalModeWithoutNetwork) throws TezException, InterruptedException,
-      IOException {
+  public void testMultipleClientsWithoutSession(boolean useDfs, boolean useLocalModeWithoutNetwork)
+      throws TezException, InterruptedException, IOException {
     TezConfiguration tezConf1 = createConf(useDfs, useLocalModeWithoutNetwork);
     TezClient tezClient1 = TezClient.create("commonName", tezConf1, false);
     tezClient1.start();
 
-    DAG dag1 = createSimpleDAG("testMultipleClientsWithoutSession", SleepProcessor.class.getName(), useDfs, useLocalModeWithoutNetwork);
+    DAG dag1 = createSimpleDAG("testMultipleClientsWithoutSession", SleepProcessor.class.getName(), useDfs,
+        useLocalModeWithoutNetwork);
 
     DAGClient dagClient1 = tezClient1.submitDAG(dag1);
     dagClient1.waitForCompletion();
@@ -179,7 +179,8 @@ public class TestLocalMode {
 
 
     TezConfiguration tezConf2 = createConf(useDfs, useLocalModeWithoutNetwork);
-    DAG dag2 = createSimpleDAG("testMultipleClientsWithoutSession_2", SleepProcessor.class.getName(), useDfs, useLocalModeWithoutNetwork);
+    DAG dag2 = createSimpleDAG("testMultipleClientsWithoutSession_2", SleepProcessor.class.getName(), useDfs,
+        useLocalModeWithoutNetwork);
     TezClient tezClient2 = TezClient.create("commonName", tezConf2, false);
     tezClient2.start();
     DAGClient dagClient2 = tezClient2.submitDAG(dag2);
@@ -195,14 +196,15 @@ public class TestLocalMode {
   @ParameterizedTest(name = "useDFS:{0} useLocalModeWithoutNetwork:{1}")
   @MethodSource("params")
   @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
-  public void testNoSysExitOnSuccessfulDAG(boolean useDfs, boolean useLocalModeWithoutNetwork) throws TezException, InterruptedException,
-      IOException {
+  public void testNoSysExitOnSuccessfulDAG(boolean useDfs, boolean useLocalModeWithoutNetwork)
+      throws TezException, InterruptedException, IOException {
     TezConfiguration tezConf1 = createConf(useDfs, useLocalModeWithoutNetwork);
     // Run in non-session mode so that the AM terminates
     TezClient tezClient1 = TezClient.create("commonName", tezConf1, false);
     tezClient1.start();
 
-    DAG dag1 = createSimpleDAG("testNoSysExitOnSuccessfulDAG", SleepProcessor.class.getName(), useDfs, useLocalModeWithoutNetwork);
+    DAG dag1 = createSimpleDAG("testNoSysExitOnSuccessfulDAG", SleepProcessor.class.getName(), useDfs,
+        useLocalModeWithoutNetwork);
 
     DAGClient dagClient1 = tezClient1.submitDAG(dag1);
     dagClient1.waitForCompletion();
@@ -219,14 +221,15 @@ public class TestLocalMode {
   @ParameterizedTest(name = "useDFS:{0} useLocalModeWithoutNetwork:{1}")
   @MethodSource("params")
   @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
-  public void testNoSysExitOnFailingDAG(boolean useDfs, boolean useLocalModeWithoutNetwork) throws TezException, InterruptedException,
-      IOException {
+  public void testNoSysExitOnFailingDAG(boolean useDfs, boolean useLocalModeWithoutNetwork)
+      throws TezException, InterruptedException, IOException {
     TezConfiguration tezConf1 = createConf(useDfs, useLocalModeWithoutNetwork);
     // Run in non-session mode so that the AM terminates
     TezClient tezClient1 = TezClient.create("commonName", tezConf1, false);
     tezClient1.start();
 
-    DAG dag1 = createSimpleDAG("testNoSysExitOnFailingDAG", FailingProcessor.class.getName(), useDfs, useLocalModeWithoutNetwork);
+    DAG dag1 = createSimpleDAG("testNoSysExitOnFailingDAG", FailingProcessor.class.getName(), useDfs,
+        useLocalModeWithoutNetwork);
 
     DAGClient dagClient1 = tezClient1.submitDAG(dag1);
     dagClient1.waitForCompletion();
@@ -266,10 +269,12 @@ public class TestLocalMode {
     }
   }
 
-  private DAG createSimpleDAG(String dagName, String processorName, boolean useDfs, boolean useLocalModeWithoutNetwork) {
+  private DAG createSimpleDAG(String dagName, String processorName, boolean useDfs,
+                              boolean useLocalModeWithoutNetwork) {
     DAG dag = DAG.create(generateDagName("DAG-" + dagName, useDfs, useLocalModeWithoutNetwork)).addVertex(
-        Vertex.create(SleepProcessor.SLEEP_VERTEX_NAME, ProcessorDescriptor.create(processorName).setUserPayload(
-            new SleepProcessor.SleepProcessorConfig(SLEEP_PROCESSOR_TIME_TO_SLEEP_MS).toUserPayload()), 1));
+        Vertex.create(SleepProcessor.SLEEP_VERTEX_NAME, ProcessorDescriptor.create(processorName)
+                .setUserPayload(new SleepProcessor.SleepProcessorConfig(SLEEP_PROCESSOR_TIME_TO_SLEEP_MS).toUserPayload()),
+            1));
     return dag;
   }
   private String generateDagName(String baseName, boolean useDfs, boolean useLocalModeWithoutNetwork) {
@@ -279,10 +284,11 @@ public class TestLocalMode {
   @ParameterizedTest(name = "useDFS:{0} useLocalModeWithoutNetwork:{1}")
   @MethodSource("params")
   @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
-  public void testMultiDAGsOnSession(boolean useDfs, boolean useLocalModeWithoutNetwork) throws IOException, TezException, InterruptedException {
+  public void testMultiDAGsOnSession(boolean useDfs, boolean useLocalModeWithoutNetwork)
+      throws IOException, TezException, InterruptedException {
     int dags = 2;//two dags will be submitted to session
     String[] inputPaths = new String[dags];
-    String[] outputPaths =  new String[dags];
+    String[] outputPaths = new String[dags];
     DAGClient[] dagClients = new DAGClient[dags];
 
     TezConfiguration tezConf = createConf(useDfs, useLocalModeWithoutNetwork);
@@ -314,9 +320,8 @@ public class TestLocalMode {
               + dagStatus.getDiagnostics());
         }
         //verify all dags sharing the same execution context
-        if(i>0) {
-          assertEquals(dagClients[i - 1].getExecutionContext(),
-              dagClients[i].getExecutionContext());
+        if (i > 0) {
+          assertEquals(dagClients[i - 1].getExecutionContext(), dagClients[i].getExecutionContext());
         }
       }
     } finally {

--- a/tez-tests/src/test/java/org/apache/tez/test/TestMiniTezCluster.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestMiniTezCluster.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 
 import org.junit.jupiter.api.Test;
 
-
 public class TestMiniTezCluster {
 
   @Test
@@ -37,8 +36,8 @@ public class TestMiniTezCluster {
     tezMiniCluster.start();
 
     // overrides if not set
-    assertEquals(99.0, tezMiniCluster.getConfig()
-        .getFloat(YarnConfiguration.NM_MAX_PER_DISK_UTILIZATION_PERCENTAGE, -1), 0.00001);
+    assertEquals(99.0,
+        tezMiniCluster.getConfig().getFloat(YarnConfiguration.NM_MAX_PER_DISK_UTILIZATION_PERCENTAGE, -1), 0.00001);
 
     tezMiniCluster.close();
 
@@ -49,8 +48,8 @@ public class TestMiniTezCluster {
     tezMiniCluster.start();
 
     // respects provided non-default value
-    assertEquals(50.0, tezMiniCluster.getConfig()
-        .getFloat(YarnConfiguration.NM_MAX_PER_DISK_UTILIZATION_PERCENTAGE, -1), 0.00001);
+    assertEquals(50.0,
+        tezMiniCluster.getConfig().getFloat(YarnConfiguration.NM_MAX_PER_DISK_UTILIZATION_PERCENTAGE, -1), 0.00001);
 
     tezMiniCluster.close();
   }

--- a/tez-tests/src/test/java/org/apache/tez/test/TestMiniTezCluster.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestMiniTezCluster.java
@@ -18,13 +18,15 @@
  */
 package org.apache.tez.test;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
 
 public class TestMiniTezCluster {
 
@@ -35,7 +37,7 @@ public class TestMiniTezCluster {
     tezMiniCluster.start();
 
     // overrides if not set
-    Assert.assertEquals(99.0, tezMiniCluster.getConfig()
+    assertEquals(99.0, tezMiniCluster.getConfig()
         .getFloat(YarnConfiguration.NM_MAX_PER_DISK_UTILIZATION_PERCENTAGE, -1), 0.00001);
 
     tezMiniCluster.close();
@@ -47,7 +49,7 @@ public class TestMiniTezCluster {
     tezMiniCluster.start();
 
     // respects provided non-default value
-    Assert.assertEquals(50.0, tezMiniCluster.getConfig()
+    assertEquals(50.0, tezMiniCluster.getConfig()
         .getFloat(YarnConfiguration.NM_MAX_PER_DISK_UTILIZATION_PERCENTAGE, -1), 0.00001);
 
     tezMiniCluster.close();

--- a/tez-tests/src/test/java/org/apache/tez/test/TestPipelinedShuffle.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestPipelinedShuffle.java
@@ -18,8 +18,8 @@
  */
 package org.apache.tez.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.Set;
@@ -56,11 +56,9 @@ import org.apache.tez.runtime.library.partitioner.HashPartitioner;
 
 import com.google.common.collect.Sets;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestPipelinedShuffle {
 
@@ -75,7 +73,7 @@ public class TestPipelinedShuffle {
 
   private static final int KEYS_PER_MAPPER = 5000;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupDFSCluster() throws Exception {
     conf = new Configuration();
     conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_EDITS_NOEDITLOGCHANNELFLUSH, false);
@@ -88,7 +86,7 @@ public class TestPipelinedShuffle {
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_OPTIMIZE_LOCAL_FETCH, false);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdownDFSCluster() {
     if (miniDFSCluster != null) {
       //shutdown
@@ -97,8 +95,8 @@ public class TestPipelinedShuffle {
   }
 
   //TODO: Add support for async http clients
-  @Before
-  public void setupTezCluster() throws Exception {
+  @BeforeAll
+  public static void setupTezCluster() {
     //With 1 MB sort buffer and with good amount of dataset, it would spill records
     conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 1);
 
@@ -122,8 +120,8 @@ public class TestPipelinedShuffle {
     miniTezCluster.start();
   }
 
-  @After
-  public void shutdownTezCluster() throws IOException {
+  @AfterAll
+  public static void shutdownTezCluster() {
     if (miniTezCluster != null) {
       miniTezCluster.stop();
     }

--- a/tez-tests/src/test/java/org/apache/tez/test/TestRecovery.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestRecovery.java
@@ -18,8 +18,8 @@
  */
 package org.apache.tez.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
@@ -81,10 +82,11 @@ import org.apache.tez.test.RecoveryServiceWithEventHandlingHook.SimpleShutdownCo
 
 import com.google.common.collect.Lists;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,7 +101,7 @@ public class TestRecovery {
   private static MiniDFSCluster dfsCluster = null;
   private static FileSystem remoteFs = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() throws Exception {
     LOG.info("Starting mini clusters");
     try {
@@ -121,7 +123,7 @@ public class TestRecovery {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterClass() throws InterruptedException {
     if (miniTezCluster != null) {
       try {
@@ -141,7 +143,8 @@ public class TestRecovery {
     }
   }
 
-  @Test(timeout=1800000)
+  @Test
+  @Timeout(value = 1800000, unit = TimeUnit.MILLISECONDS)
   public void testRecovery_OrderedWordCount() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(),
         1);
@@ -285,13 +288,14 @@ public class TestRecovery {
     tezConf.set(TezConfiguration.TEZ_AM_LOG_LEVEL, "INFO;org.apache.tez=DEBUG");
     OrderedWordCount job = new OrderedWordCount();
     if (generateSplitInClient) {
-      Assert
-          .assertTrue("OrderedWordCount failed", job.run(tezConf, new String[]{
-              "-generateSplitInClient", inputDirStr, outputDirStr, "5"}, null) == 0);
+
+          assertEquals(0, job.run(tezConf, new String[]{
+                  "-generateSplitInClient", inputDirStr, outputDirStr, "5"}, null),
+              "OrderedWordCount failed");
     } else {
-      Assert
-          .assertTrue("OrderedWordCount failed", job.run(tezConf, new String[]{
-              inputDirStr, outputDirStr, "5"}, null) == 0);
+
+          assertEquals(0, job.run(tezConf, new String[]{
+              inputDirStr, outputDirStr, "5"}, null), "OrderedWordCount failed");
     }
     TestTezJobs.verifyOutput(outputDir, remoteFs);
     List<HistoryEvent> historyEventsOfAttempt1 = RecoveryParser
@@ -343,18 +347,20 @@ public class TestRecovery {
             TezConfiguration.TEZ_AM_STAGING_SCRATCH_DATA_AUTO_DELETE, false);
     OrderedWordCount job = new OrderedWordCount();
     if (generateSplitInClient) {
-      Assert
-              .assertTrue("OrderedWordCount failed", job.run(tezConf, new String[]{
-                      "-generateSplitInClient", inputDirStr, outputDirStr, "5"}, null) == 0);
+
+             Assertions.assertEquals(0, job.run(tezConf, new String[]{
+                     "-generateSplitInClient", inputDirStr, outputDirStr, "5"}, null),
+                 "OrderedWordCount failed");
     } else {
-      Assert
-              .assertTrue("OrderedWordCount failed", job.run(tezConf, new String[]{
-                      inputDirStr, outputDirStr, "5"}, null) == 0);
+
+              Assertions.assertEquals(0, job.run(tezConf, new String[]{
+                  inputDirStr, outputDirStr, "5"}, null), "OrderedWordCount failed");
     }
     TestTezJobs.verifyOutput(outputDir, remoteFs);
   }
 
-  @Test(timeout = 1800000)
+  @Test
+  @Timeout(value = 1800000, unit = TimeUnit.MILLISECONDS)
   public void testRecovery_HashJoin() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(),
         1);
@@ -557,7 +563,8 @@ public class TestRecovery {
     assertTrue(shutdownCondition.match(lastEvent));
   }
 
-  @Test(timeout = 1800000)
+  @Test
+  @Timeout(value = 1800000, unit = TimeUnit.MILLISECONDS)
   public void testTwoRoundsRecoverying() throws Exception {
     ApplicationId appId = ApplicationId.newInstance(System.currentTimeMillis(),
             1);

--- a/tez-tests/src/test/java/org/apache/tez/test/TestRecovery.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestRecovery.java
@@ -288,14 +288,10 @@ public class TestRecovery {
     tezConf.set(TezConfiguration.TEZ_AM_LOG_LEVEL, "INFO;org.apache.tez=DEBUG");
     OrderedWordCount job = new OrderedWordCount();
     if (generateSplitInClient) {
-
-          assertEquals(0, job.run(tezConf, new String[]{
-                  "-generateSplitInClient", inputDirStr, outputDirStr, "5"}, null),
-              "OrderedWordCount failed");
+      assertEquals(0, job.run(tezConf, new String[]{"-generateSplitInClient", inputDirStr, outputDirStr, "5"}, null),
+          "OrderedWordCount failed");
     } else {
-
-          assertEquals(0, job.run(tezConf, new String[]{
-              inputDirStr, outputDirStr, "5"}, null), "OrderedWordCount failed");
+      assertEquals(0, job.run(tezConf, new String[]{inputDirStr, outputDirStr, "5"}, null), "OrderedWordCount failed");
     }
     TestTezJobs.verifyOutput(outputDir, remoteFs);
     List<HistoryEvent> historyEventsOfAttempt1 = RecoveryParser
@@ -347,14 +343,12 @@ public class TestRecovery {
             TezConfiguration.TEZ_AM_STAGING_SCRATCH_DATA_AUTO_DELETE, false);
     OrderedWordCount job = new OrderedWordCount();
     if (generateSplitInClient) {
-
-             Assertions.assertEquals(0, job.run(tezConf, new String[]{
-                     "-generateSplitInClient", inputDirStr, outputDirStr, "5"}, null),
-                 "OrderedWordCount failed");
+      Assertions.assertEquals(0,
+          job.run(tezConf, new String[]{"-generateSplitInClient", inputDirStr, outputDirStr, "5"}, null),
+          "OrderedWordCount failed");
     } else {
-
-              Assertions.assertEquals(0, job.run(tezConf, new String[]{
-                  inputDirStr, outputDirStr, "5"}, null), "OrderedWordCount failed");
+      Assertions.assertEquals(0, job.run(tezConf, new String[]{inputDirStr, outputDirStr, "5"}, null),
+          "OrderedWordCount failed");
     }
     TestTezJobs.verifyOutput(outputDir, remoteFs);
   }

--- a/tez-tests/src/test/java/org/apache/tez/test/TestSecureShuffle.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestSecureShuffle.java
@@ -19,7 +19,7 @@
 package org.apache.tez.test;
 
 import static org.apache.hadoop.security.ssl.SSLFactory.SSL_CLIENT_CONF_KEY;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -30,11 +30,11 @@ import java.net.InetAddress;
 import java.security.KeyPair;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -56,18 +56,16 @@ import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.X509Extensions;
 import org.bouncycastle.x509.X509V3CertificateGenerator;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.*;
+import org.junit.jupiter.params.provider.*;
 
 /**
  * Test to verify secure-shuffle (SSL mode) in Tez
  */
-@RunWith(Parameterized.class)
 public class TestSecureShuffle {
 
   private static MiniDFSCluster miniDFSCluster;
@@ -80,38 +78,19 @@ public class TestSecureShuffle {
       + TestSecureShuffle.class.getName() + "-tmpDir";
   private static File keysStoresDir = new File(TEST_ROOT_DIR, "keystores");
 
-  private boolean enableSSLInCluster; //To set ssl config in cluster
-  private int resultWithTezSSL; //expected result with tez ssl setting
-  private int resultWithoutTezSSL; //expected result without tez ssl setting
-  private boolean asyncHttp;
-
-  public TestSecureShuffle(boolean sslInCluster, int resultWithTezSSL, int resultWithoutTezSSL,
-      boolean asyncHttp) {
-    this.enableSSLInCluster = sslInCluster;
-    this.resultWithTezSSL = resultWithTezSSL;
-    this.resultWithoutTezSSL = resultWithoutTezSSL;
-    this.asyncHttp = asyncHttp;
+  public static Stream<Arguments> getParameters() {
+    return Stream.of(
+        // enable ssl in cluster, succeed with tez-ssl enabled, fail with tez-ssl disabled
+        Arguments.of(true, 0, 1, false),
+        // With asyncHttp
+        Arguments.of(true, 0, 1, true),
+        Arguments.of(false, 1, 0, true),
+        // Negative testcase
+        // disable ssl in cluster, fail with tez-ssl enabled, succeed with tez-ssl disabled
+        Arguments.of(false, 1, 0, false));
   }
 
-  @Parameterized.Parameters(name = "test[sslInCluster:{0}, resultWithTezSSL:{1}, "
-      + "resultWithoutTezSSL:{2}, asyncHttp:{3}]")
-  public static Collection<Object[]> getParameters() {
-    Collection<Object[]> parameters = new ArrayList<Object[]>();
-    //enable ssl in cluster, succeed with tez-ssl enabled, fail with tez-ssl disabled
-    parameters.add(new Object[] { true, 0, 1, false });
-
-    //With asyncHttp
-    parameters.add(new Object[] { true, 0, 1, true });
-    parameters.add(new Object[] { false, 1, 0, true });
-
-    //Negative testcase
-    //disable ssl in cluster, fail with tez-ssl enabled, succeed with tez-ssl disabled
-    parameters.add(new Object[] { false, 1, 0, false });
-
-    return parameters;
-  }
-
-  @BeforeClass
+  @BeforeAll
   public static void setupDFSCluster() throws Exception {
     conf = new Configuration();
     conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_EDITS_NOEDITLOGCHANNELFLUSH, false);
@@ -125,7 +104,7 @@ public class TestSecureShuffle {
     conf.setBoolean(TezRuntimeConfiguration.TEZ_RUNTIME_OPTIMIZE_LOCAL_FETCH, false);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdownDFSCluster() {
     if (miniDFSCluster != null) {
       //shutdown
@@ -133,8 +112,7 @@ public class TestSecureShuffle {
     }
   }
 
-  @Before
-  public void setupTezCluster() throws Exception {
+  public void setupTezCluster(boolean enableSSLInCluster, boolean asyncHttp) throws Exception {
     if (enableSSLInCluster) {
       // Enable SSL debugging
       System.setProperty("javax.net.debug", "all");
@@ -163,10 +141,11 @@ public class TestSecureShuffle {
     createSampleFile(inputLoc);
   }
 
-  @After
+  @AfterEach
   public void shutdownTezCluster() throws IOException {
     if (miniTezCluster != null) {
       miniTezCluster.stop();
+      miniTezCluster = null;
     }
   }
 
@@ -180,22 +159,23 @@ public class TestSecureShuffle {
     assertEquals(expectedResult, wordCount.run(args));
   }
 
-  /**
-   * Verify whether shuffle works in mini cluster
-   *
-   * @throws Exception
-   */
-  @Test(timeout = 500000)
-  public void testSecureShuffle() throws Exception {
+  @ParameterizedTest(name = "test[sslInCluster:{0}, resultWithTezSSL:{1}, "
+      + "resultWithoutTezSSL:{2}, asyncHttp:{3}]")
+  @MethodSource("getParameters")
+  @Timeout(value = 500000, unit = TimeUnit.MILLISECONDS)
+  public void testSecureShuffle(
+      boolean sslInCluster, int resultWithTezSSL, int resultWithoutTezSSL, boolean asyncHttp)
+      throws Exception {
+    setupTezCluster(sslInCluster, asyncHttp);
     //With tez-ssl setting
     miniTezCluster.getConfig().setBoolean(
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_SSL, true);
-    baseTest(this.resultWithTezSSL);
+    baseTest(resultWithTezSSL);
 
     //Without tez-ssl setting
     miniTezCluster.getConfig().setBoolean(
         TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_ENABLE_SSL, false);
-    baseTest(this.resultWithoutTezSSL);
+    baseTest(resultWithoutTezSSL);
   }
 
   /**

--- a/tez-tests/src/test/java/org/apache/tez/test/TestSecureShuffle.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestSecureShuffle.java
@@ -60,8 +60,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Timeout;
-import org.junit.jupiter.params.*;
-import org.junit.jupiter.params.provider.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test to verify secure-shuffle (SSL mode) in Tez
@@ -83,8 +84,7 @@ public class TestSecureShuffle {
         // enable ssl in cluster, succeed with tez-ssl enabled, fail with tez-ssl disabled
         Arguments.of(true, 0, 1, false),
         // With asyncHttp
-        Arguments.of(true, 0, 1, true),
-        Arguments.of(false, 1, 0, true),
+        Arguments.of(true, 0, 1, true), Arguments.of(false, 1, 0, true),
         // Negative testcase
         // disable ssl in cluster, fail with tez-ssl enabled, succeed with tez-ssl disabled
         Arguments.of(false, 1, 0, false));
@@ -159,12 +159,10 @@ public class TestSecureShuffle {
     assertEquals(expectedResult, wordCount.run(args));
   }
 
-  @ParameterizedTest(name = "test[sslInCluster:{0}, resultWithTezSSL:{1}, "
-      + "resultWithoutTezSSL:{2}, asyncHttp:{3}]")
+  @ParameterizedTest(name = "test[sslInCluster:{0}, resultWithTezSSL:{1}, " + "resultWithoutTezSSL:{2}, asyncHttp:{3}]")
   @MethodSource("getParameters")
   @Timeout(value = 500000, unit = TimeUnit.MILLISECONDS)
-  public void testSecureShuffle(
-      boolean sslInCluster, int resultWithTezSSL, int resultWithoutTezSSL, boolean asyncHttp)
+  public void testSecureShuffle(boolean sslInCluster, int resultWithTezSSL, int resultWithoutTezSSL, boolean asyncHttp)
       throws Exception {
     setupTezCluster(sslInCluster, asyncHttp);
     //With tez-ssl setting

--- a/tez-tests/src/test/java/org/apache/tez/test/TestTaskErrorsUsingLocalMode.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestTaskErrorsUsingLocalMode.java
@@ -18,12 +18,13 @@
  */
 package org.apache.tez.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.tez.client.TezClient;
 import org.apache.tez.dag.api.DAG;
@@ -41,7 +42,8 @@ import org.apache.tez.runtime.api.ProcessorContext;
 import org.apache.tez.runtime.api.TaskFailureType;
 import org.apache.tez.runtime.library.api.TezRuntimeConfiguration;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +56,8 @@ public class TestTaskErrorsUsingLocalMode {
       TestTaskErrorsUsingLocalMode.class.getName()).getAbsoluteFile();
 
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testFatalErrorReported() throws IOException, TezException, InterruptedException {
 
     TezClient tezClient = getTezClient("testFatalErrorReported");
@@ -78,7 +81,8 @@ public class TestTaskErrorsUsingLocalMode {
     }
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testNonFatalErrorReported() throws IOException, TezException, InterruptedException {
 
     TezClient tezClient = getTezClient("testNonFatalErrorReported");
@@ -102,7 +106,8 @@ public class TestTaskErrorsUsingLocalMode {
     }
   }
 
-  @Test(timeout = 20000)
+  @Test
+  @Timeout(value = 20000, unit = TimeUnit.MILLISECONDS)
   public void testSelfKillReported() throws IOException, TezException, InterruptedException {
 
     TezClient tezClient = getTezClient("testSelfKillReported");

--- a/tez-tests/src/test/java/org/apache/tez/test/TestTezJobs.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestTezJobs.java
@@ -117,7 +117,6 @@ import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Tests for Tez example jobs
  *
@@ -524,7 +523,8 @@ public class TestTezJobs {
       assertNotNull(input1Counter, "input1 counter cannot be null " + c.name());
       assertNotNull(input2Counter, "input2 counter cannot be null " + c.name());
 
-      assertEquals(aggregatedCounter.getValue(), input1Counter.getValue() + input2Counter.getValue(), "aggregated counter does not match sum of input counters " + c.name());
+      assertEquals(aggregatedCounter.getValue(), input1Counter.getValue() + input2Counter.getValue(),
+          "aggregated counter does not match sum of input counters " + c.name());
 
       if (aggregatedCounter.getValue() > 0) {
         nonZeroCounters++;
@@ -542,7 +542,8 @@ public class TestTezJobs {
     assertNotNull(aggregateCounter, "aggregated counter cannot be null " + outputCounterName);
     assertNotNull(joinerOutputCounter, "output counter cannot be null " + outputCounterName);
     assertTrue(aggregateCounter.getValue() > 0, "counter value is zero. test is invalid");
-    assertEquals(aggregateCounter.getValue(), joinerOutputCounter.getValue(), "aggregated counter does not match sum of output counters " + outputCounterName);
+    assertEquals(aggregateCounter.getValue(), joinerOutputCounter.getValue(),
+        "aggregated counter does not match sum of output counters " + outputCounterName);
   }
 
 
@@ -860,8 +861,7 @@ public class TestTezJobs {
     try {
 
       OrderedWordCount job = new OrderedWordCount();
-      assertEquals(0,
-          job.run(tezConf, new String[]{"-counter", inputDirStr, outputDirStr, "2"}, null),
+      assertEquals(0, job.run(tezConf, new String[]{"-counter", inputDirStr, outputDirStr, "2"}, null),
           "OrderedWordCount failed");
       verifyOutput(outputDir, remoteFs);
 
@@ -895,8 +895,9 @@ public class TestTezJobs {
     try {
 
       OrderedWordCount job = new OrderedWordCount();
-      assertEquals(0, job.run(tezConf, new String[]{"-counter", "-local", "-disableSplitGrouping",
-          inputDirStr, outputDirStr, "2"}, null), "OrderedWordCount failed");
+      assertEquals(0,
+          job.run(tezConf, new String[]{"-counter", "-local", "-disableSplitGrouping", inputDirStr, outputDirStr, "2"},
+              null), "OrderedWordCount failed");
       verifyOutput(outputDir, localFs);
 
     } finally {
@@ -945,8 +946,9 @@ public class TestTezJobs {
 
       SimpleSessionExample job = new SimpleSessionExample();
       tezConf.setBoolean(TezConfiguration.TEZ_AM_SESSION_MODE, true);
-      assertEquals(0, job.run(tezConf, new String[]{StringUtils.join(",", inputPaths),
-          StringUtils.join(",", outputPaths), "2"}, null), "SimpleSessionExample failed");
+      assertEquals(0,
+          job.run(tezConf, new String[]{StringUtils.join(",", inputPaths), StringUtils.join(",", outputPaths), "2"},
+              null), "SimpleSessionExample failed");
 
       for (int i=0; i<numIterations; ++i) {
         verifyOutput(outputDirs[i], remoteFs);
@@ -1069,11 +1071,11 @@ public class TestTezJobs {
     int i = 0;
     for (String vertexName : resultVertices){
       if (i <= 1){
-        assertTrue( vertexName.equals("v1") || vertexName.equals("v2"));
-      } else if (i == 2){
+        assertTrue(vertexName.equals("v1") || vertexName.equals("v2"));
+      } else if (i == 2) {
         assertEquals("v3", vertexName);
-      } else if (i <= 4){
-        assertTrue( vertexName.equals("v4") || vertexName.equals("v5"));
+      } else if (i <= 4) {
+        assertTrue(vertexName.equals("v4") || vertexName.equals("v5"));
       } else {
         assertEquals("v6", vertexName);
       }
@@ -1191,7 +1193,7 @@ public class TestTezJobs {
   private void verifyCommits(String outputPrefix, int outputNum) throws IllegalArgumentException, IOException {
     for (int i=0; i< outputNum; ++i) {
       String outputDir = outputPrefix + "_" + i;
-      assertTrue(remoteFs.exists(new Path( outputDir + "/_SUCCESS")), "Output of " + outputDir + " is not succeeded");
+      assertTrue(remoteFs.exists(new Path(outputDir + "/_SUCCESS")), "Output of " + outputDir + " is not succeeded");
     }
   }
 
@@ -1417,9 +1419,9 @@ public class TestTezJobs {
       // Add a sleep because YARN is not consistent in terms of reporting uptodate diagnostics
       Thread.sleep(2000);
       report = yarnClient.getApplicationReport(appId);
-      LOG.info("App Report for appId=" + appId
-          + ", report=" + report);
-      assertTrue(report.getDiagnostics().contains("Client-to-AM Heartbeat timeout interval expired"), "Actual diagnostics: " + report.getDiagnostics());
+      LOG.info("App Report for appId=" + appId + ", report=" + report);
+      assertTrue(report.getDiagnostics().contains("Client-to-AM Heartbeat timeout interval expired"),
+          "Actual diagnostics: " + report.getDiagnostics());
 
     } finally {
       remoteFs.delete(stagingDirPath, true);
@@ -1473,8 +1475,7 @@ public class TestTezJobs {
       Thread.sleep(2000);
       report = yarnClient.getApplicationReport(appId);
       LOG.info("App Report for appId=" + appId + ", report=" + report);
-      assertTrue(
-          report.getDiagnostics().contains("Session timed out"),
+      assertTrue(report.getDiagnostics().contains("Session timed out"),
           "Actual diagnostics: " + report.getDiagnostics());
 
     } finally {
@@ -1527,6 +1528,6 @@ public class TestTezJobs {
     TezConfiguration tezConf = new TezConfiguration(mrrTezCluster.getConfig());
     tezConf.setInt(CartesianProductVertexManager.TEZ_CARTESIAN_PRODUCT_MAX_PARALLELISM, 10);
     tezConf.setInt(CartesianProductVertexManager.TEZ_CARTESIAN_PRODUCT_MIN_OPS_PER_WORKER, 25);
-    assertEquals(job.run(tezConf, null, null), 0, "CartesianProduct failed");
+    assertEquals(0, job.run(tezConf, null, null), "CartesianProduct failed");
   }
 }

--- a/tez-tests/src/test/java/org/apache/tez/test/TestTezJobs.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestTezJobs.java
@@ -22,10 +22,10 @@ import static org.apache.tez.dag.api.TezConfiguration.TEZ_AM_HOOKS;
 import static org.apache.tez.dag.api.TezConfiguration.TEZ_TASK_ATTEMPT_HOOKS;
 import static org.apache.tez.dag.api.TezConfiguration.TEZ_THREAD_DUMP_INTERVAL;
 import static org.apache.tez.dag.api.TezConstants.TEZ_CONTAINER_LOGGER_NAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -109,10 +110,10 @@ import org.apache.tez.test.dag.MultiAttemptDAG;
 
 import com.google.common.collect.Lists;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,7 +136,7 @@ public class TestTezJobs {
   private static String TEST_ROOT_DIR = "target" + Path.SEPARATOR + TestTezJobs.class.getName()
       + "-tmpDir";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     localFs = FileSystem.getLocal(conf);
     try {
@@ -157,7 +158,7 @@ public class TestTezJobs {
 
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     if (mrrTezCluster != null) {
       mrrTezCluster.stop();
@@ -170,14 +171,16 @@ public class TestTezJobs {
     // TODO Add cleanup code.
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testHashJoinExample() throws Exception {
     HashJoinExample hashJoinExample = new HashJoinExample();
     hashJoinExample.setConf(new Configuration(mrrTezCluster.getConfig()));
     runHashJoinExample(hashJoinExample);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testHashJoinExampleWithLogPattern() throws Exception {
     HashJoinExample hashJoinExample = new HashJoinExample();
 
@@ -280,7 +283,8 @@ public class TestTezJobs {
    * {@link JoinDataGen} -> {@link HashJoinExample} -> {@link JoinValidate}
    * @throws Exception
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testHashJoinExampleWithDataViaEvent() throws Exception {
 
     Path testDir = new Path("/tmp/testHashJoinExampleDataViaEvent");
@@ -329,7 +333,8 @@ public class TestTezJobs {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testHashJoinExampleDisableSplitGrouping() throws Exception {
     HashJoinExample hashJoinExample = new HashJoinExample();
     hashJoinExample.setConf(new Configuration(mrrTezCluster.getConfig()));
@@ -387,7 +392,8 @@ public class TestTezJobs {
     assertEquals(0, expectedResult.size());
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testSortMergeJoinExample() throws Exception {
     SortMergeJoinExample sortMergeJoinExample = new SortMergeJoinExample();
     sortMergeJoinExample.setConf(new Configuration(mrrTezCluster.getConfig()));
@@ -444,7 +450,8 @@ public class TestTezJobs {
     assertEquals(0, expectedResult.size());
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testPerIOCounterAggregation() throws Exception {
     String baseDir = "/tmp/perIOCounterAgg/";
     Path inPath1 = new Path(baseDir + "inPath1");
@@ -483,9 +490,9 @@ public class TestTezJobs {
         TaskCounter.class.getSimpleName() + "_" + joinerVertexName + "_INPUT_" + input1Name);
     final CounterGroup input2Group = joinerCounters.getGroup(
         TaskCounter.class.getSimpleName() + "_" + joinerVertexName + "_INPUT_" + input2Name);
-    assertTrue("aggregated counter group cannot be empty", aggregatedGroup.size() > 0);
-    assertTrue("per io group for input1 cannot be empty", input1Group.size() > 0);
-    assertTrue("per io group for input1 cannot be empty", input2Group.size() > 0);
+    assertTrue(aggregatedGroup.size() > 0, "aggregated counter group cannot be empty");
+    assertTrue(input1Group.size() > 0, "per io group for input1 cannot be empty");
+    assertTrue(input2Group.size() > 0, "per io group for input1 cannot be empty");
 
     List<TaskCounter> countersToVerifyAgg = Arrays.asList(
         TaskCounter.ADDITIONAL_SPILLS_BYTES_READ,
@@ -513,12 +520,11 @@ public class TestTezJobs {
       TezCounter aggregatedCounter = aggregatedGroup.findCounter(c.name(), false);
       TezCounter input1Counter = input1Group.findCounter(c.name(), false);
       TezCounter input2Counter = input2Group.findCounter(c.name(), false);
-      assertNotNull("aggregated counter cannot be null " + c.name(), aggregatedCounter);
-      assertNotNull("input1 counter cannot be null " + c.name(), input1Counter);
-      assertNotNull("input2 counter cannot be null " + c.name(), input2Counter);
+      assertNotNull(aggregatedCounter, "aggregated counter cannot be null " + c.name());
+      assertNotNull(input1Counter, "input1 counter cannot be null " + c.name());
+      assertNotNull(input2Counter, "input2 counter cannot be null " + c.name());
 
-      assertEquals("aggregated counter does not match sum of input counters " + c.name(),
-          aggregatedCounter.getValue(), input1Counter.getValue() + input2Counter.getValue());
+      assertEquals(aggregatedCounter.getValue(), input1Counter.getValue() + input2Counter.getValue(), "aggregated counter does not match sum of input counters " + c.name());
 
       if (aggregatedCounter.getValue() > 0) {
         nonZeroCounters++;
@@ -526,22 +532,22 @@ public class TestTezJobs {
     }
 
     // ensure that at least one of the counters tested above were non-zero.
-    assertTrue("At least one of the counter should be non-zero. invalid test ", nonZeroCounters > 0);
+    assertTrue(nonZeroCounters > 0, "At least one of the counter should be non-zero. invalid test ");
 
     CounterGroup joinerOutputGroup = joinerCounters.getGroup(
         TaskCounter.class.getSimpleName() + "_" + joinerVertexName + "_OUTPUT_" + joinOutputName);
     String outputCounterName = TaskCounter.OUTPUT_RECORDS.name();
     TezCounter aggregateCounter = aggregatedGroup.findCounter(outputCounterName, false);
     TezCounter joinerOutputCounter = joinerOutputGroup.findCounter(outputCounterName, false);
-    assertNotNull("aggregated counter cannot be null " + outputCounterName, aggregateCounter);
-    assertNotNull("output counter cannot be null " + outputCounterName, joinerOutputCounter);
-    assertTrue("counter value is zero. test is invalid", aggregateCounter.getValue() > 0);
-    assertEquals("aggregated counter does not match sum of output counters " + outputCounterName,
-        aggregateCounter.getValue(), joinerOutputCounter.getValue());
+    assertNotNull(aggregateCounter, "aggregated counter cannot be null " + outputCounterName);
+    assertNotNull(joinerOutputCounter, "output counter cannot be null " + outputCounterName);
+    assertTrue(aggregateCounter.getValue() > 0, "counter value is zero. test is invalid");
+    assertEquals(aggregateCounter.getValue(), joinerOutputCounter.getValue(), "aggregated counter does not match sum of output counters " + outputCounterName);
   }
 
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testSortMergeJoinExampleDisableSplitGrouping() throws Exception {
     testSortMergeJoinExampleDisableSplitGrouping(false);
   }
@@ -653,7 +659,8 @@ public class TestTezJobs {
    * {@link JoinDataGen} -> {@link HashJoinExample} -> {@link JoinValidate}
    * @throws Exception
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testHashJoinExamplePipeline() throws Exception {
 
     Path testDir = new Path("/tmp/testHashJoinExample");
@@ -702,7 +709,8 @@ public class TestTezJobs {
    * {@link JoinDataGen} -> {@link SortMergeJoinExample} -> {@link JoinValidate}
    * @throws Exception
    */
-  @Test(timeout = 120000)
+  @Test
+  @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testSortMergeJoinExamplePipeline() throws Exception {
 
     Path testDir = new Path("/tmp/testSortMergeExample");
@@ -794,13 +802,13 @@ public class TestTezJobs {
       LOG.info("Line: " + line + ", counter=" + currentCounter);
       int pos = line.indexOf("\t");
       String word = line.substring(0, pos-1);
-      Assert.assertEquals(prefix + "_" + currentCounter, word);
+      assertEquals(prefix + "_" + currentCounter, word);
       String val = line.substring(pos+1, line.length());
-      Assert.assertEquals((long)(11 - currentCounter) * 2, (long)Long.valueOf(val));
+      assertEquals((long)(11 - currentCounter) * 2, (long)Long.valueOf(val));
       currentCounter--;
     }
 
-    Assert.assertEquals(0, currentCounter);
+    assertEquals(0, currentCounter);
   }
 
   public static void verifyOutput(Path outputDir, FileSystem fs) throws IOException {
@@ -827,12 +835,13 @@ public class TestTezJobs {
       }
     }
     assertTrue(foundResult);
-    assertTrue(resultFile != null);
+    assertNotNull(resultFile);
     assertTrue(foundSuccessFile);
     verifyOrderedWordCountOutput(resultFile, fs);
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testOrderedWordCount() throws Exception {
     String inputDirStr = "/tmp/owc-input/";
     Path inputDir = new Path(inputDirStr);
@@ -851,7 +860,9 @@ public class TestTezJobs {
     try {
 
       OrderedWordCount job = new OrderedWordCount();
-      Assert.assertTrue("OrderedWordCount failed", job.run(tezConf, new String[]{"-counter", inputDirStr, outputDirStr, "2"}, null)==0);
+      assertEquals(0,
+          job.run(tezConf, new String[]{"-counter", inputDirStr, outputDirStr, "2"}, null),
+          "OrderedWordCount failed");
       verifyOutput(outputDir, remoteFs);
 
     } finally {
@@ -863,7 +874,8 @@ public class TestTezJobs {
 
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testOrderedWordCountDisableSplitGrouping() throws Exception {
     String inputDirStr = TEST_ROOT_DIR + "/tmp/owc-input/";
     Path inputDir = new Path(inputDirStr);
@@ -883,8 +895,8 @@ public class TestTezJobs {
     try {
 
       OrderedWordCount job = new OrderedWordCount();
-      Assert.assertTrue("OrderedWordCount failed", job.run(tezConf, new String[]{"-counter", "-local", "-disableSplitGrouping",
-          inputDirStr, outputDirStr, "2"}, null)==0);
+      assertEquals(0, job.run(tezConf, new String[]{"-counter", "-local", "-disableSplitGrouping",
+          inputDirStr, outputDirStr, "2"}, null), "OrderedWordCount failed");
       verifyOutput(outputDir, localFs);
 
     } finally {
@@ -896,7 +908,8 @@ public class TestTezJobs {
 
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testSimpleSessionExample() throws Exception {
     Path stagingDirPath = new Path("/tmp/owc-staging-dir");
     remoteFs.mkdirs(stagingDirPath);
@@ -932,10 +945,8 @@ public class TestTezJobs {
 
       SimpleSessionExample job = new SimpleSessionExample();
       tezConf.setBoolean(TezConfiguration.TEZ_AM_SESSION_MODE, true);
-      Assert.assertTrue(
-          "SimpleSessionExample failed",
-          job.run(tezConf, new String[] { StringUtils.join(",", inputPaths),
-              StringUtils.join(",", outputPaths), "2" }, null) == 0);
+      assertEquals(0, job.run(tezConf, new String[]{StringUtils.join(",", inputPaths),
+          StringUtils.join(",", outputPaths), "2"}, null), "SimpleSessionExample failed");
 
       for (int i=0; i<numIterations; ++i) {
         verifyOutput(outputDirs[i], remoteFs);
@@ -945,7 +956,7 @@ public class TestTezJobs {
       int appsAfterCount = apps != null ? apps.size() : 0;
 
       // Running in session mode. So should only create 1 more app.
-      Assert.assertEquals(appsBeforeCount + 1, appsAfterCount);
+      assertEquals(appsBeforeCount + 1, appsAfterCount);
     } finally {
       remoteFs.delete(stagingDirPath, true);
       if (yarnClient != null) {
@@ -955,7 +966,8 @@ public class TestTezJobs {
 
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidQueueSubmission() throws Exception {
 
     TezConfiguration tezConf = new TezConfiguration(mrrTezCluster.getConfig());
@@ -979,9 +991,9 @@ public class TestTezJobs {
       outputPaths[0] = outputDirStr;
       int result = job.run(tezConf, new String[] { StringUtils.join(",", inputPaths),
           StringUtils.join(",", outputPaths), "2" }, null);
-      Assert.assertTrue("Job should have failed", result != 0);
+      assertTrue(result != 0, "Job should have failed");
     } catch (TezException e) {
-      Assert.assertTrue(e.getMessage().contains("Failed to submit application"));
+      assertTrue(e.getMessage().contains("Failed to submit application"));
     } finally {
       if (yarnClient != null) {
         yarnClient.stop();
@@ -989,7 +1001,8 @@ public class TestTezJobs {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testInvalidQueueSubmissionToSession() throws Exception {
 
     TezConfiguration tezConf = new TezConfiguration(mrrTezCluster.getConfig());
@@ -1018,7 +1031,7 @@ public class TestTezJobs {
       // Expected
       LOG.info("Session not running", e);
     } catch (TezException e) {
-      Assert.assertTrue(e.getMessage().contains("Failed to submit application"));
+      assertTrue(e.getMessage().contains("Failed to submit application"));
     } finally {
       if (yarnClient != null) {
         yarnClient.stop();
@@ -1028,7 +1041,8 @@ public class TestTezJobs {
   }
 
 
-  @Test (timeout=60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testVertexOrder() throws Exception {
     TezConfiguration tezConf = new TezConfiguration(mrrTezCluster.getConfig());
     TezClient tezClient = TezClient.create("TestVertexOrder", tezConf);
@@ -1047,21 +1061,21 @@ public class TestTezJobs {
       dagStatus = dagClient.getDAGStatus(null);
     }
 
-    Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagStatus.getState());
+    assertEquals(DAGStatus.State.SUCCEEDED, dagStatus.getState());
 
     // verify vertex order
     Set<String> resultVertices = dagStatus.getVertexProgress().keySet();
-    Assert.assertEquals(6, resultVertices.size());
+    assertEquals(6, resultVertices.size());
     int i = 0;
     for (String vertexName : resultVertices){
       if (i <= 1){
-        Assert.assertTrue( vertexName.equals("v1") || vertexName.equals("v2"));
+        assertTrue( vertexName.equals("v1") || vertexName.equals("v2"));
       } else if (i == 2){
-        Assert.assertTrue( vertexName.equals("v3"));
+        assertEquals("v3", vertexName);
       } else if (i <= 4){
-        Assert.assertTrue( vertexName.equals("v4") || vertexName.equals("v5"));
+        assertTrue( vertexName.equals("v4") || vertexName.equals("v5"));
       } else {
-        Assert.assertTrue( vertexName.equals("v6"));
+        assertEquals("v6", vertexName);
       }
       i++;
     }
@@ -1072,7 +1086,8 @@ public class TestTezJobs {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testInputInitializerEvents() throws TezException, InterruptedException, IOException {
 
     TezConfiguration tezConf = new TezConfiguration(mrrTezCluster.getConfig());
@@ -1096,13 +1111,14 @@ public class TestTezJobs {
 
       DAGClient dagClient = tezClient.submitDAG(dag);
       dagClient.waitForCompletion();
-      Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+      assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
     } finally {
       tezClient.stop();
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleCommits_OnDAGSuccess() throws Exception {
     Path stagingDirPath = new Path("/tmp/commit-staging-dir");
     Random rand = new Random();
@@ -1120,9 +1136,10 @@ public class TestTezJobs {
 
     try {
       MultipleCommitsExample job = new MultipleCommitsExample();
-      Assert.assertTrue("MultipleCommitsExample failed", job.run(tezConf,
-          new String[]{ v1OutputPathPrefix, v1OutputNum + "", v2OutputPathPrefix, v2OutputNum + "",
-          uv12OutputPathPrefix, uv12OutputNum + "", v3OutputPathPrefix, v3OutputNum + ""}, null)==0);
+      assertEquals(0, job.run(tezConf,
+          new String[]{v1OutputPathPrefix, v1OutputNum + "", v2OutputPathPrefix, v2OutputNum + "",
+              uv12OutputPathPrefix, uv12OutputNum + "", v3OutputPathPrefix, v3OutputNum + ""},
+          null), "MultipleCommitsExample failed");
       verifyCommits(v1OutputPathPrefix, v1OutputNum);
       verifyCommits(v2OutputPathPrefix, v2OutputNum);
       verifyCommits(uv12OutputPathPrefix, uv12OutputNum);
@@ -1135,7 +1152,8 @@ public class TestTezJobs {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testMultipleCommits_OnVertexSuccess() throws Exception {
     Path stagingDirPath = new Path("/tmp/commit-staging-dir");
     Random rand = new Random();
@@ -1153,10 +1171,11 @@ public class TestTezJobs {
 
     try {
       MultipleCommitsExample job = new MultipleCommitsExample();
-      Assert.assertTrue("MultipleCommitsExample failed", job.run(tezConf,
-          new String[]{ v1OutputPathPrefix, v1OutputNum + "", v2OutputPathPrefix, v2OutputNum + "",
-          uv12OutputPathPrefix, uv12OutputNum + "", v3OutputPathPrefix, v3OutputNum + "",
-          MultipleCommitsExample.CommitOnVertexSuccessOption}, null)==0);
+      assertEquals(0, job.run(tezConf,
+              new String[]{v1OutputPathPrefix, v1OutputNum + "", v2OutputPathPrefix, v2OutputNum + "",
+                  uv12OutputPathPrefix, uv12OutputNum + "", v3OutputPathPrefix, v3OutputNum + "",
+                  MultipleCommitsExample.CommitOnVertexSuccessOption}, null),
+          "MultipleCommitsExample failed");
       verifyCommits(v1OutputPathPrefix, v1OutputNum);
       verifyCommits(v2OutputPathPrefix, v2OutputNum);
       verifyCommits(uv12OutputPathPrefix, uv12OutputNum);
@@ -1172,8 +1191,7 @@ public class TestTezJobs {
   private void verifyCommits(String outputPrefix, int outputNum) throws IllegalArgumentException, IOException {
     for (int i=0; i< outputNum; ++i) {
       String outputDir = outputPrefix + "_" + i;
-      Assert.assertTrue("Output of " + outputDir + " is not succeeded",
-          remoteFs.exists(new Path( outputDir + "/_SUCCESS")));
+      assertTrue(remoteFs.exists(new Path( outputDir + "/_SUCCESS")), "Output of " + outputDir + " is not succeeded");
     }
   }
 
@@ -1355,7 +1373,8 @@ public class TestTezJobs {
     assertEquals(0, expectedResult.size());
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testAMClientHeartbeatTimeout() throws Exception {
     Path stagingDirPath = new Path("/tmp/timeout-staging-dir");
     remoteFs.mkdirs(stagingDirPath);
@@ -1383,7 +1402,7 @@ public class TestTezJobs {
       int appsAfterCount = apps != null ? apps.size() : 0;
 
       // Running in session mode. So should only create 1 more app.
-      Assert.assertEquals(appsBeforeCount + 1, appsAfterCount);
+      assertEquals(appsBeforeCount + 1, appsAfterCount);
 
       ApplicationReport report;
       while (true) {
@@ -1400,8 +1419,7 @@ public class TestTezJobs {
       report = yarnClient.getApplicationReport(appId);
       LOG.info("App Report for appId=" + appId
           + ", report=" + report);
-      Assert.assertTrue("Actual diagnostics: " + report.getDiagnostics(),
-          report.getDiagnostics().contains("Client-to-AM Heartbeat timeout interval expired"));
+      assertTrue(report.getDiagnostics().contains("Client-to-AM Heartbeat timeout interval expired"), "Actual diagnostics: " + report.getDiagnostics());
 
     } finally {
       remoteFs.delete(stagingDirPath, true);
@@ -1411,7 +1429,8 @@ public class TestTezJobs {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testSessionTimeout() throws Exception {
     Path stagingDirPath = new Path("/tmp/sessiontimeout-staging-dir");
     remoteFs.mkdirs(stagingDirPath);
@@ -1438,7 +1457,7 @@ public class TestTezJobs {
       int appsAfterCount = apps != null ? apps.size() : 0;
 
       // Running in session mode. So should only create 1 more app.
-      Assert.assertEquals(appsBeforeCount + 1, appsAfterCount);
+      assertEquals(appsBeforeCount + 1, appsAfterCount);
 
       ApplicationReport report;
       while (true) {
@@ -1453,10 +1472,10 @@ public class TestTezJobs {
       // Add a sleep because YARN is not consistent in terms of reporting uptodate diagnostics
       Thread.sleep(2000);
       report = yarnClient.getApplicationReport(appId);
-      LOG.info("App Report for appId=" + appId
-          + ", report=" + report);
-      Assert.assertTrue("Actual diagnostics: " + report.getDiagnostics(),
-          report.getDiagnostics().contains("Session timed out"));
+      LOG.info("App Report for appId=" + appId + ", report=" + report);
+      assertTrue(
+          report.getDiagnostics().contains("Session timed out"),
+          "Actual diagnostics: " + report.getDiagnostics());
 
     } finally {
       remoteFs.delete(stagingDirPath, true);
@@ -1466,7 +1485,8 @@ public class TestTezJobs {
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testVertexFailuresMaxPercent() throws TezException, InterruptedException, IOException {
 
     TezConfiguration tezConf = new TezConfiguration(mrrTezCluster.getConfig());
@@ -1492,13 +1512,14 @@ public class TestTezJobs {
 
       DAGClient dagClient = tezClient.submitDAG(dag);
       dagClient.waitForCompletion();
-      Assert.assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
+      assertEquals(DAGStatus.State.SUCCEEDED, dagClient.getDAGStatus(null).getState());
     } finally {
       tezClient.stop();
     }
   }
 
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60000, unit = TimeUnit.MILLISECONDS)
   public void testCartesianProduct() throws Exception {
     LOG.info("Running CartesianProduct Test");
     CartesianProduct job = new CartesianProduct();
@@ -1506,6 +1527,6 @@ public class TestTezJobs {
     TezConfiguration tezConf = new TezConfiguration(mrrTezCluster.getConfig());
     tezConf.setInt(CartesianProductVertexManager.TEZ_CARTESIAN_PRODUCT_MAX_PARALLELISM, 10);
     tezConf.setInt(CartesianProductVertexManager.TEZ_CARTESIAN_PRODUCT_MIN_OPS_PER_WORKER, 25);
-    Assert.assertEquals("CartesianProduct failed", job.run(tezConf, null, null), 0);
+    assertEquals(job.run(tezConf, null, null), 0, "CartesianProduct failed");
   }
 }

--- a/tez-tests/src/test/java/org/apache/tez/test/dag/SimpleReverseVTestDAG.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/dag/SimpleReverseVTestDAG.java
@@ -33,7 +33,6 @@ import org.apache.tez.test.TestInput;
 import org.apache.tez.test.TestOutput;
 import org.apache.tez.test.TestProcessor;
 
-
 /**
  * A DAG with 3 vertices of which their graph can be depicted easily with reverse V shape.
  *     v1

--- a/tez-tests/src/test/java/org/apache/tez/test/dag/SimpleReverseVTestDAG.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/dag/SimpleReverseVTestDAG.java
@@ -33,6 +33,7 @@ import org.apache.tez.test.TestInput;
 import org.apache.tez.test.TestOutput;
 import org.apache.tez.test.TestProcessor;
 
+
 /**
  * A DAG with 3 vertices of which their graph can be depicted easily with reverse V shape.
  *     v1

--- a/tez-tests/src/test/java/org/apache/tez/test/dag/SimpleVTestDAG.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/dag/SimpleVTestDAG.java
@@ -33,6 +33,7 @@ import org.apache.tez.test.TestInput;
 import org.apache.tez.test.TestOutput;
 import org.apache.tez.test.TestProcessor;
 
+
 /**
  * A DAG with 3 vertices of which their graph can be depicted easily with V shape.
  *  v1     v2

--- a/tez-tests/src/test/java/org/apache/tez/test/dag/SimpleVTestDAG.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/dag/SimpleVTestDAG.java
@@ -33,7 +33,6 @@ import org.apache.tez.test.TestInput;
 import org.apache.tez.test.TestOutput;
 import org.apache.tez.test.TestProcessor;
 
-
 /**
  * A DAG with 3 vertices of which their graph can be depicted easily with V shape.
  *  v1     v2

--- a/tez-tools/analyzers/job-analyzer/pom.xml
+++ b/tez-tools/analyzers/job-analyzer/pom.xml
@@ -152,9 +152,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.media</groupId>
@@ -164,16 +163,6 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-shuffle</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/tez-tools/analyzers/job-analyzer/src/test/java/org/apache/tez/analyzer/TestAnalyzer.java
+++ b/tez-tools/analyzers/job-analyzer/src/test/java/org/apache/tez/analyzer/TestAnalyzer.java
@@ -18,13 +18,15 @@
  */
 package org.apache.tez.analyzer;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -64,10 +66,10 @@ import org.apache.tez.tests.MiniTezClusterWithTimeline;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +94,7 @@ public class TestAnalyzer {
   private boolean downloadedSimpleHistoryFile = false;
   private static String yarnTimelineAddress;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupClass() throws Exception {
     conf = new Configuration();
     conf.setBoolean(DFSConfigKeys.DFS_NAMENODE_EDITS_NOEDITLOGCHANNELFLUSH, false);
@@ -106,7 +108,7 @@ public class TestAnalyzer {
     setupTezCluster();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownClass() throws Exception {
     LOG.info("Stopping mini clusters");
     if (miniTezCluster != null) {
@@ -245,7 +247,7 @@ public class TestAnalyzer {
       dagStatus = dagClient.getDAGStatus(null);
     }
 
-    Assert.assertEquals(finalState, dagStatus.getState());
+    assertEquals(finalState, dagStatus.getState());
   }
 
   private void verify(ApplicationId appId, int dagNum, List<StepCheck[]> steps) throws Exception {
@@ -263,7 +265,7 @@ public class TestAnalyzer {
       String[] args = { "--dagId=" + dagId, "--downloadDir=" + DOWNLOAD_DIR, "--yarnTimelineAddress=" + yarnTimelineAddress };
 
       int result = ATSImportTool.process(args);
-      assertTrue(result == 0);
+      assertEquals(0, result);
 
       //Parse ATS data and verify results
       //Parse downloaded contents
@@ -271,7 +273,7 @@ public class TestAnalyzer {
           + Path.SEPARATOR + dagId + ".zip");
       ATSFileParser parser = new ATSFileParser(Arrays.asList(downloadedFile));
       dagInfo = parser.getDAGData(dagId);
-      assertTrue(dagInfo.getDagId().equals(dagId));
+      assertEquals(dagInfo.getDagId(), dagId);
     } else {
       if (!downloadedSimpleHistoryFile) {
         downloadedSimpleHistoryFile = true;
@@ -290,7 +292,7 @@ public class TestAnalyzer {
       File localFile = new File(DOWNLOAD_DIR, HISTORY_TXT);
       SimpleHistoryParser parser = new SimpleHistoryParser(Arrays.asList(localFile));
       dagInfo = parser.getDAGData(dagId);
-      assertTrue(dagInfo.getDagId().equals(dagId));
+      assertEquals(dagInfo.getDagId(), dagId);
     }
     return dagInfo;
   }
@@ -316,47 +318,48 @@ public class TestAnalyzer {
     for (StepCheck[] steps : stepsOptions) {
       if (steps.length + 2 == criticalPath.size()) {
         foundMatchingLength = true;
-        Assert.assertEquals(CriticalPathStep.EntityType.VERTEX_INIT, criticalPath.get(0).getType());
-        Assert.assertEquals(criticalPath.get(1).getAttempt().getShortName(),
+        assertEquals(CriticalPathStep.EntityType.VERTEX_INIT, criticalPath.get(0).getType());
+        assertEquals(criticalPath.get(1).getAttempt().getShortName(),
             criticalPath.get(0).getAttempt().getShortName());
 
         for (int i=1; i<criticalPath.size() - 1; ++i) {
           StepCheck check = steps[i-1];
           CriticalPathStep step = criticalPath.get(i);
-          Assert.assertEquals(CriticalPathStep.EntityType.ATTEMPT, step.getType());
-          Assert.assertTrue(check.getAttemptDetail(),
-              step.getAttempt().getShortName().matches(check.getAttemptDetail()));
-          Assert.assertEquals(steps[i-1].getReason(), step.getReason());
+          assertEquals(EntityType.ATTEMPT, step.getType());
+          assertTrue(step.getAttempt().getShortName().matches(check.getAttemptDetail()), check.getAttemptDetail());
+          assertEquals(steps[i-1].getReason(), step.getReason());
           if (check.getErrCause() != null) {
-            Assert.assertEquals(check.getErrCause(),
+            assertEquals(check.getErrCause(),
                 TaskAttemptTerminationCause.valueOf(step.getAttempt().getTerminationCause()));
           }
           if (check.getNotesStr() != null) {
             String notes = Joiner.on("#").join(step.getNotes());
             for (String note : check.getNotesStr()) {
-              Assert.assertTrue(note, notes.contains(notes));
+              assertTrue(notes.contains(notes), note);
             }
           }
         }
 
-        Assert.assertEquals(CriticalPathStep.EntityType.DAG_COMMIT,
+        assertEquals(CriticalPathStep.EntityType.DAG_COMMIT,
             criticalPath.get(criticalPath.size() - 1).getType());
         break;
       }
     }
 
-    Assert.assertTrue(foundMatchingLength);
+    assertTrue(foundMatchingLength);
 
   }
 
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300000, unit = TimeUnit.MILLISECONDS)
   public void testWithATS() throws Exception {
     usingATS = true;
     createTezSessionATS();
     runTests();
   }
 
-  @Test (timeout=300000)
+  @Test
+  @Timeout(value = 300000, unit = TimeUnit.MILLISECONDS)
   public void testWithSimpleHistory() throws Exception {
     usingATS = false;
     createTezSessionSimpleHistory();

--- a/tez-tools/analyzers/job-analyzer/src/test/java/org/apache/tez/analyzer/TestAnalyzer.java
+++ b/tez-tools/analyzers/job-analyzer/src/test/java/org/apache/tez/analyzer/TestAnalyzer.java
@@ -319,15 +319,14 @@ public class TestAnalyzer {
       if (steps.length + 2 == criticalPath.size()) {
         foundMatchingLength = true;
         assertEquals(CriticalPathStep.EntityType.VERTEX_INIT, criticalPath.get(0).getType());
-        assertEquals(criticalPath.get(1).getAttempt().getShortName(),
-            criticalPath.get(0).getAttempt().getShortName());
+        assertEquals(criticalPath.get(1).getAttempt().getShortName(), criticalPath.get(0).getAttempt().getShortName());
 
         for (int i=1; i<criticalPath.size() - 1; ++i) {
           StepCheck check = steps[i-1];
           CriticalPathStep step = criticalPath.get(i);
           assertEquals(EntityType.ATTEMPT, step.getType());
           assertTrue(step.getAttempt().getShortName().matches(check.getAttemptDetail()), check.getAttemptDetail());
-          assertEquals(steps[i-1].getReason(), step.getReason());
+          assertEquals(steps[i - 1].getReason(), step.getReason());
           if (check.getErrCause() != null) {
             assertEquals(check.getErrCause(),
                 TaskAttemptTerminationCause.valueOf(step.getAttempt().getTerminationCause()));
@@ -340,8 +339,7 @@ public class TestAnalyzer {
           }
         }
 
-        assertEquals(CriticalPathStep.EntityType.DAG_COMMIT,
-            criticalPath.get(criticalPath.size() - 1).getType());
+        assertEquals(CriticalPathStep.EntityType.DAG_COMMIT, criticalPath.get(criticalPath.size() - 1).getType());
         break;
       }
     }

--- a/tez-tools/analyzers/job-analyzer/src/test/java/org/apache/tez/analyzer/TestCSVResult.java
+++ b/tez-tools/analyzers/job-analyzer/src/test/java/org/apache/tez/analyzer/TestCSVResult.java
@@ -98,20 +98,17 @@ public class TestCSVResult {
 
   @Test
   public void testDumpToFileRejectsNullFileName() throws Exception {
-    assertThrows(
-        IllegalArgumentException.class, () -> new CSVResult(new String[] {"x"}).dumpToFile(null));
+    assertThrows(IllegalArgumentException.class, () -> new CSVResult(new String[]{"x"}).dumpToFile(null));
   }
 
   @Test
   public void testDumpToFileRejectsEmptyFileName() throws Exception {
-    assertThrows(
-        IllegalArgumentException.class, () -> new CSVResult(new String[] {"x"}).dumpToFile(""));
+    assertThrows(IllegalArgumentException.class, () -> new CSVResult(new String[]{"x"}).dumpToFile(""));
   }
 
   @Test
   public void testDumpToFileRejectsBlankFileName() throws Exception {
-    assertThrows(
-        IllegalArgumentException.class, () -> new CSVResult(new String[] {"x"}).dumpToFile("   "));
+    assertThrows(IllegalArgumentException.class, () -> new CSVResult(new String[]{"x"}).dumpToFile("   "));
   }
 
   @Test

--- a/tez-tools/analyzers/job-analyzer/src/test/java/org/apache/tez/analyzer/TestCSVResult.java
+++ b/tez-tools/analyzers/job-analyzer/src/test/java/org/apache/tez/analyzer/TestCSVResult.java
@@ -18,6 +18,11 @@
  */
 package org.apache.tez.analyzer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
@@ -25,22 +30,21 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestCSVResult {
 
   private Path testDir;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     testDir = Paths.get(System.getProperty("user.dir") + "/test");
     Files.createDirectories(testDir);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     if (Files.exists(testDir)) {
       Files.walk(testDir)
@@ -59,7 +63,7 @@ public class TestCSVResult {
     result.dumpToFile(out.toString());
 
     String content = Files.readString(out, StandardCharsets.UTF_8);
-    Assert.assertEquals("h1,h2\na,b\n", content);
+    assertEquals("h1,h2\na,b\n", content);
   }
 
   @Test
@@ -71,9 +75,9 @@ public class TestCSVResult {
 
     try {
       result.dumpToFile(out.toString());
-      Assert.fail("Expected FileAlreadyExistsException when output file already exists");
+      fail("Expected FileAlreadyExistsException when output file already exists");
     } catch (FileAlreadyExistsException e) {
-      Assert.assertTrue(e.getMessage().contains(out.toString()));
+      assertTrue(e.getMessage().contains(out.toString()));
     }
   }
 
@@ -86,25 +90,28 @@ public class TestCSVResult {
 
     try {
       result.dumpToFile(out.toString());
-      Assert.fail("Expected IOException when parent directory does not exist");
+      fail("Expected IOException when parent directory does not exist");
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains("Parent directory does not exist"));
+      assertTrue(e.getMessage().contains("Parent directory does not exist"));
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDumpToFileRejectsNullFileName() throws Exception {
-    new CSVResult(new String[]{"x"}).dumpToFile(null);
+    assertThrows(
+        IllegalArgumentException.class, () -> new CSVResult(new String[] {"x"}).dumpToFile(null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDumpToFileRejectsEmptyFileName() throws Exception {
-    new CSVResult(new String[]{"x"}).dumpToFile("");
+    assertThrows(
+        IllegalArgumentException.class, () -> new CSVResult(new String[] {"x"}).dumpToFile(""));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDumpToFileRejectsBlankFileName() throws Exception {
-    new CSVResult(new String[]{"x"}).dumpToFile("   ");
+    assertThrows(
+        IllegalArgumentException.class, () -> new CSVResult(new String[] {"x"}).dumpToFile("   "));
   }
 
   @Test
@@ -118,7 +125,7 @@ public class TestCSVResult {
     result.addRecord(new String[]{"r"});
     result.dumpToFile(out.toString());
 
-    Assert.assertEquals("h\nr\n", Files.readString(out, StandardCharsets.UTF_8));
+    assertEquals("h\nr\n", Files.readString(out, StandardCharsets.UTF_8));
   }
 
   @Test
@@ -128,9 +135,9 @@ public class TestCSVResult {
 
     try {
       result.dumpToFile(relativePath);
-      Assert.fail("Expected IOException due to moving upwards from pwd");
+      fail("Expected IOException due to moving upwards from pwd");
     } catch (IOException e) {
-      Assert.assertTrue(e.getMessage().contains(Paths.get(relativePath).toAbsolutePath().normalize().toString()));
+      assertTrue(e.getMessage().contains(Paths.get(relativePath).toAbsolutePath().normalize().toString()));
     }
   }
 }


### PR DESCRIPTION
1. Update Annotations:
```
@Test (Change import from org.junit.Test to org.junit.jupiter.api.Test)
@Before → @BeforeEach
@After → @AfterEach
@BeforeClass → @BeforeAll (Method must be static)
@AfterClass → @AfterAll (Method must be static)
@Ignore → @Disabled
```
2. Update Assertions:
`org.junit.Assert.* → org.junit.jupiter.api.Assertions.*`

3. Removed the transitive dependency on `Hamcrest` matchers.
4. Migrated all `@Test(timeout = ...)` parameters to the `@Timeout` annotation while maintianing the Millisecond timeunit
5. Replaced `@Rule TemporaryFolder` with JUnit Jupiter's `@TempDir`
6. **Note**: In JUnit 4, the custom assertion message was the first parameter. In JUnit 6, it is the last parameter.
In JUnit 4: `assertEquals("Values should match", expected, actual);`
In JUnit 6:`assertEquals(expected, actual, "Values should match");`