### PR TITLE
TEZ-4740: Fix typo in ProfileServlet javadoc for method profiling

### DIFF
--- a/tez-common/src/main/java/org/apache/tez/common/web/ProfileServlet.java
+++ b/tez-common/src/main/java/org/apache/tez/common/web/ProfileServlet.java
@@ -48,12 +48,12 @@ import org.slf4j.LoggerFactory;
  * <pre>
  * Servlet that runs async-profiler as web-endpoint.
  * Following options from async-profiler can be specified as query parameter.
- * //  -e event          profiling event: cpu|alloc|lock|cache-misses etc.
+ * //  -e event/method   profiling event: cpu|alloc|lock|cache-misses etc.
+ * //                    OR fully qualified method name: 'ClassName.methodName'
  * //  -d duration       run profiling for{@literal <duration>} seconds (integer)
  * //  -i interval       sampling interval in nanoseconds (long)
  * //  -j jstackdepth    maximum Java stack depth (integer)
  * //  -b bufsize        frame buffer size (long)
- * //  -m method         fully qualified method name: 'ClassName.methodName'
  * //  -t                profile different threads separately
  * //  -s                simple class names instead of FQN
  * //  -o fmt[,fmt...]   output format: summary|traces|flat|collapsed|svg|tree|jfr|html


### PR DESCRIPTION
Method profiling is still supported in newer versions of async-profiler (including 3.x and 4.x),
but it is accessed via the '-e' flag instead of '-m' in the backend. Admins can continue to use
the '?method=' HTTP query parameter for method profiling. This commit simply updates the Javadoc
to reflect the correct async-profiler flag, while leaving the existing method profiling functionality
intact.