### PR TITLE
TEZ-4733: Fix flaky TestHistoryParser.testParserWithSuccessfulJob

### DIFF
--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/ATSFileParser.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/ATSFileParser.java
@@ -24,6 +24,7 @@ import static org.apache.hadoop.classification.InterfaceStability.Evolving;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
@@ -174,11 +175,23 @@ public class ATSFileParser extends BaseParser implements ATSData {
     }
   }
 
-  private JSONObject readJson(InputStream in) throws IOException, JSONException {
-    //Read entire content to memory
-    final NonSyncByteArrayOutputStream bout = new NonSyncByteArrayOutputStream();
-    IOUtils.copy(in, bout);
-    return new JSONObject(new String(bout.toByteArray(), "UTF-8"));
+  /**
+   * Parse the raw payload of a single zip entry as JSON.
+   * Returns null if the payload is empty or blank — callers should skip such entries.
+   */
+  private JSONObject readJson(byte[] payload, String entryName) throws JSONException {
+    String text = new String(payload, StandardCharsets.UTF_8);
+    if (text.trim().isEmpty()) {
+      LOG.warn("Skipping zip entry '{}' - payload is empty or whitespace only", entryName);
+      return null;
+    }
+    try {
+      return new JSONObject(text);
+    } catch (JSONException e) {
+      String snippet = text.length() > 200 ? text.substring(0, 200) + "..." : text;
+      throw new JSONException("Failed to parse JSON from zip entry '" + entryName
+          + "' (length=" + text.length() + ", snippet=" + snippet + "): " + e.getMessage());
+    }
   }
 
   /**
@@ -197,7 +210,13 @@ public class ATSFileParser extends BaseParser implements ATSData {
         ZipEntry zipEntry = zipEntries.nextElement();
         LOG.debug("Processing " + zipEntry.getName());
         InputStream inputStream = atsZipFile.getInputStream(zipEntry);
-        JSONObject jsonObject = readJson(inputStream);
+        //Read entire content to memory so we can pass entry name into error messages
+        final NonSyncByteArrayOutputStream bout = new NonSyncByteArrayOutputStream();
+        IOUtils.copy(inputStream, bout);
+        JSONObject jsonObject = readJson(bout.toByteArray(), zipEntry.getName());
+        if (jsonObject == null) {
+          continue;
+        }
 
         //This json can contain dag, vertices, tasks, task_attempts
         JSONObject dagJson = jsonObject.optJSONObject(Constants.DAG);

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/ATSFileParser.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/ATSFileParser.java
@@ -176,13 +176,20 @@ public class ATSFileParser extends BaseParser implements ATSData {
   }
 
   /**
-   * Parse the raw payload of a single zip entry as JSON.
-   * Returns null if the payload is empty or blank — callers should skip such entries.
+   * Read a zip entry's payload and parse it as JSON.
+   * Returns null if the payload contains only whitespace (including a zero-length payload) —
+   * callers should skip such entries.
+   *
+   * @throws JSONException if the payload is non-blank but not valid JSON
    */
-  private JSONObject readJson(byte[] payload, String entryName) throws JSONException {
-    String text = new String(payload, StandardCharsets.UTF_8);
+  private JSONObject readJson(InputStream inputStream, String entryName)
+      throws IOException, JSONException {
+    NonSyncByteArrayOutputStream bout = new NonSyncByteArrayOutputStream();
+    IOUtils.copy(inputStream, bout);
+    String text = new String(bout.toByteArray(), StandardCharsets.UTF_8);
     if (text.trim().isEmpty()) {
-      LOG.warn("Skipping zip entry '{}' - payload is empty or whitespace only", entryName);
+      LOG.warn("Skipping zip entry '{}' - payload is whitespace only (length={})",
+          entryName, text.length());
       return null;
     }
     try {
@@ -203,17 +210,15 @@ public class ATSFileParser extends BaseParser implements ATSData {
    */
   private void parseATSZipFile(File atsFile)
       throws IOException, JSONException, TezException, InterruptedException {
-    final ZipFile atsZipFile = new ZipFile(atsFile);
-    try {
+    try (ZipFile atsZipFile = new ZipFile(atsFile)) {
       Enumeration<? extends ZipEntry> zipEntries = atsZipFile.entries();
       while (zipEntries.hasMoreElements()) {
         ZipEntry zipEntry = zipEntries.nextElement();
         LOG.debug("Processing " + zipEntry.getName());
-        InputStream inputStream = atsZipFile.getInputStream(zipEntry);
-        //Read entire content to memory so we can pass entry name into error messages
-        final NonSyncByteArrayOutputStream bout = new NonSyncByteArrayOutputStream();
-        IOUtils.copy(inputStream, bout);
-        JSONObject jsonObject = readJson(bout.toByteArray(), zipEntry.getName());
+        JSONObject jsonObject;
+        try (InputStream inputStream = atsZipFile.getInputStream(zipEntry)) {
+          jsonObject = readJson(inputStream, zipEntry.getName());
+        }
         if (jsonObject == null) {
           continue;
         }
@@ -249,8 +254,6 @@ public class ATSFileParser extends BaseParser implements ATSData {
           processApplication(tezAppJson);
         }
       }
-    } finally {
-      atsZipFile.close();
     }
   }
 }

--- a/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/ATSFileParser.java
+++ b/tez-plugins/tez-history-parser/src/main/java/org/apache/tez/history/parser/ATSFileParser.java
@@ -76,6 +76,16 @@ public class ATSFileParser extends BaseParser implements ATSData {
     try {
       parseATSZipFile(atsZipFile);
 
+      // parseATSZipFile skips whitespace-only zip entries (see readJson) — if no entry
+      // carried the DAG payload, dagInfo is still null and addRawDataToDagInfo would NPE
+      // on BaseParser#addRawDataToDagInfo. Fail fast with a diagnostic naming the archive
+      // and the requested dagId so the caller sees a real TezException.
+      if (dagInfo == null) {
+        throw new TezException("No DAG entry found in ATS archive " + atsZipFile
+            + " for dagId=" + dagId + " (all entries were empty or missing the '"
+            + Constants.DAG + "' payload)");
+      }
+
       linkParsedContents();
       addRawDataToDagInfo();
 

--- a/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/TestHistoryParser.java
+++ b/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/TestHistoryParser.java
@@ -209,14 +209,13 @@ public class TestHistoryParser {
     String dagId = runWordCount(WordCount.TokenProcessor.class.getName(),
         WordCount.SumProcessor.class.getName(), "WordCount", true);
 
-    //Export the data from ATS
-    String[] args = { "--dagId=" + dagId, "--downloadDir=" + DOWNLOAD_DIR, "--yarnTimelineAddress=" + yarnTimelineAddress };
+    //Retry the ATS export+parse pipeline until the resulting DagInfo actually contains
+    //the expected DAG (two vertices, non-empty vertices/tasks). Under load the AM's async
+    //flush and the timeline server's write path can race the export, leaving empty/partial
+    //entities in the zip. Before TEZ-4733 that produced a misleading
+    //"A JSONObject text must begin with '{'" JSONException at parse time.
+    DagInfo dagInfoFromATS = fetchDagInfoFromAtsWithRetry(dagId, 6, 5_000L);
 
-    int result = ATSImportTool.process(args);
-    assertEquals(0, result);
-
-    //Parse ATS data and verify results
-    DagInfo dagInfoFromATS = getDagInfo(dagId);
     verifyDagInfo(dagInfoFromATS, true);
     verifyJobSpecificInfo(dagInfoFromATS);
     checkConfig(dagInfoFromATS);
@@ -224,7 +223,8 @@ public class TestHistoryParser {
     //Now run with SimpleHistoryLogging
     dagId = runWordCount(WordCount.TokenProcessor.class.getName(),
         WordCount.SumProcessor.class.getName(), "WordCount", false);
-    Thread.sleep(10000); //For all flushes to happen and to avoid half-cooked download.
+
+    waitForHistoryFileReady(dagId, 60_000L);
 
     DagInfo shDagInfo = getDagInfoFromSimpleHistory(dagId);
     verifyDagInfo(shDagInfo, false);
@@ -232,6 +232,77 @@ public class TestHistoryParser {
 
     //Compare dagInfo by parsing ATS data with DagInfo obtained by parsing SimpleHistoryLog
     isDAGEqual(dagInfoFromATS, shDagInfo);
+  }
+
+  /**
+   * the ATS write path is async (AM event queue → timeline client →
+   * timeline server). Even after the DAG client reports the job complete, timeline entities
+   * may still be in transit. Downloading too early produced empty zip entries and a
+   * misleading JSONException: A JSONObject text must begin with '{'} at parse time.
+   */
+  private DagInfo fetchDagInfoFromAtsWithRetry(String dagId, int maxAttempts,
+      long delayMs) throws Exception {
+    String[] args = { "--dagId=" + dagId, "--downloadDir=" + DOWNLOAD_DIR,
+        "--yarnTimelineAddress=" + yarnTimelineAddress };
+    Exception lastError = null;
+    DagInfo lastPartial = null;
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        // Fresh download every attempt — ATSImportTool overwrites the zip.
+        int result = ATSImportTool.process(args);
+        assertEquals(0, result);
+        DagInfo info = getDagInfo(dagId);
+        if (isDagInfoComplete(info)) {
+          return info;
+        }
+        lastPartial = info;
+      } catch (Exception e) {
+        lastError = e;
+      }
+      if (attempt < maxAttempts) {
+        Thread.sleep(delayMs);
+      }
+    }
+    fail("Could not fetch a complete DagInfo for " + dagId + " after " + maxAttempts
+        + " attempts (lastError=" + lastError + ", lastPartial="
+        + (lastPartial == null ? "null"
+            : "vertices=" + lastPartial.getVertices().size()
+            + ", tasks=" + (lastPartial.getVertices().isEmpty() ? 0
+                : lastPartial.getVertices().iterator().next().getTasks().size()))
+        + ")");
+    return null;
+  }
+
+  private static boolean isDagInfoComplete(DagInfo info) {
+    return info != null
+        && info.getVertices().size() >= 2
+        && info.getVertices().stream().allMatch(v ->
+            !v.getTasks().isEmpty()
+                && v.getTasks().stream().allMatch(t -> !t.getTaskAttempts().isEmpty()));
+  }
+
+  private void waitForHistoryFileReady(String dagId, long timeoutMs) throws Exception {
+    TezDAGID tezDAGID = TezDAGID.fromString(dagId);
+    ApplicationAttemptId applicationAttemptId = ApplicationAttemptId.newInstance(tezDAGID
+        .getApplicationId(), 1);
+    Path historyPath = new Path(conf.get("fs.defaultFS")
+        + SIMPLE_HISTORY_DIR + HISTORY_TXT + "."
+        + applicationAttemptId);
+    FileSystem hfs = historyPath.getFileSystem(conf);
+    long deadline = System.currentTimeMillis() + timeoutMs;
+    long lastLen = -1L;
+    while (System.currentTimeMillis() < deadline) {
+      if (hfs.exists(historyPath)) {
+        long len = hfs.getFileStatus(historyPath).getLen();
+        if (len > 0 && len == lastLen) {
+          return;
+        }
+        lastLen = len;
+      }
+      Thread.sleep(500);
+    }
+    fail("Timed out waiting for SimpleHistory file " + historyPath
+        + " to be ready within " + timeoutMs + "ms (lastLen=" + lastLen + ")");
   }
 
   private DagInfo getDagInfoFromSimpleHistory(String dagId) throws TezException, IOException {

--- a/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/TestHistoryParser.java
+++ b/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/TestHistoryParser.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
@@ -118,6 +119,7 @@ public class TestHistoryParser {
   private final static String SUMMATION = "Summation";
   private final static String SIMPLE_HISTORY_DIR = "/tmp/simplehistory/";
   private final static String HISTORY_TXT = "history.txt";
+  private static final long ATS_RETRY_DELAY_MS = 5_000L;
 
   private static Configuration conf = new Configuration();
   private static FileSystem fs;
@@ -212,9 +214,8 @@ public class TestHistoryParser {
     //Retry the ATS export+parse pipeline until the resulting DagInfo actually contains
     //the expected DAG (two vertices, non-empty vertices/tasks). Under load the AM's async
     //flush and the timeline server's write path can race the export, leaving empty/partial
-    //entities in the zip. Before TEZ-4733 that produced a misleading
-    //"A JSONObject text must begin with '{'" JSONException at parse time.
-    DagInfo dagInfoFromATS = fetchDagInfoFromAtsWithRetry(dagId, 6, 5_000L);
+    //entities in the zip.
+    DagInfo dagInfoFromATS = fetchDagInfoFromAtsWithRetry(dagId, 6, 2);
 
     verifyDagInfo(dagInfoFromATS, true);
     verifyJobSpecificInfo(dagInfoFromATS);
@@ -235,32 +236,33 @@ public class TestHistoryParser {
   }
 
   /**
-   * the ATS write path is async (AM event queue → timeline client →
-   * timeline server). Even after the DAG client reports the job complete, timeline entities
-   * may still be in transit. Downloading too early produced empty zip entries and a
-   * misleading JSONException: A JSONObject text must begin with '{'} at parse time.
+   * The ATS write path is async (AM event queue → timeline client → timeline server). Even
+   * after the DAG client reports the job complete, timeline entities may still be in transit,
+   * so an export triggered right after completion can capture a partial snapshot (empty zip
+   * entries, or a DagInfo with fewer vertices / empty task lists). Retry the export+parse
+   * pipeline until {@link #isDagInfoComplete} confirms the snapshot is populated.
    */
   private DagInfo fetchDagInfoFromAtsWithRetry(String dagId, int maxAttempts,
-      long delayMs) throws Exception {
+      int expectedNumOfVertices) throws Exception {
     String[] args = { "--dagId=" + dagId, "--downloadDir=" + DOWNLOAD_DIR,
         "--yarnTimelineAddress=" + yarnTimelineAddress };
     Exception lastError = null;
     DagInfo lastPartial = null;
-    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+    for (int attempt = 0; attempt < maxAttempts; attempt++) {
       try {
         // Fresh download every attempt — ATSImportTool overwrites the zip.
         int result = ATSImportTool.process(args);
         assertEquals(0, result);
         DagInfo info = getDagInfo(dagId);
-        if (isDagInfoComplete(info)) {
+        if (isDagInfoComplete(info, expectedNumOfVertices)) {
           return info;
         }
         lastPartial = info;
       } catch (Exception e) {
         lastError = e;
       }
-      if (attempt < maxAttempts) {
-        Thread.sleep(delayMs);
+      if (attempt < maxAttempts - 1) {
+        Thread.sleep(ATS_RETRY_DELAY_MS);
       }
     }
     fail("Could not fetch a complete DagInfo for " + dagId + " after " + maxAttempts
@@ -273,9 +275,16 @@ public class TestHistoryParser {
     return null;
   }
 
-  private static boolean isDagInfoComplete(DagInfo info) {
+  /**
+   * ATS parsing can succeed on a partially-written zip: the reader returns a DagInfo with
+   * fewer vertices than the DAG actually has, or vertices whose task/attempt lists are still
+   * empty. That's the race we're guarding against — a "successful" parse is not proof the
+   * export was complete. We know the expected vertex count from the DAG under test, so require
+   * it explicitly and require every vertex to have at least one task with at least one attempt.
+   */
+  private static boolean isDagInfoComplete(DagInfo info, int expectedNumOfVertices) {
     return info != null
-        && info.getVertices().size() >= 2
+        && info.getVertices().size() >= expectedNumOfVertices
         && info.getVertices().stream().allMatch(v ->
             !v.getTasks().isEmpty()
                 && v.getTasks().stream().allMatch(t -> !t.getTaskAttempts().isEmpty()));
@@ -283,15 +292,13 @@ public class TestHistoryParser {
 
   private void waitForHistoryFileReady(String dagId, long timeoutMs) throws Exception {
     TezDAGID tezDAGID = TezDAGID.fromString(dagId);
-    ApplicationAttemptId applicationAttemptId = ApplicationAttemptId.newInstance(tezDAGID
-        .getApplicationId(), 1);
+    ApplicationAttemptId applicationAttemptId = ApplicationAttemptId.newInstance(tezDAGID.getApplicationId(), 1);
     Path historyPath = new Path(conf.get("fs.defaultFS")
-        + SIMPLE_HISTORY_DIR + HISTORY_TXT + "."
-        + applicationAttemptId);
+        + SIMPLE_HISTORY_DIR + HISTORY_TXT + "." + applicationAttemptId);
     FileSystem hfs = historyPath.getFileSystem(conf);
-    long deadline = System.currentTimeMillis() + timeoutMs;
+    long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
     long lastLen = -1L;
-    while (System.currentTimeMillis() < deadline) {
+    while (System.nanoTime() < deadlineNanos) {
       if (hfs.exists(historyPath)) {
         long len = hfs.getFileStatus(historyPath).getLen();
         if (len > 0 && len == lastLen) {

--- a/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/TestHistoryParser.java
+++ b/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/TestHistoryParser.java
@@ -28,6 +28,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -37,8 +38,10 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -252,7 +255,9 @@ public class TestHistoryParser {
       try {
         // Fresh download every attempt — ATSImportTool overwrites the zip.
         int result = ATSImportTool.process(args);
-        assertEquals(0, result);
+        if (result != 0) {
+          throw new IOException("ATS export failed with exit code: " + result);
+        }
         DagInfo info = getDagInfo(dagId);
         if (isDagInfoComplete(info, expectedNumOfVertices)) {
           return info;
@@ -290,9 +295,19 @@ public class TestHistoryParser {
                 && v.getTasks().stream().allMatch(t -> !t.getTaskAttempts().isEmpty()));
   }
 
+  /**
+   * SimpleHistoryLoggingService writes events asynchronously and only hflushes/closes the file
+   * when the AM shuts down (see SimpleHistoryLoggingService#serviceStop). Two equal-length size
+   * samples do not prove the writer has finished — it can pause between events while the file
+   * is still open. Poll for the terminal DAG record instead: a JSON object with
+   * {@code "eventType":"DAG_FINISHED"} that carries this DAG's entityId. That record is the
+   * last one {@link SimpleHistoryLoggingService} emits for the DAG, so its presence guarantees
+   * the snapshot the parser will read is complete.
+   */
   private void waitForHistoryFileReady(String dagId, long timeoutMs) throws Exception {
     TezDAGID tezDAGID = TezDAGID.fromString(dagId);
-    ApplicationAttemptId applicationAttemptId = ApplicationAttemptId.newInstance(tezDAGID.getApplicationId(), 1);
+    ApplicationAttemptId applicationAttemptId =
+        ApplicationAttemptId.newInstance(tezDAGID.getApplicationId(), 1);
     Path historyPath = new Path(conf.get("fs.defaultFS")
         + SIMPLE_HISTORY_DIR + HISTORY_TXT + "." + applicationAttemptId);
     FileSystem hfs = historyPath.getFileSystem(conf);
@@ -300,16 +315,30 @@ public class TestHistoryParser {
     long lastLen = -1L;
     while (System.nanoTime() < deadlineNanos) {
       if (hfs.exists(historyPath)) {
-        long len = hfs.getFileStatus(historyPath).getLen();
-        if (len > 0 && len == lastLen) {
+        lastLen = hfs.getFileStatus(historyPath).getLen();
+        if (lastLen > 0 && hasDagFinishedRecord(hfs, historyPath, dagId)) {
           return;
         }
-        lastLen = len;
       }
       Thread.sleep(500);
     }
     fail("Timed out waiting for SimpleHistory file " + historyPath
-        + " to be ready within " + timeoutMs + "ms (lastLen=" + lastLen + ")");
+        + " to contain DAG_FINISHED for " + dagId + " within " + timeoutMs + "ms (lastLen="
+        + lastLen + ")");
+  }
+
+  /**
+   * Return true if the history file contains a DAG_FINISHED record for the given dagId. The
+   * check reads the file's current bytes and searches for the two markers the JSON encoding
+   * always emits together (see HistoryEventJsonConversion#convertDAGFinishedEvent):
+   */
+  private static boolean hasDagFinishedRecord(FileSystem hfs, Path historyPath, String dagId)
+      throws IOException {
+    try (FSDataInputStream in = hfs.open(historyPath)) {
+      String contents = new String(IOUtils.toByteArray(in), StandardCharsets.UTF_8);
+      return contents.contains("\"entityId\":\"" + dagId + "\"")
+          && contents.contains("\"eventType\":\"DAG_FINISHED\"");
+    }
   }
 
   private DagInfo getDagInfoFromSimpleHistory(String dagId) throws TezException, IOException {

--- a/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/parser/TestATSFileParser.java
+++ b/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/parser/TestATSFileParser.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.tez.history.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.apache.tez.dag.api.TezException;
+import org.apache.tez.history.parser.datamodel.DagInfo;
+
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestATSFileParser {
+
+  private static final String DAG_ID = "dag_1234567890_0001_1";
+
+  private static JSONObject minimalDagJson() throws JSONException {
+    JSONObject dag = new JSONObject();
+    dag.put("entityId", DAG_ID);
+    dag.put("entityType", "TEZ_DAG_ID");
+    JSONObject otherInfo = new JSONObject();
+    otherInfo.put("startTime", 1L);
+    otherInfo.put("endTime", 2L);
+    otherInfo.put("status", "SUCCEEDED");
+    otherInfo.put("counters", new JSONObject().put("counterGroups", new JSONArray()));
+    dag.put("otherInfo", otherInfo);
+    return dag;
+  }
+
+  private static File writeZip(Path dir, String name, ZipContent... entries) throws Exception {
+    File zip = dir.resolve(name).toFile();
+    try (FileOutputStream fos = new FileOutputStream(zip);
+         ZipOutputStream zos = new ZipOutputStream(fos)) {
+      for (ZipContent entry : entries) {
+        zos.putNextEntry(new ZipEntry(entry.name()));
+        zos.write(entry.payload().getBytes(StandardCharsets.UTF_8));
+        zos.closeEntry();
+      }
+    }
+    return zip;
+  }
+
+  @Test
+  public void parserSkipsEmptyZipEntryAndParsesRemaining(@TempDir Path tmp) throws Exception {
+    JSONObject dagRoot = new JSONObject().put("dag", minimalDagJson());
+
+    File zip = writeZip(tmp, "empty-then-good.zip",
+        new ZipContent("empty-part.json", ""),
+        new ZipContent("whitespace-part.json", "   \n\t  "),
+        new ZipContent(DAG_ID, dagRoot.toString()));
+
+    ATSFileParser parser = new ATSFileParser(Collections.singletonList(zip));
+    DagInfo info = parser.getDAGData(DAG_ID);
+
+    assertNotNull(info, "Parser should return DagInfo even when some entries are empty");
+    assertEquals(DAG_ID, info.getDagId());
+    assertEquals("SUCCEEDED", info.getStatus());
+  }
+
+  @Test
+  public void parserReportsOffendingEntryOnMalformedJson(@TempDir Path tmp) throws Exception {
+    // Simulates the timeline server returning an HTML error page instead of JSON.
+    File zip = writeZip(tmp, "malformed.zip",
+        new ZipContent(DAG_ID, "<html><body>internal error</body></html>"));
+
+    ATSFileParser parser = new ATSFileParser(Collections.singletonList(zip));
+    TezException thrown = assertThrows(TezException.class, () -> parser.getDAGData(DAG_ID));
+
+    Throwable cause = thrown.getCause();
+    assertNotNull(cause);
+    String msg = cause.getMessage();
+    assertNotNull(msg);
+    assertTrue(msg.contains(DAG_ID),
+        "Error should name the offending zip entry, got: " + msg);
+    assertTrue(msg.contains("<html>"),
+        "Error should include a snippet of the offending payload, got: " + msg);
+  }
+
+  private record ZipContent(String name, String payload) {
+  }
+}

--- a/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/parser/TestATSFileParser.java
+++ b/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/parser/TestATSFileParser.java
@@ -100,10 +100,8 @@ public class TestATSFileParser {
     assertNotNull(cause);
     String msg = cause.getMessage();
     assertNotNull(msg);
-    assertTrue(msg.contains(DAG_ID),
-        "Error should name the offending zip entry, got: " + msg);
-    assertTrue(msg.contains("<html>"),
-        "Error should include a snippet of the offending payload, got: " + msg);
+    assertTrue(msg.contains(DAG_ID), "Error should name the offending zip entry, got: " + msg);
+    assertTrue(msg.contains("<html>"), "Error should include a snippet of the offending payload, got: " + msg);
   }
 
   private record ZipContent(String name, String payload) {

--- a/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/parser/TestATSFileParser.java
+++ b/tez-plugins/tez-history-parser/src/test/java/org/apache/tez/history/parser/TestATSFileParser.java
@@ -88,6 +88,20 @@ public class TestATSFileParser {
   }
 
   @Test
+  public void parserRejectsArchiveWithNoDagEntry(@TempDir Path tmp) throws Exception {
+    File zip = writeZip(tmp, "all-blank.zip",
+        new ZipContent("empty-part.json", ""),
+        new ZipContent("whitespace-part.json", "   \n\t  "));
+
+    ATSFileParser parser = new ATSFileParser(Collections.singletonList(zip));
+    TezException thrown = assertThrows(TezException.class, () -> parser.getDAGData(DAG_ID));
+    String msg = thrown.getMessage();
+    assertNotNull(msg);
+    assertTrue(msg.contains(DAG_ID), "Error should name the requested dagId, got: " + msg);
+    assertTrue(msg.contains("all-blank.zip"), "Error should name the archive, got: " + msg);
+  }
+
+  @Test
   public void parserReportsOffendingEntryOnMalformedJson(@TempDir Path tmp) throws Exception {
     // Simulates the timeline server returning an HTML error page instead of JSON.
     File zip = writeZip(tmp, "malformed.zip",


### PR DESCRIPTION
#### Problem                                                                                                                                                                                                             
  org.apache.tez.history.TestHistoryParser.testParserWithSuccessfulJob fails intermittently with:                                                                                                                                                 
```
  JSONException: A JSONObject text must begin with '{' at character 0 of                                                      
      at ATSFileParser.readJson(ATSFileParser.java:181)                                                                       
      at ATSFileParser.parseATSZipFile(...)                                                                                   
      at ATSFileParser.getDAGData(...)     
```                                                                                                                                                                                                               
####  Root cause
After the DAG client returns, ATSHistoryLoggingService still has history events in an async queue that must be  
  flushed to the timeline server. The test previously called ATSImportTool.process(...) immediately, so under load the        
  download could race the timeline write path — **producing a zip whose entries were empty/whitespace**, which then failed JSON parsing with the misleading "must begin with {" error. 
A fixed Thread.sleep(10000) was already present before the SimpleHistory parse path (as a workaround for the same class of race), but there was no equivalent guard for the ATS parse path.
####  Changes
  1. ATSFileParser: 
    - skip empty/whitespace zip entries with a WARN; enrich JSON parse errors with the offending entry name + payload snippet.                                                                                                            
  2. TestHistoryParser: 
   -replaced the unguarded ATS export+parse with a retry loop that only accepts a DagInfo with ≥2        
  vertices, tasks, and attempts. 
   -replaced the fixed Thread.sleep(10000) before SimpleHistory parse with a                     
  poll-until-file-size-stable.                                                                                                
  3. New TestATSFileParser:
    -New tests added that checks (empty entry skipped, malformed entry names itself in the error).

