### PR TITLE
TEZ-4725: Fix flaky tests in TestAMRecoveryAggregationBroadcast

### DIFF
--- a/tez-api/src/main/java/org/apache/tez/client/TezClientUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/client/TezClientUtils.java
@@ -961,7 +961,26 @@ public final class TezClientUtils {
       throw new TezException(e);
     }
 
-    return getAMProxy(conf, appReport.getHost(), appReport.getRpcPort(),
+    // YARN-808 gap: when the AM container is first allocated YARN briefly
+    // reports state=RUNNING before the AM has registered with the RM or bound
+    // its RPC listener. During that window the ApplicationReport contains
+    // sentinel values that must not be passed to
+    // NetUtils.createSocketAddrForHost() (which would throw
+    // IllegalArgumentException: port out of range) or to RPC.getProxy():
+    //   host == null / "N/A" : RM has not received registerApplicationMaster()
+    //   rpcPort == 0         : protobuf wire default
+    //   rpcPort == -1        : container up but RPC listener not yet bound
+    // Returning null lets callers (waitForProxy, sendAMHeartbeat) back off
+    // and retry rather than crash.
+    String amHost = appReport.getHost();
+    int amRpcPort = appReport.getRpcPort();
+    if (amHost == null || amHost.equals("N/A") || amRpcPort <= 0) {
+      LOG.debug("AM RPC endpoint not yet available for {} (host={}, port={})"
+          + " - will retry", applicationId, amHost, amRpcPort);
+      return null;
+    }
+
+    return getAMProxy(conf, amHost, amRpcPort,
         appReport.getClientToAMToken(), ugi);
   }
 

--- a/tez-api/src/main/java/org/apache/tez/client/TezClientUtils.java
+++ b/tez-api/src/main/java/org/apache/tez/client/TezClientUtils.java
@@ -961,27 +961,35 @@ public final class TezClientUtils {
       throw new TezException(e);
     }
 
-    // YARN-808 gap: when the AM container is first allocated YARN briefly
-    // reports state=RUNNING before the AM has registered with the RM or bound
-    // its RPC listener. During that window the ApplicationReport contains
-    // sentinel values that must not be passed to
-    // NetUtils.createSocketAddrForHost() (which would throw
-    // IllegalArgumentException: port out of range) or to RPC.getProxy():
-    //   host == null / "N/A" : RM has not received registerApplicationMaster()
-    //   rpcPort == 0         : protobuf wire default
-    //   rpcPort == -1        : container up but RPC listener not yet bound
     // Returning null lets callers (waitForProxy, sendAMHeartbeat) back off
     // and retry rather than crash.
-    String amHost = appReport.getHost();
-    int amRpcPort = appReport.getRpcPort();
-    if (amHost == null || amHost.equals("N/A") || amRpcPort <= 0) {
+    if (isAMRpcEndpointUnavailable(appReport)) {
       LOG.debug("AM RPC endpoint not yet available for {} (host={}, port={})"
-          + " - will retry", applicationId, amHost, amRpcPort);
+          + " - will retry", applicationId, appReport.getHost(), appReport.getRpcPort());
       return null;
     }
 
-    return getAMProxy(conf, amHost, amRpcPort,
+    return getAMProxy(conf, appReport.getHost(), appReport.getRpcPort(),
         appReport.getClientToAMToken(), ugi);
+  }
+
+  /**
+   * Returns true when appReport does NOT yet expose an AM RPC
+   * endpoint that is safe to hand to org.apache.hadoop.net.NetUtils#createSocketAddrForHost.
+   * YARN-808 gap: when the AM container is first allocated YARN briefly
+   * reports state=RUNNING before the AM has registered with the RM or bound
+   * its RPC listener. During that window the ApplicationReport contains
+   * sentinel values that must not be passed to the RPC layer (which would
+   * throw IllegalArgumentException: port out of range):
+   *   host == null / "N/A" : RM has not received registerApplicationMaster()
+   *   rpcPort == 0         : protobuf wire default
+   *   rpcPort == -1        : container up but RPC listener not yet bound
+   */
+  @Private
+  public static boolean isAMRpcEndpointUnavailable(ApplicationReport appReport) {
+    String amHost = appReport.getHost();
+    int amRpcPort = appReport.getRpcPort();
+    return amHost == null || amHost.equals("N/A") || amRpcPort <= 0;
   }
 
   @Private

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/rpc/DAGClientRPCImpl.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/rpc/DAGClientRPCImpl.java
@@ -280,10 +280,14 @@ public class DAGClientRPCImpl extends DAGClientInternal {
     }
 
     // YARN-808. Cannot ascertain if AM is ready until we connect to it.
-    // workaround check the default string set by YARN
-    if(appReport.getHost() == null || appReport.getHost().equals("N/A") ||
-        appReport.getRpcPort() == 0){
-      // attempt not running
+    // Workaround: check the default strings/sentinels set by YARN.
+    //   port == 0  : protobuf wire default, AM has not called
+    //                registerApplicationMaster() yet.
+    //   port == -1 : AM container is allocated (state=RUNNING) but the
+    //                RPC listener has not been bound yet.
+    if (appReport.getHost() == null || appReport.getHost().equals("N/A") ||
+        appReport.getRpcPort() <= 0) {
+      // AM RPC endpoint not yet available
       return false;
     }
 

--- a/tez-api/src/main/java/org/apache/tez/dag/api/client/rpc/DAGClientRPCImpl.java
+++ b/tez-api/src/main/java/org/apache/tez/dag/api/client/rpc/DAGClientRPCImpl.java
@@ -280,14 +280,8 @@ public class DAGClientRPCImpl extends DAGClientInternal {
     }
 
     // YARN-808. Cannot ascertain if AM is ready until we connect to it.
-    // Workaround: check the default strings/sentinels set by YARN.
-    //   port == 0  : protobuf wire default, AM has not called
-    //                registerApplicationMaster() yet.
-    //   port == -1 : AM container is allocated (state=RUNNING) but the
-    //                RPC listener has not been bound yet.
-    if (appReport.getHost() == null || appReport.getHost().equals("N/A") ||
-        appReport.getRpcPort() <= 0) {
-      // AM RPC endpoint not yet available
+    if (TezClientUtils.isAMRpcEndpointUnavailable(appReport)) {
+      // AM RPC endpoint not yet available - try again on the next poll.
       return false;
     }
 

--- a/tez-api/src/test/java/org/apache/tez/client/TestTezClientUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/client/TestTezClientUtils.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -54,16 +56,19 @@ import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.io.DataInputByteBuffer;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
 import org.apache.hadoop.yarn.api.records.ContainerLaunchContext;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.apache.hadoop.yarn.api.records.Resource;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.util.Records;
@@ -1002,5 +1007,42 @@ public class TestTezClientUtils {
     // if there is another token in am conf creds of the same token type,
     // session token should be applied while creating ContainerLaunchContext
     assertEquals(sessionToken, amLaunchCredentials.getToken(tokenType));
+  }
+
+  /**
+   * Covers the YARN-808 guard in TezClientUtils#getAMProxy
+   */
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testGetAMProxyReturnsNullWhenRpcEndpointNotAvailable() throws Exception {
+    TezConfiguration conf = new TezConfiguration();
+    ApplicationId appId = ApplicationId.newInstance(1L, 1);
+    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+
+    // Case 1: rpcPort == -1  (YARN-808 gap — AM container up, RPC not bound)
+    assertNull(TezClientUtils.getAMProxy(
+        newRunningFrameworkClient(appId, "somehost", -1), conf, appId, ugi),
+        "rpcPort == -1 should return null");
+
+    // Case 2: rpcPort == 0  (protobuf wire default)
+    assertNull(TezClientUtils.getAMProxy(
+        newRunningFrameworkClient(appId, "somehost", 0), conf, appId, ugi),
+        "rpcPort == 0 should return null");
+
+    // Case 3: host == "N/A"  (RM has not yet received AM registration)
+    assertNull(TezClientUtils.getAMProxy(
+        newRunningFrameworkClient(appId, "N/A", 8080), conf, appId, ugi),
+        "host == N/A should return null");
+  }
+
+  private static FrameworkClient newRunningFrameworkClient(ApplicationId appId,
+      String host, int rpcPort) throws IOException, YarnException {
+    ApplicationReport report = mock(ApplicationReport.class);
+    when(report.getYarnApplicationState()).thenReturn(YarnApplicationState.RUNNING);
+    when(report.getHost()).thenReturn(host);
+    when(report.getRpcPort()).thenReturn(rpcPort);
+    FrameworkClient frameworkClient = mock(FrameworkClient.class);
+    when(frameworkClient.getApplicationReport(appId)).thenReturn(report);
+    return frameworkClient;
   }
 }

--- a/tez-api/src/test/java/org/apache/tez/client/TestTezClientUtils.java
+++ b/tez-api/src/test/java/org/apache/tez/client/TestTezClientUtils.java
@@ -1033,6 +1033,11 @@ public class TestTezClientUtils {
     assertNull(TezClientUtils.getAMProxy(
         newRunningFrameworkClient(appId, "N/A", 8080), conf, appId, ugi),
         "host == N/A should return null");
+
+    // Case 4: host == null  (RM has not yet received AM registration)
+    assertNull(TezClientUtils.getAMProxy(
+        newRunningFrameworkClient(appId, null, 8080), conf, appId, ugi),
+        "host == null should return null");
   }
 
   private static FrameworkClient newRunningFrameworkClient(ApplicationId appId,

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClient.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClient.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.tez.client.FrameworkClient;
 import org.apache.tez.common.CachedEntity;
@@ -722,6 +723,55 @@ public class TestDAGClient {
         assertEquals(1, dagClientImpl.numGetStatusViaRmInvocations);
         assertEquals(1, dagClientRpc.numGetStatusViaAmInvocations);
       }
+    }
+  }
+
+  /**
+   * Covers the YARN-808 guard in DAGClientRPCImpl#createAMProxyIfNeeded
+   */
+  @Test
+  @Timeout(value = 5000, unit = TimeUnit.MILLISECONDS)
+  public void testCreateAMProxyIfNeededReturnsFalseOnBadEndpoint() throws Exception {
+    TezConfiguration tezConf = new TezConfiguration();
+
+    // Case: rpcPort == 0 (protobuf default sentinel).
+    assertFalse(mockReportClient(tezConf, "somehost", 0).createAMProxyIfNeeded(),
+        "rpcPort == 0 should return false");
+
+    // Case: rpcPort == -1 (YARN-808 gap — AM allocated but RPC not bound).
+    assertFalse(mockReportClient(tezConf, "somehost", -1).createAMProxyIfNeeded(),
+        "rpcPort == -1 should return false");
+
+    // Case: host == null.
+    assertFalse(mockReportClient(tezConf, null, 8080).createAMProxyIfNeeded(),
+        "host == null should return false");
+
+    // Case: host == "N/A".
+    assertFalse(mockReportClient(tezConf, "N/A", 8080).createAMProxyIfNeeded(),
+        "host == N/A should return false");
+  }
+
+  private DAGClientRPCImplWithFakeReport mockReportClient(TezConfiguration conf,
+      String host, int rpcPort) throws IOException {
+    ApplicationReport report = mock(ApplicationReport.class);
+    when(report.getYarnApplicationState()).thenReturn(YarnApplicationState.RUNNING);
+    when(report.getHost()).thenReturn(host);
+    when(report.getRpcPort()).thenReturn(rpcPort);
+    return new DAGClientRPCImplWithFakeReport(mockAppId, dagIdStr, conf, report);
+  }
+
+  private static final class DAGClientRPCImplWithFakeReport extends DAGClientRPCImpl {
+    private final ApplicationReport fakeReport;
+
+    DAGClientRPCImplWithFakeReport(ApplicationId appId, String dagId,
+        TezConfiguration conf, ApplicationReport fakeReport) throws IOException {
+      super(appId, dagId, conf, null, UserGroupInformation.getCurrentUser());
+      this.fakeReport = fakeReport;
+    }
+
+    @Override
+    ApplicationReport getAppReport() {
+      return fakeReport;
     }
   }
 

--- a/tez-api/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClient.java
+++ b/tez-api/src/test/java/org/apache/tez/dag/api/client/rpc/TestDAGClient.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.util.Records;
 import org.apache.tez.client.FrameworkClient;
 import org.apache.tez.common.CachedEntity;
 import org.apache.tez.dag.api.NoCurrentDAGException;
@@ -735,28 +736,32 @@ public class TestDAGClient {
     TezConfiguration tezConf = new TezConfiguration();
 
     // Case: rpcPort == 0 (protobuf default sentinel).
-    assertFalse(mockReportClient(tezConf, "somehost", 0).createAMProxyIfNeeded(),
-        "rpcPort == 0 should return false");
+    try (DAGClientRPCImplWithFakeReport client = newFakeReportClient(tezConf, "somehost", 0)) {
+      assertFalse(client.createAMProxyIfNeeded(), "rpcPort == 0 should return false");
+    }
 
     // Case: rpcPort == -1 (YARN-808 gap — AM allocated but RPC not bound).
-    assertFalse(mockReportClient(tezConf, "somehost", -1).createAMProxyIfNeeded(),
-        "rpcPort == -1 should return false");
+    try (DAGClientRPCImplWithFakeReport client = newFakeReportClient(tezConf, "somehost", -1)) {
+      assertFalse(client.createAMProxyIfNeeded(), "rpcPort == -1 should return false");
+    }
 
     // Case: host == null.
-    assertFalse(mockReportClient(tezConf, null, 8080).createAMProxyIfNeeded(),
-        "host == null should return false");
+    try (DAGClientRPCImplWithFakeReport client = newFakeReportClient(tezConf, null, 8080)) {
+      assertFalse(client.createAMProxyIfNeeded(), "host == null should return false");
+    }
 
     // Case: host == "N/A".
-    assertFalse(mockReportClient(tezConf, "N/A", 8080).createAMProxyIfNeeded(),
-        "host == N/A should return false");
+    try (DAGClientRPCImplWithFakeReport client = newFakeReportClient(tezConf, "N/A", 8080)) {
+      assertFalse(client.createAMProxyIfNeeded(), "host == N/A should return false");
+    }
   }
 
-  private DAGClientRPCImplWithFakeReport mockReportClient(TezConfiguration conf,
+  private DAGClientRPCImplWithFakeReport newFakeReportClient(TezConfiguration conf,
       String host, int rpcPort) throws IOException {
-    ApplicationReport report = mock(ApplicationReport.class);
-    when(report.getYarnApplicationState()).thenReturn(YarnApplicationState.RUNNING);
-    when(report.getHost()).thenReturn(host);
-    when(report.getRpcPort()).thenReturn(rpcPort);
+    ApplicationReport report = Records.newRecord(ApplicationReport.class);
+    report.setYarnApplicationState(YarnApplicationState.RUNNING);
+    report.setHost(host);
+    report.setRpcPort(rpcPort);
     return new DAGClientRPCImplWithFakeReport(mockAppId, dagIdStr, conf, report);
   }
 

--- a/tez-tests/src/test/java/org/apache/tez/test/TestAMRecoveryAggregationBroadcast.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestAMRecoveryAggregationBroadcast.java
@@ -26,6 +26,7 @@ import java.io.OutputStreamWriter;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -68,6 +69,7 @@ import org.apache.tez.dag.api.client.DAGClient;
 import org.apache.tez.dag.api.client.DAGStatus;
 import org.apache.tez.dag.api.client.DAGStatus.State;
 import org.apache.tez.dag.api.client.StatusGetOpts;
+import org.apache.tez.dag.api.client.VertexStatus;
 import org.apache.tez.dag.api.oldrecords.TaskAttemptState;
 import org.apache.tez.dag.app.RecoveryParser;
 import org.apache.tez.dag.history.HistoryEvent;
@@ -105,7 +107,6 @@ public class TestAMRecoveryAggregationBroadcast {
   private static final String TEST_ROOT_DIR = "target" + Path.SEPARATOR
       + TestAMRecoveryAggregationBroadcast.class.getName() + "-tmpDir";
   private static final Path INPUT_FILE = new Path(TEST_ROOT_DIR, "input.csv");
-  private static final Path OUT_PATH = new Path(TEST_ROOT_DIR, "out-groups");
   private static final String EXPECTED_OUTPUT = "1-5\n1-5\n1-5\n1-5\n1-5\n"
       + "2-4\n2-4\n2-4\n2-4\n" + "3-3\n3-3\n3-3\n" + "4-2\n4-2\n" + "5-1\n";
   private static final String TABLE_SCAN_SLEEP = "tez.test.table.scan.sleep";
@@ -119,6 +120,10 @@ public class TestAMRecoveryAggregationBroadcast {
 
   private TezConfiguration tezConf;
   private TezClient tezSession;
+  // Per-test unique output path.
+  // replaces the former static OUT_PATH so that a stale file from a prior run in the same forked JVM
+  // cannot bleed into a later run.
+  private Path outPath;
 
   @BeforeAll
   public static void setupAll() {
@@ -173,6 +178,7 @@ public class TestAMRecoveryAggregationBroadcast {
     Path remoteStagingDir = remoteFs.makeQualified(new Path(TEST_ROOT_DIR, String
         .valueOf(new Random().nextInt(100000))));
     TezClientUtils.ensureStagingDirExists(dfsConf, remoteStagingDir);
+    outPath = new Path(TEST_ROOT_DIR, "out-groups-" + new Random().nextInt(100000));
 
     tezConf = new TezConfiguration(tezCluster.getConfig());
     tezConf.setInt(TezConfiguration.DAG_RECOVERY_MAX_UNFLUSHED_EVENTS, 0);
@@ -204,7 +210,7 @@ public class TestAMRecoveryAggregationBroadcast {
   @Timeout(value = 120000, unit = TimeUnit.MILLISECONDS)
   public void testSucceed() throws Exception {
     DAG dag = createDAG("Succeed");
-    TezCounters counters = runDAGAndVerify(dag, false);
+    TezCounters counters = runDAGAndVerify(dag, false, Collections.emptyList());
     assertEquals(3, counters.findCounter(DAGCounter.NUM_SUCCEEDED_TASKS).getValue());
 
     List<HistoryEvent> historyEvents1 = readRecoveryLog(1);
@@ -221,7 +227,7 @@ public class TestAMRecoveryAggregationBroadcast {
   public void testTableScanTemporalFailure() throws Exception {
     tezConf.setBoolean(TABLE_SCAN_SLEEP, true);
     DAG dag = createDAG("TableScanTemporalFailure");
-    TezCounters counters = runDAGAndVerify(dag, true);
+    TezCounters counters = runDAGAndVerify(dag, true, Collections.emptyList());
     assertEquals(3, counters.findCounter(DAGCounter.NUM_SUCCEEDED_TASKS).getValue());
 
     List<HistoryEvent> historyEvents1 = readRecoveryLog(1);
@@ -242,7 +248,9 @@ public class TestAMRecoveryAggregationBroadcast {
   public void testAggregationTemporalFailure() throws Exception {
     tezConf.setBoolean(AGGREGATION_SLEEP, true);
     DAG dag = createDAG("AggregationTemporalFailure");
-    TezCounters counters = runDAGAndVerify(dag, true);
+    // Wait for TableScan to be SUCCEEDED before killing the
+    TezCounters counters = runDAGAndVerify(dag, true,
+        Collections.singletonList(TABLE_SCAN));
     assertEquals(3, counters.findCounter(DAGCounter.NUM_SUCCEEDED_TASKS).getValue());
 
     List<HistoryEvent> historyEvents1 = readRecoveryLog(1);
@@ -263,7 +271,9 @@ public class TestAMRecoveryAggregationBroadcast {
   public void testMapJoinTemporalFailure() throws Exception {
     tezConf.setBoolean(MAP_JOIN_SLEEP, true);
     DAG dag = createDAG("MapJoinTemporalFailure");
-    TezCounters counters = runDAGAndVerify(dag, true);
+    // Wait for both upstream vertices to be SUCCEEDED before killing the AM
+    TezCounters counters = runDAGAndVerify(dag, true,
+        Arrays.asList(TABLE_SCAN, AGGREGATION));
     assertEquals(3, counters.findCounter(DAGCounter.NUM_SUCCEEDED_TASKS).getValue());
 
     List<HistoryEvent> historyEvents1 = readRecoveryLog(1);
@@ -310,7 +320,7 @@ public class TestAMRecoveryAggregationBroadcast {
 
     DataSinkDescriptor dataSink = MROutput
         .createConfigBuilder(new Configuration(tezConf), TextOutputFormat.class,
-            OUT_PATH.toString())
+            outPath.toString())
         .build();
     // Broadcast Hash Join
     Vertex mapJoinVertex = Vertex
@@ -339,12 +349,20 @@ public class TestAMRecoveryAggregationBroadcast {
     return dag;
   }
 
-  TezCounters runDAGAndVerify(DAG dag, boolean killAM) throws Exception {
+  TezCounters runDAGAndVerify(DAG dag, boolean killAM,
+      List<String> vertexNamesToWaitFor) throws Exception {
     tezSession.waitTillReady();
     DAGClient dagClient = tezSession.submitDAG(dag);
 
     if (killAM) {
-      TimeUnit.SECONDS.sleep(10);
+      // Deterministic wait: block until every named upstream vertex reaches
+      // SUCCEEDED. Replaces a fixed Thread.sleep(10s) which was too short on
+      // slow CI machines and caused the recovery-log assertions below to
+      // fail intermittently.
+      for (String vertexName : vertexNamesToWaitFor) {
+        waitForVertexSucceeded(dagClient, vertexName,
+            TimeUnit.SECONDS.toMillis(60));
+      }
       YarnClient yarnClient = YarnClient.createYarnClient();
       yarnClient.init(tezConf);
       yarnClient.start();
@@ -356,12 +374,38 @@ public class TestAMRecoveryAggregationBroadcast {
     LOG.info("Diagnosis: " + dagStatus.getDiagnostics());
     assertEquals(State.SUCCEEDED, dagStatus.getState());
 
-    FSDataInputStream in = remoteFs.open(new Path(OUT_PATH, "part-v002-o000-r-00000"));
+    FSDataInputStream in = remoteFs.open(new Path(outPath, "part-v002-o000-r-00000"));
     ByteBuffer buf = ByteBuffer.allocate(100);
     in.read(buf);
     buf.flip();
     assertEquals(EXPECTED_OUTPUT, StandardCharsets.UTF_8.decode(buf).toString());
     return dagStatus.getDAGCounters();
+  }
+
+  private void waitForVertexSucceeded(DAGClient dagClient, String vertexName,
+      long timeoutMs) throws Exception {
+    long deadline = System.currentTimeMillis() + timeoutMs;
+    while (System.currentTimeMillis() < deadline) {
+      // Before the vertex is initialized on the AM, getVertexStatus may
+      // return null - treat that the same as NEW / INITIALIZING and keep
+      // polling.
+      VertexStatus status = dagClient.getVertexStatus(vertexName, null);
+      if (status != null) {
+        VertexStatus.State state = status.getState();
+        if (state == VertexStatus.State.SUCCEEDED) {
+          return;
+        }
+        if (state == VertexStatus.State.FAILED
+            || state == VertexStatus.State.KILLED
+            || state == VertexStatus.State.ERROR) {
+          throw new AssertionError("Vertex " + vertexName
+              + " reached terminal non-success state: " + state);
+        }
+      }
+      TimeUnit.MILLISECONDS.sleep(500);
+    }
+    throw new AssertionError("Timeout waiting for vertex " + vertexName
+        + " to reach SUCCEEDED");
   }
 
   private List<HistoryEvent> readRecoveryLog(int attemptNum) throws IOException {

--- a/tez-tests/src/test/java/org/apache/tez/test/TestAMRecoveryAggregationBroadcast.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestAMRecoveryAggregationBroadcast.java
@@ -249,8 +249,7 @@ public class TestAMRecoveryAggregationBroadcast {
     tezConf.setBoolean(AGGREGATION_SLEEP, true);
     DAG dag = createDAG("AggregationTemporalFailure");
     // Wait for TableScan to be SUCCEEDED before killing the
-    TezCounters counters = runDAGAndVerify(dag, true,
-        Collections.singletonList(TABLE_SCAN));
+    TezCounters counters = runDAGAndVerify(dag, true, Collections.singletonList(TABLE_SCAN));
     assertEquals(3, counters.findCounter(DAGCounter.NUM_SUCCEEDED_TASKS).getValue());
 
     List<HistoryEvent> historyEvents1 = readRecoveryLog(1);
@@ -272,8 +271,7 @@ public class TestAMRecoveryAggregationBroadcast {
     tezConf.setBoolean(MAP_JOIN_SLEEP, true);
     DAG dag = createDAG("MapJoinTemporalFailure");
     // Wait for both upstream vertices to be SUCCEEDED before killing the AM
-    TezCounters counters = runDAGAndVerify(dag, true,
-        Arrays.asList(TABLE_SCAN, AGGREGATION));
+    TezCounters counters = runDAGAndVerify(dag, true, Arrays.asList(TABLE_SCAN, AGGREGATION));
     assertEquals(3, counters.findCounter(DAGCounter.NUM_SUCCEEDED_TASKS).getValue());
 
     List<HistoryEvent> historyEvents1 = readRecoveryLog(1);
@@ -319,8 +317,7 @@ public class TestAMRecoveryAggregationBroadcast {
             .create(AggregationProcessor.class.getName()).setUserPayload(payload), 1);
 
     DataSinkDescriptor dataSink = MROutput
-        .createConfigBuilder(new Configuration(tezConf), TextOutputFormat.class,
-            outPath.toString())
+        .createConfigBuilder(new Configuration(tezConf), TextOutputFormat.class, outPath.toString())
         .build();
     // Broadcast Hash Join
     Vertex mapJoinVertex = Vertex
@@ -349,8 +346,7 @@ public class TestAMRecoveryAggregationBroadcast {
     return dag;
   }
 
-  TezCounters runDAGAndVerify(DAG dag, boolean killAM,
-      List<String> vertexNamesToWaitFor) throws Exception {
+  TezCounters runDAGAndVerify(DAG dag, boolean killAM, List<String> vertexNamesToWaitFor) throws Exception {
     tezSession.waitTillReady();
     DAGClient dagClient = tezSession.submitDAG(dag);
 
@@ -360,8 +356,7 @@ public class TestAMRecoveryAggregationBroadcast {
       // slow CI machines and caused the recovery-log assertions below to
       // fail intermittently.
       for (String vertexName : vertexNamesToWaitFor) {
-        waitForVertexSucceeded(dagClient, vertexName,
-            TimeUnit.SECONDS.toMillis(60));
+        waitForVertexSucceeded(dagClient, vertexName, TimeUnit.SECONDS.toMillis(60));
       }
       YarnClient yarnClient = YarnClient.createYarnClient();
       yarnClient.init(tezConf);
@@ -384,28 +379,29 @@ public class TestAMRecoveryAggregationBroadcast {
 
   private void waitForVertexSucceeded(DAGClient dagClient, String vertexName,
       long timeoutMs) throws Exception {
-    long deadline = System.currentTimeMillis() + timeoutMs;
-    while (System.currentTimeMillis() < deadline) {
+    long timeoutNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+    long startNanos = System.nanoTime();
+    while ((System.nanoTime() - startNanos) < timeoutNanos) {
       // Before the vertex is initialized on the AM, getVertexStatus may
-      // return null - treat that the same as NEW / INITIALIZING and keep
-      // polling.
+      // return null - treat that the same as NEW / INITIALIZING and keep polling.
       VertexStatus status = dagClient.getVertexStatus(vertexName, null);
       if (status != null) {
         VertexStatus.State state = status.getState();
-        if (state == VertexStatus.State.SUCCEEDED) {
-          return;
-        }
-        if (state == VertexStatus.State.FAILED
-            || state == VertexStatus.State.KILLED
-            || state == VertexStatus.State.ERROR) {
-          throw new AssertionError("Vertex " + vertexName
-              + " reached terminal non-success state: " + state);
+        switch (state) {
+          case SUCCEEDED -> {
+            return;
+          }
+          case FAILED, KILLED, ERROR ->
+              throw new AssertionError(
+                  "Vertex " + vertexName + " reached terminal non-success state: " + state);
+          default -> {
+            // Still running / initializing; fall through to sleep and poll again.
+          }
         }
       }
       TimeUnit.MILLISECONDS.sleep(500);
     }
-    throw new AssertionError("Timeout waiting for vertex " + vertexName
-        + " to reach SUCCEEDED");
+    throw new AssertionError("Timeout waiting for vertex " + vertexName + " to reach SUCCEEDED");
   }
 
   private List<HistoryEvent> readRecoveryLog(int attemptNum) throws IOException {

--- a/tez-tests/src/test/java/org/apache/tez/test/TestAMRecoveryAggregationBroadcast.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestAMRecoveryAggregationBroadcast.java
@@ -245,7 +245,7 @@ public class TestAMRecoveryAggregationBroadcast {
   public void testAggregationTemporalFailure() throws Exception {
     tezConf.setBoolean(AGGREGATION_SLEEP, true);
     DAG dag = createDAG("AggregationTemporalFailure");
-    // Wait for TableScan to be SUCCEEDED before killing the
+    // Wait for TableScan to be SUCCEEDED before killing the AM
     TezCounters counters = runDAGAndVerify(dag, true, Collections.singletonList(TABLE_SCAN));
     assertEquals(3, counters.findCounter(DAGCounter.NUM_SUCCEEDED_TASKS).getValue());
 

--- a/tez-tests/src/test/java/org/apache/tez/test/TestAMRecoveryAggregationBroadcast.java
+++ b/tez-tests/src/test/java/org/apache/tez/test/TestAMRecoveryAggregationBroadcast.java
@@ -120,9 +120,6 @@ public class TestAMRecoveryAggregationBroadcast {
 
   private TezConfiguration tezConf;
   private TezClient tezSession;
-  // Per-test unique output path.
-  // replaces the former static OUT_PATH so that a stale file from a prior run in the same forked JVM
-  // cannot bleed into a later run.
   private Path outPath;
 
   @BeforeAll
@@ -351,10 +348,7 @@ public class TestAMRecoveryAggregationBroadcast {
     DAGClient dagClient = tezSession.submitDAG(dag);
 
     if (killAM) {
-      // Deterministic wait: block until every named upstream vertex reaches
-      // SUCCEEDED. Replaces a fixed Thread.sleep(10s) which was too short on
-      // slow CI machines and caused the recovery-log assertions below to
-      // fail intermittently.
+      // Deterministic wait: block until every named upstream vertex reaches SUCCEEDED.
       for (String vertexName : vertexNamesToWaitFor) {
         waitForVertexSucceeded(dagClient, vertexName, TimeUnit.SECONDS.toMillis(60));
       }


### PR DESCRIPTION
#### Root causes and fixes:

1) TestAMRecoveryAggregationBroadcast.testMapJoinTemporalFailure **(race condition)**
Replace fixed Thread.sleep(10s) before AM kill with a deterministic
waitForVertexSucceeded() helper that polls DAGClient.getVertexStatus()
every 500ms (up to 60s) until the target vertices reach SUCCEEDED state.
Each test now waits for only the vertices it logically depends on before
killing the AM, ensuring the recovery log assertions always see the
expected counts.
Make OUT_PATH unique per test run (random suffix) to eliminate cross-test.

2) DAGClientRPCImpl / TezClientUtils: port out of range:-1 **(YARN-808 gap)**
YARN sets rpcPort=-1 when an AM container is allocated (state=RUNNING)
but the AM has not yet bound its RPC listener. The existing guard only
checked rpcPort==0 (protobuf default), so rpcPort==-1 reached
NetUtils.createSocketAddrForHost(), which threw
IllegalArgumentException: port out of range:-1.
Fix DAGClientRPCImpl.createAMProxyIfNeeded(): rpcPort == 0 → rpcPort <= 0.
Fix TezClientUtils.getAMProxy(FrameworkClient,...): add the same
rpcPort <= 0 guard