### PR TITLE
TEZ-4726: Replace deprecated java.net.URL constructors with URI alternatives

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/TimelineReaderFactory.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.security.ssl.SSLFactory.Mode.CLIENT;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.security.GeneralSecurityException;
@@ -284,7 +285,7 @@ public final class TimelineReaderFactory {
             URLEncoder.encode(UserGroupInformation.getCurrentUser().getShortUserName(), "UTF8");
 
         HttpURLConnection httpURLConnection =
-            (HttpURLConnection) (new URL(url + tokenString)).openConnection();
+            (HttpURLConnection) URI.create(url + tokenString).toURL().openConnection();
         this.connectionConf.configure(httpURLConnection);
 
         return httpURLConnection;

--- a/tez-api/src/test/java/org/apache/tez/client/TestTezClientUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/client/TestTezClientUtils.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -141,7 +142,7 @@ public class TestTezClientUtils {
     File lastFile = null;
     // Add one file and one directory.
     for (String path : classpaths) {
-      URL url = new URL("file://" + path);
+      URL url = URI.create("file://" + path).toURL();
       File file = FileUtils.toFile(url);
       if (lastFile == null) {
         lastFile = file;

--- a/tez-api/src/test/java/org/apache/tez/common/TestReflectionUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/common/TestReflectionUtils.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
 
@@ -77,7 +78,7 @@ public class TestReflectionUtils {
       assertTrue(localFs.createNewFile(p));
       String urlForm = p.toUri().toURL().toString();
       urlForm = urlForm.substring(0, urlForm.lastIndexOf('/') + 1);
-      URL url = new URL(urlForm);
+      URL url = URI.create(urlForm).toURL();
 
       ReflectionUtils.addResourcesToSystemClassLoader(Collections.singletonList(url));
 

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/TestTimelineReaderFactory.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/TestTimelineReaderFactory.java
@@ -21,7 +21,7 @@ package org.apache.tez.dag.api.client;
 import static org.mockito.Mockito.mock;
 
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -55,7 +55,7 @@ public class TestTimelineReaderFactory {
           .PseudoAuthenticatedURLConnectionFactory(connConf);
     String inputUrl = "http://host:8080/path";
     String expectedUrl = inputUrl + "?user.name=" + UserGroupInformation.getCurrentUser().getShortUserName();
-    HttpURLConnection httpURLConnection = connectionFactory.getHttpURLConnection(new URL(inputUrl));
+    HttpURLConnection httpURLConnection = connectionFactory.getHttpURLConnection(URI.create(inputUrl).toURL());
     Assert.assertEquals(expectedUrl, httpURLConnection.getURL().toString());
   }
 

--- a/tez-dag/src/main/java/org/apache/tez/dag/app/web/AMWebController.java
+++ b/tez-dag/src/main/java/org/apache/tez/dag/app/web/AMWebController.java
@@ -21,6 +21,7 @@ package org.apache.tez.dag.app.web;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -142,9 +143,9 @@ public class AMWebController extends Controller {
     String origin = request().getHeader(ORIGIN);
     if(origin == null) {
       try {
-        URL url = new URL(historyUrlBase);
+        URL url = URI.create(historyUrlBase).toURL();
         origin = url.getProtocol() + "://" + url.getAuthority();
-      } catch (MalformedURLException e) {
+      } catch (IllegalArgumentException | MalformedURLException e) {
         LOG.debug("Invalid url set for tez history url base: {}", historyUrlBase, e);
       }
     }

--- a/tez-ext-service-tests/src/test/java/org/apache/tez/shufflehandler/ShuffleHandler.java
+++ b/tez-ext-service-tests/src/test/java/org/apache/tez/shufflehandler/ShuffleHandler.java
@@ -35,6 +35,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.URL;
 import java.nio.channels.ClosedChannelException;
 import java.util.ArrayList;
@@ -427,7 +428,7 @@ public class ShuffleHandler {
       HttpResponse response = new DefaultHttpResponse(HTTP_1_1, OK);
       try {
         verifyRequest(jobId, ctx, request, response,
-            new URL("http", "", this.port, reqUri));
+            URI.create("http://:" + this.port + reqUri).toURL());
       } catch (IOException e) {
         LOG.warn("Shuffle failure ", e);
         sendError(ctx, e.getMessage(), UNAUTHORIZED);

--- a/tez-plugins/tez-aux-services/src/main/java/org/apache/tez/auxservices/ShuffleHandler.java
+++ b/tez-plugins/tez-aux-services/src/main/java/org/apache/tez/auxservices/ShuffleHandler.java
@@ -37,6 +37,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
@@ -1084,7 +1085,7 @@ public class ShuffleHandler extends AuxiliaryService {
       HttpResponse response = new DefaultHttpResponse(HTTP_1_1, OK);
       try {
         verifyRequest(jobId, ctx, request, response,
-            new URL("http", "", this.port, reqUri));
+            URI.create("http://:" + this.port + reqUri).toURL());
       } catch (IOException e) {
         LOG.warn("Shuffle failure ", e);
         sendError(ctx, e.getMessage(), UNAUTHORIZED);

--- a/tez-plugins/tez-aux-services/src/test/java/org/apache/tez/auxservices/TestShuffleHandler.java
+++ b/tez-plugins/tez-aux-services/src/test/java/org/apache/tez/auxservices/TestShuffleHandler.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.SocketAddress;
 import java.net.SocketException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -392,9 +393,9 @@ public class TestShuffleHandler {
 
     // simulate a reducer that closes early by reading a single shuffle header
     // then closing the connection
-    URL url = new URL("http://127.0.0.1:"
+    URL url = URI.create("http://127.0.0.1:"
       + shuffleHandler.getConfig().get(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
-      + "/mapOutput?job=job_12345_1&dag=1&reduce=1&map=attempt_12345_1_m_1_0");
+      + "/mapOutput?job=job_12345_1&dag=1&reduce=1&map=attempt_12345_1_m_1_0").toURL();
     HttpURLConnection conn = (HttpURLConnection)url.openConnection();
     conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
         ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
@@ -522,8 +523,8 @@ public class TestShuffleHandler {
             + shuffleHandler.getConfig().get(
               ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY);
     URL url =
-        new URL(shuffleBaseURL + "/mapOutput?job=job_12345_1&dag=1&reduce=1&"
-            + "map=attempt_12345_1_m_1_0");
+        URI.create(shuffleBaseURL + "/mapOutput?job=job_12345_1&dag=1&reduce=1&"
+            + "map=attempt_12345_1_m_1_0").toURL();
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
       ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
@@ -545,8 +546,8 @@ public class TestShuffleHandler {
 
     // For keepAlive via URL
     url =
-        new URL(shuffleBaseURL + "/mapOutput?job=job_12345_1&dag=1&reduce=1&"
-            + "map=attempt_12345_1_m_1_0&keepAlive=true");
+        URI.create(shuffleBaseURL + "/mapOutput?job=job_12345_1&dag=1&reduce=1&"
+            + "map=attempt_12345_1_m_1_0&keepAlive=true").toURL();
     conn = (HttpURLConnection) url.openConnection();
     conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
       ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
@@ -591,8 +592,8 @@ public class TestShuffleHandler {
               + shuffleHandler.getConfig().get(
                 ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY);
       URL url =
-          new URL(shuffleBaseURL + "/mapOutput?job=job_12345_1&dag=1&reduce=1&"
-              + "map=attempt_12345_1_m_1_0");
+          URI.create(shuffleBaseURL + "/mapOutput?job=job_12345_1&dag=1&reduce=1&"
+              + "map=attempt_12345_1_m_1_0").toURL();
       conn = (HttpURLConnection) url.openConnection();
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
           ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
@@ -626,9 +627,9 @@ public class TestShuffleHandler {
 
     // simulate a reducer that closes early by reading a single shuffle header
     // then closing the connection
-    URL url = new URL("http://127.0.0.1:"
+    URL url = URI.create("http://127.0.0.1:"
       + shuffleHandler.getConfig().get(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
-      + "/mapOutput?job=job_12345_1&&dag=1reduce=1&map=attempt_12345_1_m_1_0");
+      + "/mapOutput?job=job_12345_1&&dag=1reduce=1&map=attempt_12345_1_m_1_0").toURL();
     for (int i = 0; i < failureNum; ++i) {
       HttpURLConnection conn = (HttpURLConnection)url.openConnection();
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
@@ -713,7 +714,7 @@ public class TestShuffleHandler {
            + shuffleHandler.getConfig().get(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
            + "/mapOutput?job=job_12345_1&dag=1&reduce=1&map=attempt_12345_1_m_"
            + i + "_0";
-      URL url = new URL(URLstring);
+      URL url = URI.create(URLstring).toURL();
       conns[i] = (HttpURLConnection)url.openConnection();
       conns[i].setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
           ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
@@ -788,12 +789,12 @@ public class TestShuffleHandler {
               appId, ByteBuffer.wrap(outputBuffer.getData(), 0,
               outputBuffer.getLength())));
       URL url =
-          new URL(
+          URI.create(
               "http://127.0.0.1:"
                   + shuffleHandler.getConfig().get(
                   ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
                   + "/mapOutput?job=job_12345_0001&dag=1&reduce=" + reducerIdStart + "-" + reducerIdEnd
-                  + "&map=attempt_12345_1_m_1_0");
+                  + "&map=attempt_12345_1_m_1_0").toURL();
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
           ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
@@ -886,9 +887,9 @@ public class TestShuffleHandler {
       jt.write(outputBuffer);
       shuffleHandler.initializeApplication(new ApplicationInitializationContext(user, appId,
           ByteBuffer.wrap(outputBuffer.getData(), 0, outputBuffer.getLength())));
-      URL url = new URL("http://127.0.0.1:" + shuffleHandler.getConfig().get(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
+      URL url = URI.create("http://127.0.0.1:" + shuffleHandler.getConfig().get(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
           + "/mapOutput?job=job_12345_0001&dag=1&reduce=" + reducerIdStart + "-" + reducerIdEnd + "&map="
-          + String.join(",", attemptIds));
+          + String.join(",", attemptIds)).toURL();
       LOG.info("Calling shuffle URL: {}", url);
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME, ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
@@ -966,12 +967,12 @@ public class TestShuffleHandler {
           appId, ByteBuffer.wrap(outputBuffer.getData(), 0,
             outputBuffer.getLength())));
       URL url =
-          new URL(
+          URI.create(
               "http://127.0.0.1:"
                   + shuffleHandler.getConfig().get(
                       ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
                   + "/mapOutput?job=job_12345_0001&dag=1&reduce=" + reducerId
-                  + "&map=attempt_12345_1_m_1_0");
+                  + "&map=attempt_12345_1_m_1_0").toURL();
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
           ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
@@ -1206,10 +1207,10 @@ public class TestShuffleHandler {
 
   private static int getShuffleResponseCode(ShuffleHandler shuffle,
       Token<JobTokenIdentifier> jt) throws IOException {
-    URL url = new URL("http://127.0.0.1:"
+    URL url = URI.create("http://127.0.0.1:"
         + shuffle.getConfig().get(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
         + "/mapOutput?job=job_12345_0001&dag=1&reduce=0" +
-        "&map=attempt_12345_1_m_1_0");
+        "&map=attempt_12345_1_m_1_0").toURL();
     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
     String encHash = SecureShuffleUtils.hashFromString(
         SecureShuffleUtils.buildMsgFrom(url),
@@ -1303,12 +1304,12 @@ public class TestShuffleHandler {
           appId, ByteBuffer.wrap(outputBuffer.getData(), 0,
           outputBuffer.getLength())));
       URL url =
-          new URL(
+          URI.create(
               "http://127.0.0.1:"
                   + shuffleHandler.getConfig().get(
                       ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
                   + "/mapOutput?job=job_12345_0001&dag=1&reduce=" + reducerId
-                  + "&map=attempt_12345_1_m_1_0");
+                  + "&map=attempt_12345_1_m_1_0").toURL();
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
           ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
@@ -1380,11 +1381,11 @@ public class TestShuffleHandler {
               appId, ByteBuffer.wrap(outputBuffer.getData(), 0,
               outputBuffer.getLength())));
       URL url =
-          new URL(
+          URI.create(
               "http://127.0.0.1:"
                   + shuffleHandler.getConfig().get(
                   ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
-                  + "/mapOutput?dagAction=delete&job=job_12345_0001&dag=1");
+                  + "/mapOutput?dagAction=delete&job=job_12345_0001&dag=1").toURL();
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
           ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
@@ -1472,11 +1473,11 @@ public class TestShuffleHandler {
                       appId, ByteBuffer.wrap(outputBuffer.getData(), 0,
                       outputBuffer.getLength())));
       URL url =
-              new URL(
+              URI.create(
                       "http://127.0.0.1:"
                               + shuffleHandler.getConfig().get(
                               ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
-                              + "/mapOutput?vertexAction=delete&job=job_12345_0001&dag=1&vertex=00");
+                              + "/mapOutput?vertexAction=delete&job=job_12345_0001&dag=1&vertex=00").toURL();
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
               ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
@@ -1559,11 +1560,11 @@ public class TestShuffleHandler {
               appId, ByteBuffer.wrap(outputBuffer.getData(), 0,
               outputBuffer.getLength())));
       URL url =
-          new URL(
+          URI.create(
               "http://127.0.0.1:"
                   + shuffleHandler.getConfig().get(
                   ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
-                  + "/mapOutput?taskAttemptAction=delete&job=job_12345_0001&dag=1&map=" + appAttemptId);
+                  + "/mapOutput?taskAttemptAction=delete&job=job_12345_0001&dag=1&map=" + appAttemptId).toURL();
       HttpURLConnection conn = (HttpURLConnection) url.openConnection();
       conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
           ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
@@ -1643,8 +1644,8 @@ public class TestShuffleHandler {
 
       String shuffleBaseURL = "http://127.0.0.1:"
           + shuffleHandler.getConfig().get(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY);
-      URL url = new URL(
-          shuffleBaseURL + "/mapOutput?job=job_12345_1&dag=1&reduce=1&map=attempt_12345_1_m_1_0");
+      URL url = URI.create(
+          shuffleBaseURL + "/mapOutput?job=job_12345_1&dag=1&reduce=1&map=attempt_12345_1_m_1_0").toURL();
       shuffleHandler.secretManager.addTokenForJob("job_12345_1",
           new Token<>("id".getBytes(), shuffleHandler.getSecret().getBytes(), null, null));
 

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/ATSImportTool.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/ATSImportTool.java
@@ -345,7 +345,7 @@ public class ATSImportTool extends Configured implements Tool {
     public HttpURLConnection getHttpURLConnection(URL url) throws IOException {
       String tokenString = (url.getQuery() == null ? "?" : "&") + "user.name=" +
           URLEncoder.encode(UserGroupInformation.getCurrentUser().getShortUserName(), "UTF8");
-      return (HttpURLConnection) (new URL(url.toString() + tokenString)).openConnection();
+      return (HttpURLConnection) URI.create(url.toString() + tokenString).toURL().openConnection();
     }
   }
 

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/TezRuntimeUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/TezRuntimeUtils.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
 
@@ -168,7 +169,7 @@ public final class TezRuntimeUtils {
     sb.append(appId.replace("application", "job"));
     sb.append("&dag=");
     sb.append(dagIdentifier);
-    return new URL(sb.toString());
+    return URI.create(sb.toString()).toURL();
   }
 
   public static URL constructBaseURIForShuffleHandlerVertexComplete(
@@ -187,7 +188,7 @@ public final class TezRuntimeUtils {
     sb.append(dagIdentifier);
     sb.append("&vertex=");
     sb.append(vertexIdentifier);
-    return new URL(sb.toString());
+    return URI.create(sb.toString()).toURL();
   }
 
   public static URL constructBaseURIForShuffleHandlerTaskAttemptFailed(
@@ -206,7 +207,7 @@ public final class TezRuntimeUtils {
     sb.append(dagIdentifier);
     sb.append("&map=");
     sb.append(taskAttemptIdentifier);
-    return new URL(sb.toString());
+    return URI.create(sb.toString()).toURL();
   }
 
   public static HttpConnectionParams getHttpConnectionParams(Configuration conf) {

--- a/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
+++ b/tez-runtime-library/src/main/java/org/apache/tez/runtime/library/common/shuffle/ShuffleUtils.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.text.DecimalFormat;
@@ -245,7 +246,7 @@ public final class ShuffleUtils {
     if (keepAlive) {
       url.append("&keepAlive=true");
     }
-    return new URL(url.toString());
+    return URI.create(url.toString()).toURL();
   }
 
   public static BaseHttpConnection getHttpConnection(boolean asyncHttp, URL url,

--- a/tez-runtime-library/src/test/java/org/apache/tez/http/TestHttpConnection.java
+++ b/tez-runtime-library/src/test/java/org/apache/tez/http/TestHttpConnection.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.channels.ClosedByInterruptException;
@@ -76,7 +77,7 @@ public class TestHttpConnection {
             return t;
           }
         });
-    url = new URL(NOT_HOSTED_URL);
+    url = URI.create(NOT_HOSTED_URL).toURL();
     tokenSecretManager = mock(JobTokenSecretManager.class);
     when(tokenSecretManager.computeHash(any())).thenReturn("1234".getBytes());
   }

--- a/tez-tests/src/test/java/org/apache/tez/test/TestAM.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestAM.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 
 import javax.servlet.http.HttpServletResponse;
@@ -138,12 +139,12 @@ public class TestAM {
     checkAddress(webUIAddress + "/prof-output");
 
     HttpURLConnection connection =
-        (HttpURLConnection) new URL(webUIAddress + "/prof-output?file=../etc/web").openConnection();
+        (HttpURLConnection) URI.create(webUIAddress + "/prof-output?file=../etc/web").toURL().openConnection();
     connection.connect();
     assertEquals(HttpServletResponse.SC_FORBIDDEN, connection.getResponseCode());
     assertTrue(new String(connection.getErrorStream().readAllBytes()).contains("Access denied: Invalid Path"));
 
-    URL url = new URL(webUIAddress);
+    URL url = URI.create(webUIAddress).toURL();
     IntegerRanges portRange = conf.getRange(TezConfiguration.TEZ_AM_WEBSERVICE_PORT_RANGE,
         TezConfiguration.TEZ_AM_WEBSERVICE_PORT_RANGE_DEFAULT);
     assertTrue("WebUIService port should be in the defined range (got: " + url.getPort() + ")",
@@ -159,7 +160,7 @@ public class TestAM {
   private void checkAddress(String url, int expectedCode) {
     boolean success = false;
     try {
-      HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+      HttpURLConnection connection = (HttpURLConnection) URI.create(url).toURL().openConnection();
       connection.connect();
       success = (connection.getResponseCode() == expectedCode);
     } catch (Exception e) {


### PR DESCRIPTION
## What changes were proposed in this PR?
Replace deprecated java.net.URL constructors with URI-based alternatives for Java 20+ compatibility

The `java.net.URL` constructors have been deprecated
since Java 20 and are marked for removal in a future JDK release.
This patch replaces all usages of deprecated URL constructors across the
codebase with the recommended URI-based alternatives.

Linked JIRA:
https://issues.apache.org/jira/browse/TEZ-4726

## How was this patch tested?
- with existed UT