### PR TITLE
TEZ-4736: Fix flaky TestMRRJobsDAGApi.testMultipleMRRSleepJobViaSession

### DIFF
--- a/tez-tests/src/test/java/org/apache/tez/mapreduce/TestMRRJobsDAGApi.java
+++ b/tez-tests/src/test/java/org/apache/tez/mapreduce/TestMRRJobsDAGApi.java
@@ -400,20 +400,20 @@ public class TestMRRJobsDAGApi {
     additionalResources.put("test.jar", createLrObjFromPath(relocFilePath));
     additionalResources.put("TezAppJar.jar", createLrObjFromPath(tezAppJarRemote));
 
-    waitForSessionReady(tezSession);
+    waitAndAssertSessionReady(tezSession);
     finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, true, MRInputAMSplitGeneratorRelocalizationTest.class, additionalResources);
     assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    waitForSessionReady(tezSession);
+    waitAndAssertSessionReady(tezSession);
     assertTrue(remoteFs.exists(new Path("/tmp/relocalizationfilefound")));
 
     stopAndVerifyYarnApp(tezSession);
   }
 
-  private void waitForSessionReady(TezClient tezSession)
+  private void waitAndAssertSessionReady(TezClient tezSession)
       throws IOException, TezException, InterruptedException {
-    boolean ready = tezSession.waitTillReady(60, TimeUnit.SECONDS);
-    assertTrue(ready, "TezSession did not reach READY within 60s, current status: "
+    boolean ready = tezSession.waitTillReady(10, TimeUnit.SECONDS);
+    assertTrue(ready, "TezSession did not reach READY within 10s, current status: "
         + tezSession.getAppMasterStatus());
     assertEquals(TezAppMasterStatus.READY, tezSession.getAppMasterStatus());
   }
@@ -520,11 +520,11 @@ public class TestMRRJobsDAGApi {
     State finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, false, null, null);
     assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    waitForSessionReady(tezSession);
+    waitAndAssertSessionReady(tezSession);
     finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, false, null, null);
     assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    waitForSessionReady(tezSession);
+    waitAndAssertSessionReady(tezSession);
 
     stopAndVerifyYarnApp(tezSession);
   }

--- a/tez-tests/src/test/java/org/apache/tez/mapreduce/TestMRRJobsDAGApi.java
+++ b/tez-tests/src/test/java/org/apache/tez/mapreduce/TestMRRJobsDAGApi.java
@@ -400,14 +400,22 @@ public class TestMRRJobsDAGApi {
     additionalResources.put("test.jar", createLrObjFromPath(relocFilePath));
     additionalResources.put("TezAppJar.jar", createLrObjFromPath(tezAppJarRemote));
 
-    assertEquals(TezAppMasterStatus.READY, tezSession.getAppMasterStatus());
+    waitForSessionReady(tezSession);
     finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, true, MRInputAMSplitGeneratorRelocalizationTest.class, additionalResources);
     assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    assertEquals(TezAppMasterStatus.READY, tezSession.getAppMasterStatus());
+    waitForSessionReady(tezSession);
     assertTrue(remoteFs.exists(new Path("/tmp/relocalizationfilefound")));
 
     stopAndVerifyYarnApp(tezSession);
+  }
+
+  private void waitForSessionReady(TezClient tezSession)
+      throws IOException, TezException, InterruptedException {
+    boolean ready = tezSession.waitTillReady(60, TimeUnit.SECONDS);
+    assertTrue(ready, "TezSession did not reach READY within 60s, current status: "
+        + tezSession.getAppMasterStatus());
+    assertEquals(TezAppMasterStatus.READY, tezSession.getAppMasterStatus());
   }
 
   private void stopAndVerifyYarnApp(TezClient tezSession) throws TezException,
@@ -512,11 +520,11 @@ public class TestMRRJobsDAGApi {
     State finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, false, null, null);
     assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    assertEquals(TezAppMasterStatus.READY, tezSession.getAppMasterStatus());
+    waitForSessionReady(tezSession);
     finalState = testMRRSleepJobDagSubmitCore(true, false, false,
         tezSession, false, null, null);
     assertEquals(DAGStatus.State.SUCCEEDED, finalState);
-    assertEquals(TezAppMasterStatus.READY, tezSession.getAppMasterStatus());
+    waitForSessionReady(tezSession);
 
     stopAndVerifyYarnApp(tezSession);
   }


### PR DESCRIPTION
#### Root causes and fixes:
TestMRRJobsDAGApi.testMultipleMRRSleepJobViaSession **(DAG SUCCEEDED ≠ AM READY)**
In session mode, DAG reaching SUCCEEDED does not mean the AM session has
transitioned back to READY. there is a short cleanup window. 
On slow CI the subsequent getAppMasterStatus() call returned RUNNING instead of READY.

Add tezSession.waitTillReady() before each assertEquals(READY, ...) so
the test waits for the actual state transition.